### PR TITLE
[FE] Input 컴포넌트, 스토리북 구현

### DIFF
--- a/client/src/shared/components/Input/Input.stories.tsx
+++ b/client/src/shared/components/Input/Input.stories.tsx
@@ -47,7 +47,7 @@ export const Required: Story = {
   args: {
     label: '이름',
     name: 'name',
-    required: true,
+    isRequired: true,
     placeholder: '이름을 입력하세요',
     value: '',
     onChange: () => {},

--- a/client/src/shared/components/Input/Input.stories.tsx
+++ b/client/src/shared/components/Input/Input.stories.tsx
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof Input>;
 
 export const Basic: Story = {
   args: {
-    title: '이메일',
+    label: '이메일',
     name: 'email',
     placeholder: '이메일을 입력하세요',
     value: '',
@@ -31,7 +31,7 @@ export const Basic: Story = {
 
 export const WithHelperText: Story = {
   args: {
-    title: '비밀번호',
+    label: '비밀번호',
     name: 'password',
     placeholder: '8자 이상 입력해주세요',
     helperText: '대소문자, 숫자, 특수문자를 포함해주세요',
@@ -43,7 +43,7 @@ export const WithHelperText: Story = {
 
 export const Required: Story = {
   args: {
-    title: '이름',
+    label: '이름',
     name: 'name',
     required: true,
     placeholder: '이름을 입력하세요',

--- a/client/src/shared/components/Input/Input.stories.tsx
+++ b/client/src/shared/components/Input/Input.stories.tsx
@@ -24,6 +24,8 @@ export const Basic: Story = {
     label: '이메일',
     name: 'email',
     placeholder: '이메일을 입력하세요',
+    error: true,
+    errorMessage: '이메일 형식이 올바르지 않아요',
     value: '',
     onChange: () => {},
   },

--- a/client/src/shared/components/Input/Input.stories.tsx
+++ b/client/src/shared/components/Input/Input.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Input } from './Input';
+
+const meta = {
+  title: 'components/Input',
+  component: Input,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A customizable input component with label, helper text, required mark, and support for native input attributes.',
+      },
+    },
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Basic: Story = {
+  args: {
+    title: '이메일',
+    name: 'email',
+    placeholder: '이메일을 입력하세요',
+    value: '',
+    onChange: () => {},
+  },
+};
+
+export const WithHelperText: Story = {
+  args: {
+    title: '비밀번호',
+    name: 'password',
+    placeholder: '8자 이상 입력해주세요',
+    helperText: '대소문자, 숫자, 특수문자를 포함해주세요',
+    type: 'password',
+    value: '',
+    onChange: () => {},
+  },
+};
+
+export const Required: Story = {
+  args: {
+    title: '이름',
+    name: 'name',
+    required: true,
+    placeholder: '이름을 입력하세요',
+    value: '',
+    onChange: () => {},
+  },
+};

--- a/client/src/shared/components/Input/Input.stories.tsx
+++ b/client/src/shared/components/Input/Input.stories.tsx
@@ -21,6 +21,7 @@ type Story = StoryObj<typeof Input>;
 
 export const Basic: Story = {
   args: {
+    id: 'email',
     label: '이메일',
     name: 'email',
     placeholder: '이메일을 입력하세요',
@@ -33,6 +34,7 @@ export const Basic: Story = {
 
 export const WithHelperText: Story = {
   args: {
+    id: 'password',
     label: '비밀번호',
     name: 'password',
     placeholder: '8자 이상 입력해주세요',
@@ -45,6 +47,7 @@ export const WithHelperText: Story = {
 
 export const Required: Story = {
   args: {
+    id: 'name',
     label: '이름',
     name: 'name',
     isRequired: true,

--- a/client/src/shared/components/Input/Input.styled.ts
+++ b/client/src/shared/components/Input/Input.styled.ts
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { InputProps } from './Input';
+
 export const StyledWrapper = styled.div`
   width: 100%;
 `;
@@ -18,11 +20,11 @@ export const StyledRequiredMark = styled.span`
   font-size: 14px;
 `;
 
-export const StyledInput = styled.input`
+export const StyledInput = styled.input<Pick<InputProps, 'error'>>`
   width: 100%;
   padding: 8px 12px;
   font-size: 14px;
-  border: 1px solid #ccc;
+  border: 1px solid ${({ error }) => (error ? '#FF5A5A' : '#ccc')};
   border-radius: 6px;
   box-sizing: border-box;
   background: white;
@@ -30,12 +32,12 @@ export const StyledInput = styled.input`
 
   &:focus {
     outline: none;
-    border-color: #333;
+    border-color: ${({ error }) => (error ? '#FF5A5A' : '#333')};
   }
 `;
 
-export const StyledHelperText = styled.p`
+export const StyledHelperText = styled.p<Pick<InputProps, 'error'>>`
   margin-top: 4px;
   font-size: 12px;
-  color: #888;
+  color: ${({ error }) => (error ? '#FF5A5A' : '#888')};
 `;

--- a/client/src/shared/components/Input/Input.styled.ts
+++ b/client/src/shared/components/Input/Input.styled.ts
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.div`
+  width: 100%;
+`;
+
+export const StyledLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 20px;
+  margin-bottom: 8px;
+  font-size: 14px;
+`;
+
+export const StyledRequiredMark = styled.span`
+  color: red;
+  font-size: 14px;
+`;
+
+export const StyledInput = styled.input`
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-sizing: border-box;
+  background: white;
+  color: black;
+
+  &:focus {
+    outline: none;
+    border-color: #333;
+  }
+`;
+
+export const StyledHelperText = styled.p`
+  margin-top: 4px;
+  font-size: 12px;
+  color: #888;
+`;

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -23,6 +23,14 @@ export type InputProps = {
   helperText?: string;
 
   /**
+   * Whether the input is required.
+   * When true, a red asterisk (*) will be shown next to the label.
+   * This does not trigger browser-native validation unless you also pass it to the DOM via `required`.
+   * @default false
+   */
+  isRequired?: boolean;
+
+  /**
    * Whether the input is in an error state.
    * When true, errorMessage will be shown instead of helperText.
    */
@@ -37,7 +45,7 @@ export type InputProps = {
 export const Input = ({
   label,
   helperText,
-  required = false,
+  isRequired = false,
   error = false,
   errorMessage,
   ...props
@@ -46,9 +54,9 @@ export const Input = ({
     <StyledWrapper>
       <StyledLabel htmlFor={props.id || props.name}>
         {label}
-        {required && <StyledRequiredMark>*</StyledRequiredMark>}
+        {isRequired && <StyledRequiredMark>*</StyledRequiredMark>}
       </StyledLabel>
-      <StyledInput {...props} required={required} error={error} />
+      <StyledInput {...props} error={error} />
       {error && errorMessage ? (
         <StyledHelperText error={error}>{errorMessage}</StyledHelperText>
       ) : (

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -61,7 +61,7 @@ export const Input = ({
         {label}
         {isRequired && <StyledRequiredMark>*</StyledRequiredMark>}
       </StyledLabel>
-      <StyledInput {...props} error={error} />
+      <StyledInput error={error} {...props} />
       {error && errorMessage ? (
         <StyledHelperText error={error}>{errorMessage}</StyledHelperText>
       ) : (

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -13,7 +13,7 @@ type InputProps = {
    * Label text displayed above the input field.
    * @type {string}
    */
-  title: string;
+  label: string;
 
   /**
    * Helper text displayed below the input field.
@@ -23,11 +23,11 @@ type InputProps = {
   helperText?: string;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-export const Input = ({ title, helperText, required = false, ...props }: InputProps) => {
+export const Input = ({ label, helperText, required = false, ...props }: InputProps) => {
   return (
     <StyledWrapper>
       <StyledLabel htmlFor={props.id || props.name}>
-        {title}
+        {label}
         {required && <StyledRequiredMark>*</StyledRequiredMark>}
       </StyledLabel>
       <StyledInput {...props} required={required} />

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes } from 'react';
+import { ComponentProps } from 'react';
 
 import {
   StyledWrapper,
@@ -40,7 +40,7 @@ export type InputProps = {
    * Message displayed when the input is invalid.
    */
   errorMessage?: string;
-} & InputHTMLAttributes<HTMLInputElement>;
+} & ComponentProps<'input'>;
 
 export const Input = ({
   label,

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -1,0 +1,27 @@
+import { InputHTMLAttributes } from 'react';
+
+import {
+  StyledWrapper,
+  StyledLabel,
+  StyledRequiredMark,
+  StyledInput,
+  StyledHelperText,
+} from './Input.styled';
+
+type InputProps = {
+  title: string;
+  helperText?: string;
+} & InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = ({ title, helperText, required = false, ...props }: InputProps) => {
+  return (
+    <StyledWrapper>
+      <StyledLabel htmlFor={props.id || props.name}>
+        {title}
+        {required && <StyledRequiredMark>*</StyledRequiredMark>}
+      </StyledLabel>
+      <StyledInput {...props} required={required} />
+      {helperText && <StyledHelperText>{helperText}</StyledHelperText>}
+    </StyledWrapper>
+  );
+};

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -8,7 +8,7 @@ import {
   StyledHelperText,
 } from './Input.styled';
 
-type InputProps = {
+export type InputProps = {
   /**
    * Label text displayed above the input field.
    * @type {string}
@@ -21,17 +21,39 @@ type InputProps = {
    * @type {string}
    */
   helperText?: string;
+
+  /**
+   * Whether the input is in an error state.
+   * When true, errorMessage will be shown instead of helperText.
+   */
+  error?: boolean;
+
+  /**
+   * Message displayed when the input is invalid.
+   */
+  errorMessage?: string;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-export const Input = ({ label, helperText, required = false, ...props }: InputProps) => {
+export const Input = ({
+  label,
+  helperText,
+  required = false,
+  error = false,
+  errorMessage,
+  ...props
+}: InputProps) => {
   return (
     <StyledWrapper>
       <StyledLabel htmlFor={props.id || props.name}>
         {label}
         {required && <StyledRequiredMark>*</StyledRequiredMark>}
       </StyledLabel>
-      <StyledInput {...props} required={required} />
-      {helperText && <StyledHelperText>{helperText}</StyledHelperText>}
+      <StyledInput {...props} required={required} error={error} />
+      {error && errorMessage ? (
+        <StyledHelperText error={error}>{errorMessage}</StyledHelperText>
+      ) : (
+        helperText && <StyledHelperText>{helperText}</StyledHelperText>
+      )}
     </StyledWrapper>
   );
 };

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -10,6 +10,10 @@ import {
 
 export type InputProps = {
   /**
+   * Unique id to link the label and input for accessibility.
+   */
+  id: string;
+  /**
    * Label text displayed above the input field.
    * @type {string}
    */
@@ -43,6 +47,7 @@ export type InputProps = {
 } & ComponentProps<'input'>;
 
 export const Input = ({
+  id,
   label,
   helperText,
   isRequired = false,
@@ -52,7 +57,7 @@ export const Input = ({
 }: InputProps) => {
   return (
     <StyledWrapper>
-      <StyledLabel htmlFor={props.id || props.name}>
+      <StyledLabel htmlFor={id}>
         {label}
         {isRequired && <StyledRequiredMark>*</StyledRequiredMark>}
       </StyledLabel>

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -9,7 +9,17 @@ import {
 } from './Input.styled';
 
 type InputProps = {
+  /**
+   * Label text displayed above the input field.
+   * @type {string}
+   */
   title: string;
+
+  /**
+   * Helper text displayed below the input field.
+   * Useful for showing hints or validation messages.
+   * @type {string}
+   */
   helperText?: string;
 } & InputHTMLAttributes<HTMLInputElement>;
 

--- a/client/src/shared/components/Input/index.ts
+++ b/client/src/shared/components/Input/index.ts
@@ -1,0 +1,1 @@
+export { Input } from './Input';


### PR DESCRIPTION
## 관련 이슈

close #36 

## ✨ 작업 내용

- 기본 <input> 요소의 속성을 그대로 사용할 수 있도록 `InputHTMLAttributes<HTMLInputElement>`을 활용해 컴포넌트를 구현했습니다.
- 그 외, prop으로 title, helperText 를 추가했습니다.

## 🙏 기타 참고 사항

### 🐸 사용 예시

```tsx
<Input
  id="email"
  label="이메일"
  name="email"
  placeholder="이메일을 입력해주세요"
  error: true,
  errorMessage: '이메일 형식이 올바르지 않아요',
  value: '',
  onChange: () => {}
/>

```