### PR TITLE
[FE] Button 컴포넌트, 스토리북 구현

### DIFF
--- a/client/commitlint.config.cjs
+++ b/client/commitlint.config.cjs
@@ -7,6 +7,7 @@ module.exports = {
       ['feat', 'fix', 'refactor', 'chore', 'docs', 'test', 'design', 'hotfix'],
     ],
     'type-case': [2, 'always', 'lower-case'],
+    'subject-case': [0],
     'subject-empty': [2, 'never'],
   },
 };

--- a/client/package.json
+++ b/client/package.json
@@ -17,10 +17,6 @@
     "node": ">=20.18.0",
     "pnpm": ">=10.0.0"
   },
-  "engines": {
-    "node": ">=20.18.0",
-    "pnpm": ">=10"
-  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/client/src/shared/components/Button/Button.stories.tsx
+++ b/client/src/shared/components/Button/Button.stories.tsx
@@ -9,11 +9,36 @@ const meta = {
 } satisfies Meta<typeof Button>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Button>;
 
 export const Basic: Story = {
   args: {
-    children: '버튼123',
+    children: 'Button',
+    width: '8rem',
+    size: 'md',
+    variant: 'filled',
+    color: '#2563EB',
+    fontColor: 'white',
+  },
+  render: (args) => <Button {...args} />,
+};
+
+export const Outlined: Story = {
+  args: {
+    width: '10rem',
+    variant: 'outlined',
+    color: '#808080',
+    fontColor: '#000000',
+    children: 'Outlined Button',
+  },
+  render: (args) => <Button {...args} />,
+};
+
+export const FullWidth: Story = {
+  args: {
+    children: 'Full Width Button',
+    width: '100%',
+    color: '#409869',
   },
   render: (args) => <Button {...args} />,
 };

--- a/client/src/shared/components/Button/Button.stories.tsx
+++ b/client/src/shared/components/Button/Button.stories.tsx
@@ -18,7 +18,7 @@ export const Basic: Story = {
     size: 'md',
     variant: 'filled',
     color: '#2563EB',
-    fontColor: 'white',
+    fontColor: '#FFFFFF',
   },
   render: (args) => <Button {...args} />,
 };

--- a/client/src/shared/components/Button/Button.styled.ts
+++ b/client/src/shared/components/Button/Button.styled.ts
@@ -53,7 +53,7 @@ export const StyledButton = styled.button<ButtonProps>`
   border-radius: 0.75rem;
   line-height: 1.4;
   width: ${({ width }) => width ?? 'auto'};
-  color: ${({ fontColor }) => fontColor ?? 'white'};
+  color: ${({ fontColor }) => fontColor ?? '#FFFFFF'};
 
   ${({ size }) => sizeStyles[size ?? 'md']}
   ${({ variant, color }) => variantStyles[variant ?? 'filled'](color ?? 'black')};

--- a/client/src/shared/components/Button/Button.styled.ts
+++ b/client/src/shared/components/Button/Button.styled.ts
@@ -1,0 +1,65 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { ButtonProps } from './Button';
+
+const sizeStyles = {
+  sm: css`
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+  `,
+  md: css`
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+  `,
+  lg: css`
+    padding: 0.625rem 1.25rem;
+    font-size: 1.125rem;
+  `,
+  xl: css`
+    padding: 0.75rem 1.5rem;
+    font-size: 1.25rem;
+  `,
+} as const;
+
+const variantStyles = {
+  filled: (color: string) => css`
+    background-color: ${color};
+    &:hover {
+      background-color: ${color};
+      opacity: 0.7;
+    }
+  `,
+  outlined: (color: string) => css`
+    border: 1px solid ${color};
+    background-color: transparent;
+
+    &:hover {
+      background-color: ${color.startsWith('#') ? `${color}1A` : `rgba(0, 0, 0, 0.1)`};
+      opacity: 0.8;
+    }
+  `,
+};
+
+export const StyledButton = styled.button<ButtonProps>`
+  cursor: pointer;
+  font-weight: 500;
+  background-color: transparent;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.75rem;
+  line-height: 1.4;
+  width: ${({ width }) => width ?? 'auto'};
+  color: ${({ fontColor }) => fontColor ?? 'white'};
+
+  ${({ size }) => sizeStyles[size ?? 'md']}
+  ${({ variant, color }) => variantStyles[variant ?? 'filled'](color ?? 'black')};
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;

