### PR TITLE
[FE] Card 컴포넌트, 스토리북 구현

### DIFF
--- a/client/src/shared/components/Card/Card.stories.tsx
+++ b/client/src/shared/components/Card/Card.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Card } from './Card';
+
+const meta = {
+  title: 'components/Card',
+  component: Card,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Card component is a styled container that can be used to display content in a card-like format.',
+      },
+    },
+  },
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Basic: Story = {
+  args: {
+    children: 'Card Component',
+  },
+  argTypes: {
+    children: { control: 'text' },
+  },
+  render: (args) => <Card {...args} />,
+};

--- a/client/src/shared/components/Card/Card.styled.ts
+++ b/client/src/shared/components/Card/Card.styled.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const StyledCard = styled.div`
+  display: block;
+  width: 100%;
+  padding: 1.375rem;
+  box-sizing: border-box;
+  border-radius: 0.875rem;
+  border: 1px solid #e5e7eb;
+  background-color: #ffffff;
+`;

--- a/client/src/shared/components/Card/Card.styled.ts
+++ b/client/src/shared/components/Card/Card.styled.ts
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 export const StyledCard = styled.div`
-  display: block;
   width: 100%;
   padding: 1.375rem;
   box-sizing: border-box;

--- a/client/src/shared/components/Card/Card.tsx
+++ b/client/src/shared/components/Card/Card.tsx
@@ -1,0 +1,7 @@
+import { ComponentProps, PropsWithChildren } from 'react';
+
+import { StyledCard } from './Card.styled';
+
+export const Card = ({ children }: PropsWithChildren<ComponentProps<'div'>>) => {
+  return <StyledCard>{children}</StyledCard>;
+};

--- a/client/src/shared/components/Card/index.ts
+++ b/client/src/shared/components/Card/index.ts
@@ -1,0 +1,1 @@
+export { Card } from './Card';


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #21

## ✨ 작업 내용

- Card 컴포넌트 구현했습니다. 
- 다형성을 제공해 div, span 등 다양한 시맨틱 태그를 허용하려 했지만, 카드는 본질적으로 블록 요소이고 인라인 카드를 실제 사용하지 않을 것 같아 제거했습니다.
- Card 컴포넌트는 폼 생성, 이벤트 상세 조회, 주최측 정보 조회 등의 UI에서 사용될 것 같습니다. 아직 디자인이 픽스나지 않아서 추후 방향성보고 스타일이나 구조 개선해나가면 좋을 것 같습니다.

**폼 생성**
<img width="380" height="537" alt="스크린샷 2025-07-16 오후 8 46 20" src="https://github.com/user-attachments/assets/028a1a5d-c9d8-4adc-9fce-5f52a16fb804" />
**이벤트 상세 조회**
<img width="396" height="264" alt="스크린샷 2025-07-16 오후 8 41 04" src="https://github.com/user-attachments/assets/b321765c-05c4-406b-885b-2aba75809fc5" />
**주최측 정보 조회**
<img width="364" height="390" alt="스크린샷 2025-07-16 오후 8 40 55" src="https://github.com/user-attachments/assets/71e0add8-ceb5-4d12-8b63-12056c382cc7" />


