### PR TITLE
[BE] 생성자 검증 로직이 필드 주입보다 먼저 오게 변경

### DIFF
--- a/server/src/main/java/com/ahmadda/application/OrganizationService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationService.java
@@ -1,6 +1,6 @@
 package com.ahmadda.application;
 
-import com.ahmadda.application.exception.NotFoundExcpetion;
+import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Organization;
 import com.ahmadda.domain.OrganizationRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,18 +14,18 @@ public class OrganizationService {
     private final OrganizationRepository organizationRepository;
 
     @Transactional
-    public void createOrganization(final OrganizationCreateRequest organizationCreateRequest) {
+    public Organization createOrganization(final OrganizationCreateRequest organizationCreateRequest) {
         Organization organization = Organization.create(
                 organizationCreateRequest.name(),
                 organizationCreateRequest.description(),
                 organizationCreateRequest.imageUrl()
         );
 
-        organizationRepository.save(organization);
+        return organizationRepository.save(organization);
     }
 
     public Organization getOrganization(final Long id) {
         return organizationRepository.findById(id)
-                .orElseThrow(() -> new NotFoundExcpetion("존재하지 않는 조직입니다."));
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 조직입니다."));
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/Answer.java
+++ b/server/src/main/java/com/ahmadda/domain/Answer.java
@@ -36,13 +36,29 @@ public class Answer extends BaseEntity {
     private String answerText;
 
     private Answer(final Question question, final Guest guest, final String answerText) {
-        this.question = Assert.notNull(question, "question null이 되면 안됩니다.");
-        this.guest = Assert.notNull(guest, "guest null이 되면 안됩니다.");
-        this.answerText = Assert.notNull(answerText, "answerText null이 되면 안됩니다.");
+        validateQuestion(question);
+        validateQuest(guest);
+        validateAnswerText(answerText);
+
+        this.question = question;
+        this.guest = guest;
+        this.answerText = answerText;
     }
 
     public static Answer create(final Question question, final Guest guest, final String answerText) {
         return new Answer(question, guest, answerText);
+    }
+
+    private void validateQuestion(final Question question) {
+        Assert.notNull(question, "question은 null이 되면 안됩니다.");
+    }
+
+    private void validateQuest(final Guest guest) {
+        Assert.notNull(guest, "guest는 null이 되면 안됩니다.");
+    }
+
+    private void validateAnswerText(final String answerText) {
+        Assert.notBlank(answerText, "answerText는 공백이면 안됩니다.");
     }
 }
 

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -65,17 +65,33 @@ public class Event extends BaseEntity {
                   final LocalDateTime registrationEnd,
                   final LocalDateTime eventStart,
                   final LocalDateTime eventEnd,
-                  final int maxCapacity) {
-        this.title = Assert.notNull(title, "title null이 되면 안됩니다.");
-        this.description = Assert.notNull(description, "description null이 되면 안됩니다.");
-        this.place = Assert.notNull(place, "place null이 되면 안됩니다.");
-        this.organizer = Assert.notNull(organizer, "organizer null이 되면 안됩니다.");
-        this.organization = Assert.notNull(organization, "organization null이 되면 안됩니다.");
-        this.registrationStart = Assert.notNull(registrationStart, "registrationStart null이 되면 안됩니다.");
-        this.registrationEnd = Assert.notNull(registrationEnd, "registrationEnd null이 되면 안됩니다.");
-        this.eventStart = Assert.notNull(eventStart, "eventStart null이 되면 안됩니다.");
-        this.eventEnd = Assert.notNull(eventEnd, "eventEnd null이 되면 안됩니다.");
+                  final int maxCapacity
+    ) {
+        validateTitle(title);
+        validateDescription(description);
+        validatePlace(place);
+        validateOrganizer(organizer);
+        validateOrganization(organization);
+        validateRegistrationStart(registrationStart);
+        validateRegistrationEnd(registrationEnd);
+        validateEventStart(eventStart);
+        validateEventEnd(eventEnd);
+
+        this.title = title;
+        this.description = description;
+        this.place = place;
+        this.organizer = organizer;
+        this.organization = organization;
+        this.registrationStart = registrationStart;
+        this.registrationEnd = registrationEnd;
+        this.eventStart = eventStart;
+        this.eventEnd = eventEnd;
         this.maxCapacity = maxCapacity;
+    }
+
+
+    private void validateTitle(final String title) {
+        Assert.notBlank(title, "title은 공백이면 안됩니다.");
     }
 
     public static Event create(final String title,
@@ -98,8 +114,39 @@ public class Event extends BaseEntity {
                 registrationEnd,
                 eventStart,
                 eventEnd,
-                maxCapacity);
+                maxCapacity
+        );
+    }
+
+    private void validateDescription(final String description) {
+        Assert.notBlank(description, "description은 공백이면 안됩니다.");
+    }
+
+    private void validatePlace(final String place) {
+        Assert.notBlank(place, "place는 공백이면 안됩니다.");
+    }
+
+    private void validateOrganizer(final OrganizationMember organizer) {
+        Assert.notNull(organizer, "organizer는 null이 되면 안됩니다.");
+    }
+
+    private void validateOrganization(final Organization organization) {
+        Assert.notNull(organization, "organization은 null이 되면 안됩니다.");
+    }
+
+    private void validateRegistrationStart(final LocalDateTime registrationStart) {
+        Assert.notNull(registrationStart, "registrationStart은 null이 되면 안됩니다.");
+    }
+
+    private void validateRegistrationEnd(final LocalDateTime registrationEnd) {
+        Assert.notNull(registrationEnd, "registrationEnd는 null이 되면 안됩니다.");
+    }
+
+    private void validateEventStart(final LocalDateTime eventStart) {
+        Assert.notNull(eventStart, "eventStart는 null이 되면 안됩니다.");
+    }
+
+    private void validateEventEnd(final LocalDateTime eventEnd) {
+        Assert.notNull(eventEnd, "eventEnd는 null이 되면 안됩니다.");
     }
 }
-
-

--- a/server/src/main/java/com/ahmadda/domain/Guest.java
+++ b/server/src/main/java/com/ahmadda/domain/Guest.java
@@ -33,13 +33,23 @@ public class Guest extends BaseEntity {
     private OrganizationMember participant;
 
     private Guest(final Event event, final OrganizationMember participant) {
-        this.event = Assert.notNull(event, "event null이 되면 안됩니다.");
-        this.participant = Assert.notNull(participant, "participant null이 되면 안됩니다.");
+        validateEvent(event);
+        validateParticipant(participant);
+
+        this.event = event;
+        this.participant = participant;
     }
 
     public static Guest create(final Event event, final OrganizationMember participant) {
+
         return new Guest(event, participant);
     }
+
+    private void validateEvent(final Event event) {
+        Assert.notNull(event, "event는 null이 되면 안됩니다.");
+    }
+
+    private void validateParticipant(final OrganizationMember participant) {
+        Assert.notNull(participant, "participant는 null이 되면 안됩니다.");
+    }
 }
-
-

--- a/server/src/main/java/com/ahmadda/domain/Member.java
+++ b/server/src/main/java/com/ahmadda/domain/Member.java
@@ -27,11 +27,22 @@ public class Member extends BaseEntity {
     private String email;
 
     private Member(final String name, final String email) {
-        this.name = Assert.notNull(name, "name null이 되면 안됩니다.");
-        this.email = Assert.notNull(email, "email null이 되면 안됩니다.");
+        validateName(name);
+        validateEmail(email);
+
+        this.name = name;
+        this.email = email;
     }
 
     public static Member create(final String name, final String email) {
         return new Member(name, email);
+    }
+
+    private void validateName(final String name) {
+        Assert.notBlank(name, "name은 공백이면 안됩니다.");
+    }
+
+    private void validateEmail(final String email) {
+        Assert.notBlank(email, "email은 공백이면 안됩니다.");
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/Organization.java
+++ b/server/src/main/java/com/ahmadda/domain/Organization.java
@@ -38,35 +38,46 @@ public class Organization extends BaseEntity {
 
 
     private Organization(final String name, final String description, final String imageUrl) {
-        this.name = Assert.notNull(name, "name null이 되면 안됩니다.");
-        this.description = Assert.notNull(description, "description null이 되면 안됩니다.");
-        this.imageUrl = Assert.notNull(imageUrl, "imageUrl null이 되면 안됩니다.");
-        validate();
+        validateName(name);
+        validateDescription(description);
+        validateImageUrl(imageUrl);
+
+        this.name = name;
+        this.description = description;
+        this.imageUrl = imageUrl;
     }
 
     public static Organization create(final String name, final String description, final String imageUrl) {
         return new Organization(name, description, imageUrl);
     }
 
-    private void validate() {
-        if (name.isBlank() || name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
+    private void validateName(final String name) {
+        Assert.notBlank(name, "name은 공백이면 안됩니다.");
+
+        if (name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
             throw new BusinessRuleViolatedException(
                     String.format("이름의 길이는 %d자 이상 %d자 이하이어야 합니다.",
-                                  MIN_NAME_LENGTH,
-                                  MAX_NAME_LENGTH
-                    )
-            );
-        }
-
-        if (description.isBlank() || description.length() < 2 || description.length() > 2000) {
-            throw new BusinessRuleViolatedException(
-                    String.format("설명의 길이는 %d자 이상 %d자 이하이어야 합니다.",
-                                  MIN_DESCRIPTION_LENGTH,
-                                  MAX_DESCRIPTION_LENGTH
+                            MIN_NAME_LENGTH,
+                            MAX_NAME_LENGTH
                     )
             );
         }
     }
+
+    private void validateDescription(final String description) {
+        Assert.notBlank(description, "description은 공백이면 안됩니다.");
+
+        if (description.length() < 2 || description.length() > 2000) {
+            throw new BusinessRuleViolatedException(
+                    String.format("설명의 길이는 %d자 이상 %d자 이하이어야 합니다.",
+                            MIN_DESCRIPTION_LENGTH,
+                            MAX_DESCRIPTION_LENGTH
+                    )
+            );
+        }
+    }
+
+    private void validateImageUrl(final String imageUrl) {
+        Assert.notBlank(imageUrl, "imageUrl은 공백이면 안됩니다.");
+    }
 }
-
-

--- a/server/src/main/java/com/ahmadda/domain/OrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationMember.java
@@ -36,16 +36,31 @@ public class OrganizationMember extends BaseEntity {
     private Organization organization;
 
     private OrganizationMember(final String nickname, final Member member, final Organization organization) {
-        this.nickname = Assert.notNull(nickname, "nickname null이 되면 안됩니다.");
-        this.member = Assert.notNull(member, "member null이 되면 안됩니다.");
-        this.organization = Assert.notNull(organization, "organization null이 되면 안됩니다.");
+        validateNickname(nickname);
+        validateMember(member);
+        validateOrganization(organization);
+
+        this.nickname = nickname;
+        this.member = member;
+        this.organization = organization;
     }
 
     public static OrganizationMember create(final String nickname,
                                             final Member member,
-                                            final Organization organization) {
+                                            final Organization organization
+    ) {
         return new OrganizationMember(nickname, member, organization);
     }
+
+    private void validateNickname(final String nickname) {
+        Assert.notBlank(nickname, "nickname은 공백이면 안됩니다.");
+    }
+
+    private void validateMember(final Member member) {
+        Assert.notNull(member, "member는 null이 되면 안됩니다.");
+    }
+
+    private void validateOrganization(final Organization organization) {
+        Assert.notNull(organization, "organization은 null이 되면 안됩니다.");
+    }
 }
-
-

--- a/server/src/main/java/com/ahmadda/domain/Question.java
+++ b/server/src/main/java/com/ahmadda/domain/Question.java
@@ -43,8 +43,11 @@ public class Question extends BaseEntity {
             final boolean isRequired,
             final int orderIndex
     ) {
-        this.event = Assert.notNull(event, "event null이 되면 안됩니다.");
-        this.questionText = Assert.notNull(questionText, "questionText null이 되면 안됩니다.");
+        validateEvent(event);
+        validateQuestionText(questionText);
+
+        this.event = event;
+        this.questionText = questionText;
         this.isRequired = isRequired;
         this.orderIndex = orderIndex;
     }
@@ -57,6 +60,12 @@ public class Question extends BaseEntity {
     ) {
         return new Question(event, questionText, isRequired, orderIndex);
     }
+
+    private void validateEvent(final Event event) {
+        Assert.notNull(event, "event는 null이 되면 안됩니다.");
+    }
+
+    private void validateQuestionText(final String questionText) {
+        Assert.notBlank(questionText, "questionText은 공백이면 안됩니다.");
+    }
 }
-
-

--- a/server/src/main/java/com/ahmadda/domain/exception/BlankPropertyException.java
+++ b/server/src/main/java/com/ahmadda/domain/exception/BlankPropertyException.java
@@ -1,0 +1,8 @@
+package com.ahmadda.domain.exception;
+
+public class BlankPropertyException extends BusinessRuleViolatedException {
+    
+    public BlankPropertyException(final String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/ahmadda/domain/util/Assert.java
+++ b/server/src/main/java/com/ahmadda/domain/util/Assert.java
@@ -1,13 +1,23 @@
 package com.ahmadda.domain.util;
 
+import com.ahmadda.domain.exception.BlankPropertyException;
 import com.ahmadda.domain.exception.NullPropertyException;
 
 public class Assert {
 
-    public static <T> T notNull(T obj, String message) {
+    public static void notNull(Object obj, String message) {
         if (obj == null) {
             throw new NullPropertyException(message);
         }
-        return obj;
+    }
+
+    public static void notBlank(String obj, String message) {
+        if (obj == null) {
+            throw new NullPropertyException(message);
+        }
+
+        if (obj.isBlank()) {
+            throw new BlankPropertyException(message);
+        }
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -5,6 +5,7 @@ import com.ahmadda.application.OrganizationReadResponse;
 import com.ahmadda.application.OrganizationService;
 import com.ahmadda.domain.Organization;
 import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +23,11 @@ public class OrganizationController {
     private final OrganizationService organizationService;
 
     @PostMapping
-    public ResponseEntity<Void> createOrganization(@RequestBody @Valid final OrganizationCreateRequest organizationCreateRequest) {
-        organizationService.createOrganization(organizationCreateRequest);
+    public ResponseEntity<Void> createOrganization(
+            @RequestBody @Valid final OrganizationCreateRequest organizationCreateRequest) {
+        Organization organization = organizationService.createOrganization(organizationCreateRequest);
 
-        return ResponseEntity.ok()
+        return ResponseEntity.created(URI.create("/api/organizations/" + organization.getId()))
                 .build();
     }
 


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #73 

## ✨ 작업 내용
- 생성자에서 Assert.notNull 메서드로 null 검증을 먼저 수행한 뒤 비즈니스 로직 검증을 수행하던 기존 방식에서, 모든 검증을 완료한 후에 필드 주입이 이루어지도록 변경했습니다.
- 또한 Assert.notBlank 유틸 메서드를 추가하여 공백 검증을 명확하게 수행할 수 있도록 했습니다.

## 🙏 리뷰시 참고 사항

이전에 투다가 작업한 validate 메서드는 모든 필드를 한 메서드에서 함께 검증하는 방식이었습니다.

```java
private void validate(String name, String description) {
    // name 컬럼 검증 
    // description 컬럼 검증
}

```

이처럼 하나의 메서드에서 여러 필드를 함께 검증하는 방식은, 추후 새로운 컬럼이 추가될 경우
validate 메서드의 파라미터와 내부 로직을 모두 수정해야 하는 불편함이 있습니다.

머피는 이를 “가로로 사고하는 방식“이라 표현하며,
대신 “세로축으로 사고하는 방식“을 도입해보자는 의견을 주었고,
그에 따라 필드별로 개별 validate 메서드를 구성하는 방식으로 변경했습니다.

```java
private void validateName(final String name) {
    Assert.notBlank(name, "name은 공백일 수 없습니다.");

    if (name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
        throw new BusinessRuleViolatedException(
            String.format("이름의 길이는 %d자 이상 %d자 이하이어야 합니다.",
                MIN_NAME_LENGTH,
                MAX_NAME_LENGTH
            )
        );
    }
}

private void validateDescription(final String description) {
    Assert.notBlank(description, "description은 공백일 수 없습니다.");

    if (description.length() < MIN_DESCRIPTION_LENGTH || description.length() > MAX_DESCRIPTION_LENGTH) {
        throw new BusinessRuleViolatedException(
            String.format("설명의 길이는 %d자 이상 %d자 이하이어야 합니다.",
                MIN_DESCRIPTION_LENGTH,
                MAX_DESCRIPTION_LENGTH
            )
        );
    }
}
```

이 방식은 새로운 컬럼이 추가되더라도 해당 필드 전용 검증 메서드만 추가하면 되기 때문에,
검증 로직의 확장성과 가독성이 훨씬 향상됩니다.