--- a/client/src/shared/components/Button/Button.tsx
+++ b/client/src/shared/components/Button/Button.tsx
@@ -1,3 +1,63 @@
-export const Button = () => {
-  return <button className="btn">Click </button>;
+import { ComponentProps, PropsWithChildren } from 'react';
+
+import { StyledButton } from './Button.styled';
+
+export type ButtonProps = {
+  /**
+   * The width of the button.
+   * @type {string}
+   * @description It can be a string (e.g. '100%') or a number (e.g. 100).  1rem = 16px
+   * @default '8rem'
+   */
+  width?: string;
+  /**
+   * The size of the button.
+   * @type {string}
+   * @default 'md'
+   */
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  /**
+   * The visual style variant of the button.
+   * @type {string}
+   * @default 'filled'
+   */
+  variant?: 'filled' | 'outlined';
+  /**
+   * The background color of the button.
+   * @type {string}
+   * @description If possible, use hex codes (e.g., `#808080`) instead of named colors like `gray`,
+   * since named colors can't be adjusted with rgba for transparency (e.g., `rgba(gray, 0.5)` won't work).
+   * @default '#2563EB'
+   */
+  color?: string;
+  /**
+   * The color of the text displayed inside the button.
+   * @type {string}
+   * @default 'white'
+   */
+  fontColor?: string;
+} & PropsWithChildren<ComponentProps<'button'>>;
+
+// S.TODO: isLoading 추가, 아이콘이 들어가는 경우
+export const Button = ({
+  width = '8rem',
+  size = 'md',
+  variant = 'filled',
+  color = '#2563EB',
+  fontColor = 'white',
+  children,
+  ...props
+}: ButtonProps) => {
+  return (
+    <StyledButton
+      width={width}
+      size={size}
+      variant={variant}
+      color={color}
+      fontColor={fontColor}
+      {...props}
+    >
+      {children}
+    </StyledButton>
+  );
 };

--- a/client/src/shared/components/Button/Button.tsx
+++ b/client/src/shared/components/Button/Button.tsx
@@ -33,7 +33,7 @@ export type ButtonProps = {
   /**
    * The color of the text displayed inside the button.
    * @type {string}
-   * @default 'white'
+   * @default '#FFFFFF'
    */
   fontColor?: string;
 } & PropsWithChildren<ComponentProps<'button'>>;
@@ -44,7 +44,7 @@ export const Button = ({
   size = 'md',
   variant = 'filled',
   color = '#2563EB',
-  fontColor = 'white',
+  fontColor = '#FFFFFF',
   children,
   ...props
 }: ButtonProps) => {

--- a/client/src/shared/components/Button/index.ts
+++ b/client/src/shared/components/Button/index.ts
@@ -1,0 +1,1 @@
+export { Button } from './Button';


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #19

## ✨ 작업 내용

- 버튼은 향후 변경 가능성이 높아, 최대한 유연하게 확장 가능하도록 구현했습니다.
- 버튼 컴포넌트 hover 시 배경색에 투명도를 주는 처리를 하고 있습니다. 'blue', 'gray'와 같은 css 네임드 컬러는 `rgba(blue, 0.1)`처럼 쓸 수 없어 hover시 예상대로 동작하지 않을 수 있습니다. 따라서 현재 모든 color 값이 허용 가능하지만(ex. `blue`, `#000000`, `rgb(0,0,0,1)`, hover 상태에서 투명도 처리를 원한다면 #808080, #000000 등의 hex 코드 사용을 권장드립니다.

```tsx
&:hover {
  background-color: ${color.startsWith('#') ? `${color}1A` : `rgba(0, 0, 0, 0.1)`};
}
```

![Jul-16-2025 13-10-40](https://github.com/user-attachments/assets/e40652a3-0e26-4159-be91-779737e01d27)


<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

- commit 콜론을 기준으로 두번째에 오는 `subject`에 대문자를 사용가능하도록 수정했습니다. 
- docs 기능을 활용하기 위해 `main.ts`에 `@storybook/addon-docs` 추가했습니다. 

<!-- 없다면 적지 않으셔도 됩니다. -->
