### PR TITLE
[FE] Header 컴포넌트, 스토리북 구현

### DIFF
--- a/client/src/shared/components/Header/Header.stories.tsx
+++ b/client/src/shared/components/Header/Header.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Header } from './Header';
+
+const meta = {
+  title: 'components/Header',
+  component: Header,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Header>;
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const LeftOnly: Story = {
+  args: {
+    left: <h2 style={{ margin: 0 }}>아맞다!</h2>,
+  },
+  render: (args) => <Header {...args} />,
+};
+
+export const LeftAndRight: Story = {
+  args: {
+    left: <h2 style={{ margin: 0 }}>아맞다!</h2>,
+    right: (
+      <div style={{ display: 'flex', gap: '12px' }}>
+        <button>로그아웃</button>
+        <button>내 이벤트</button>
+      </div>
+    ),
+  },
+  render: (args) => <Header {...args} />,
+};

--- a/client/src/shared/components/Header/Header.styled.ts
+++ b/client/src/shared/components/Header/Header.styled.ts
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled';
+
+export const StyledHeader = styled.header<{ justifyContent: string }>`
+  position: sticky;
+  top: 0;
+  height: 30px;
+  padding: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: ${({ justifyContent }) => justifyContent};
+  flex-shrink: 0;
+  z-index: 1;
+  border-bottom: 1px solid #e5e5e5;
+`;

--- a/client/src/shared/components/Header/Header.tsx
+++ b/client/src/shared/components/Header/Header.tsx
@@ -1,0 +1,31 @@
+import { ComponentProps, ReactNode } from 'react';
+
+import { StyledHeader } from './Header.styled';
+
+export type HeaderProps = {
+  /**
+   * The left element of the header.
+   * @type {ReactNode}
+   * @description Usually used for logo, title, or back button.
+   * @required
+   */
+  left: ReactNode;
+  /**
+   * The right element of the header.
+   * @type {ReactNode}
+   * @description Can include icons, profile menus, or action buttons.
+   * @optional
+   */
+  right?: ReactNode;
+} & ComponentProps<'header'>;
+
+export const Header = ({ left, right, ...props }: HeaderProps) => {
+  const justifyContent = right ? 'space-between' : 'flex-start';
+
+  return (
+    <StyledHeader justifyContent={justifyContent} {...props}>
+      {left}
+      {right}
+    </StyledHeader>
+  );
+};

--- a/client/src/shared/components/Header/index.ts
+++ b/client/src/shared/components/Header/index.ts
@@ -1,0 +1,1 @@
+export { Header } from './Header';


### PR DESCRIPTION
## 관련 이슈

close #33 

## ✨ 작업 내용

- 공통 `Header` 컴포넌트 구현
- `left`(필수)와 `right`(옵셔널) 영역을 전달받아 flex로 배치
- `right`가 존재하면 `justify-content: space-between`, 없으면 `flex-start`로 자동 설정

## 🙏 기타 참고 사항

### 사용 예시

#### 📌 왼쪽 콘텐츠만 있는 경우

```tsx
<Header
  left={<h2>아맞다!</h2>}
/>
```

📌 왼쪽과 오른쪽 콘텐츠가 모두 있는 경우

```tsx
<Header
  left={<h2>아맞다!</h2>}
  right={
    <div>
      <button>로그아웃</button>
      <button>내 이벤트</button>
    </div>
  }
/>

```
