### PR TITLE
[FE] Slack과 Storybook 연동하는 webhook 내 env 키값 naming 변경

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -48,4 +48,4 @@ jobs:
 
             👉 ${{ steps.chromatic.outputs.storybookUrl }}
         env:
-          SLACK_WEBHOOK_URL_STORYBOOK: ${{ secrets.SLACK_WEBHOOK_URL_STORYBOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_STORYBOOK }}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #50 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- 서버 친구들이 설정해놓은 discussion과 관련된 슬랙 웹훅과 저희가 설정해놓은 스토리북 알람 관련 슬랙 웹훅이 이름이 겹치는 이슈가 있어,
새로운 네이밍을 지었습니다. 

- 결론 :github action에서 SLACK_WEBHOOK_URL_STORYBOOK을 인지하지 못하여 SLACK_WEBHOOK_URL로 변경하였습니다. 

