### PR TITLE
[BE] 주최한 이벤트의 게스트 현황 API 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -1,0 +1,39 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.Event;
+import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.Organization;
+import com.ahmadda.domain.OrganizationMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EventGuestService {
+
+    private final EventRepository eventRepository;
+
+    // TODO. 추후 주최자에 대한 인가 처리 필요
+    public List<OrganizationMember> getGuestMembers(final Long eventId) {
+        final Event event = getEvent(eventId);
+
+        return event.getGuestOrganizationMembers();
+    }
+
+    // TODO. 추후 주최자에 대한 인가 처리 필요
+    public List<OrganizationMember> getNonGuestMembers(final Long eventId) {
+        final Event event = getEvent(eventId);
+        final Organization organization = event.getOrganization();
+        final List<OrganizationMember> allMembers = organization.getOrganizationMembers();
+
+        return event.getNonGuestOrganizationMembers(allMembers);
+    }
+
+    private Event getEvent(final Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 이벤트입니다."));
+    }
+}

--- a/server/src/main/java/com/ahmadda/application/OrganizationMemberEventService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationMemberEventService.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class OrganizationMemberService {
+public class OrganizationMemberEventService {
 
     private final EventRepository eventRepository;
     private final OrganizationMemberRepository organizationMemberRepository;

--- a/server/src/main/java/com/ahmadda/application/dto/OrganizationCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/OrganizationCreateRequest.java
@@ -3,8 +3,13 @@ package com.ahmadda.application.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record OrganizationCreateRequest(@NotBlank String name,
-                                        @NotBlank String description,
-                                        @NotNull String imageUrl) {
+public record OrganizationCreateRequest(
+        @NotBlank
+        String name,
+        @NotBlank
+        String description,
+        @NotNull
+        String imageUrl
+) {
 
 }

--- a/server/src/main/java/com/ahmadda/domain/AnswerRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/AnswerRepository.java
@@ -3,4 +3,5 @@ package com.ahmadda.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
 }

--- a/server/src/main/java/com/ahmadda/domain/BaseEntity.java
+++ b/server/src/main/java/com/ahmadda/domain/BaseEntity.java
@@ -3,11 +3,12 @@ package com.ahmadda.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -21,4 +22,3 @@ public abstract class BaseEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 }
-

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -143,6 +143,7 @@ public class Event extends BaseEntity {
         Set<OrganizationMember> participants = guests.stream()
                 .map(Guest::getParticipant)
                 .collect(Collectors.toSet());
+        participants.add(organizer);
 
         return organizationMembers.stream()
                 .filter(organizationMember -> !participants.contains(organizationMember))

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -63,16 +63,17 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private int maxCapacity;
 
-    private Event(final String title,
-                  final String description,
-                  final String place,
-                  final OrganizationMember organizer,
-                  final Organization organization,
-                  final LocalDateTime registrationStart,
-                  final LocalDateTime registrationEnd,
-                  final LocalDateTime eventStart,
-                  final LocalDateTime eventEnd,
-                  final int maxCapacity
+    private Event(
+            final String title,
+            final String description,
+            final String place,
+            final OrganizationMember organizer,
+            final Organization organization,
+            final LocalDateTime registrationStart,
+            final LocalDateTime registrationEnd,
+            final LocalDateTime eventStart,
+            final LocalDateTime eventEnd,
+            final int maxCapacity
     ) {
         validateTitle(title);
         validateDescription(description);
@@ -99,16 +100,18 @@ public class Event extends BaseEntity {
         organization.addEvent(this);
     }
 
-    public static Event create(final String title,
-                               final String description,
-                               final String place,
-                               final OrganizationMember organizer,
-                               final Organization organization,
-                               final LocalDateTime registrationStart,
-                               final LocalDateTime registrationEnd,
-                               final LocalDateTime eventStart,
-                               final LocalDateTime eventEnd,
-                               final int maxCapacity) {
+    public static Event create(
+            final String title,
+            final String description,
+            final String place,
+            final OrganizationMember organizer,
+            final Organization organization,
+            final LocalDateTime registrationStart,
+            final LocalDateTime registrationEnd,
+            final LocalDateTime eventStart,
+            final LocalDateTime eventEnd,
+            final int maxCapacity
+    ) {
         return new Event(
                 title,
                 description,

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -18,6 +18,8 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -129,6 +131,22 @@ public class Event extends BaseEntity {
     public boolean hasGuest(final OrganizationMember organizationMember) {
         return guests.stream()
                 .anyMatch(guest -> guest.isSameParticipant(organizationMember));
+    }
+
+    public List<OrganizationMember> getGuestOrganizationMembers() {
+        return guests.stream()
+                .map(Guest::getParticipant)
+                .toList();
+    }
+
+    public List<OrganizationMember> getNonGuestOrganizationMembers(final List<OrganizationMember> organizationMembers) {
+        Set<OrganizationMember> participants = guests.stream()
+                .map(Guest::getParticipant)
+                .collect(Collectors.toSet());
+
+        return organizationMembers.stream()
+                .filter(organizationMember -> !participants.contains(organizationMember))
+                .toList();
     }
 
     private void validateTitle(final String title) {

--- a/server/src/main/java/com/ahmadda/domain/Guest.java
+++ b/server/src/main/java/com/ahmadda/domain/Guest.java
@@ -38,7 +38,8 @@ public class Guest extends BaseEntity {
 
         this.event = event;
         this.participant = participant;
-        event.getGuests().add(this);
+        event.getGuests()
+                .add(this);
     }
 
     public static Guest create(final Event event, final OrganizationMember participant) {

--- a/server/src/main/java/com/ahmadda/domain/MemberRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/MemberRepository.java
@@ -3,5 +3,5 @@ package com.ahmadda.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    
+
 }

--- a/server/src/main/java/com/ahmadda/domain/Organization.java
+++ b/server/src/main/java/com/ahmadda/domain/Organization.java
@@ -68,7 +68,8 @@ public class Organization extends BaseEntity {
         LocalDateTime currentDateTime = LocalDateTime.now();
 
         return events.stream()
-                .filter((event) -> event.getEventStart().isAfter(currentDateTime))
+                .filter((event) -> event.getEventStart()
+                        .isAfter(currentDateTime))
                 .toList();
     }
 
@@ -77,9 +78,10 @@ public class Organization extends BaseEntity {
 
         if (name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
             throw new BusinessRuleViolatedException(
-                    String.format("이름의 길이는 %d자 이상 %d자 이하이어야 합니다.",
-                                  MIN_NAME_LENGTH,
-                                  MAX_NAME_LENGTH
+                    String.format(
+                            "이름의 길이는 %d자 이상 %d자 이하이어야 합니다.",
+                            MIN_NAME_LENGTH,
+                            MAX_NAME_LENGTH
                     )
             );
         }
@@ -90,9 +92,10 @@ public class Organization extends BaseEntity {
 
         if (description.length() < 2 || description.length() > 2000) {
             throw new BusinessRuleViolatedException(
-                    String.format("설명의 길이는 %d자 이상 %d자 이하이어야 합니다.",
-                                  MIN_DESCRIPTION_LENGTH,
-                                  MAX_DESCRIPTION_LENGTH
+                    String.format(
+                            "설명의 길이는 %d자 이상 %d자 이하이어야 합니다.",
+                            MIN_DESCRIPTION_LENGTH,
+                            MAX_DESCRIPTION_LENGTH
                     )
             );
         }

--- a/server/src/main/java/com/ahmadda/domain/Organization.java
+++ b/server/src/main/java/com/ahmadda/domain/Organization.java
@@ -43,7 +43,10 @@ public class Organization extends BaseEntity {
     private String name;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "organization")
-    private List<Event> events;
+    private final List<Event> events = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "organization")
+    private final List<OrganizationMember> organizationMembers = new ArrayList<>();
 
     private Organization(final String name, final String description, final String imageUrl) {
         validateName(name);
@@ -53,7 +56,6 @@ public class Organization extends BaseEntity {
         this.name = name;
         this.description = description;
         this.imageUrl = imageUrl;
-        this.events = new ArrayList<>();
     }
 
     public static Organization create(final String name, final String description, final String imageUrl) {

--- a/server/src/main/java/com/ahmadda/domain/OrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationMember.java
@@ -45,6 +45,8 @@ public class OrganizationMember extends BaseEntity {
         this.nickname = nickname;
         this.member = member;
         this.organization = organization;
+        organization.getOrganizationMembers()
+                .add(this);
     }
 
     public static OrganizationMember create(

--- a/server/src/main/java/com/ahmadda/domain/OrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationMember.java
@@ -47,15 +47,17 @@ public class OrganizationMember extends BaseEntity {
         this.organization = organization;
     }
 
-    public static OrganizationMember create(final String nickname,
-                                            final Member member,
-                                            final Organization organization
+    public static OrganizationMember create(
+            final String nickname,
+            final Member member,
+            final Organization organization
     ) {
         return new OrganizationMember(nickname, member, organization);
     }
 
     public List<Event> getParticipatedEvents() {
-        return organization.getEvents().stream()
+        return organization.getEvents()
+                .stream()
                 .filter(event -> event.hasGuest(this))
                 .toList();
     }

--- a/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
@@ -3,4 +3,5 @@ package com.ahmadda.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrganizationMemberRepository extends JpaRepository<OrganizationMember, Long> {
+
 }

--- a/server/src/main/java/com/ahmadda/domain/OrganizationRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationRepository.java
@@ -3,5 +3,5 @@ package com.ahmadda.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrganizationRepository extends JpaRepository<Organization, Long> {
-    
+
 }

--- a/server/src/main/java/com/ahmadda/domain/QuestionRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/QuestionRepository.java
@@ -3,4 +3,5 @@ package com.ahmadda.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
 }

--- a/server/src/main/java/com/ahmadda/domain/exception/BlankPropertyException.java
+++ b/server/src/main/java/com/ahmadda/domain/exception/BlankPropertyException.java
@@ -1,7 +1,7 @@
 package com.ahmadda.domain.exception;
 
 public class BlankPropertyException extends BusinessRuleViolatedException {
-    
+
     public BlankPropertyException(final String message) {
         super(message);
     }

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -1,0 +1,43 @@
+package com.ahmadda.presentation;
+
+import com.ahmadda.application.EventGuestService;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.presentation.dto.OrganizationMemberResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/events")
+@RequiredArgsConstructor
+public class EventGuestController {
+
+    private final EventGuestService eventGuestService;
+
+    @GetMapping("/{eventId}/guest-members")
+    public ResponseEntity<List<OrganizationMemberResponse>> getGuestMembers(@PathVariable final Long eventId) {
+        List<OrganizationMember> guestMembers = eventGuestService.getGuestMembers(eventId);
+
+        List<OrganizationMemberResponse> responses = guestMembers.stream()
+                .map(OrganizationMemberResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/{eventId}/non-guest-members")
+    public ResponseEntity<List<OrganizationMemberResponse>> getNonGuestMembers(@PathVariable final Long eventId) {
+        List<OrganizationMember> nonGuestMembers = eventGuestService.getNonGuestMembers(eventId);
+
+        List<OrganizationMemberResponse> responses = nonGuestMembers.stream()
+                .map(OrganizationMemberResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -3,7 +3,7 @@ package com.ahmadda.presentation;
 import com.ahmadda.application.OrganizationService;
 import com.ahmadda.application.dto.OrganizationCreateRequest;
 import com.ahmadda.domain.Organization;
-import com.ahmadda.presentation.dto.OrganizationReadResponse;
+import com.ahmadda.presentation.dto.OrganizationResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -34,10 +34,10 @@ public class OrganizationController {
     }
 
     @GetMapping("/{organizationId}")
-    public ResponseEntity<OrganizationReadResponse> readOrganization(@PathVariable final Long organizationId) {
+    public ResponseEntity<OrganizationResponse> readOrganization(@PathVariable final Long organizationId) {
         Organization organization = organizationService.getOrganization(organizationId);
-        OrganizationReadResponse organizationReadResponse = OrganizationReadResponse.from(organization);
+        OrganizationResponse organizationResponse = OrganizationResponse.from(organization);
 
-        return ResponseEntity.ok(organizationReadResponse);
+        return ResponseEntity.ok(organizationResponse);
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -25,7 +25,8 @@ public class OrganizationController {
 
     @PostMapping
     public ResponseEntity<Void> createOrganization(
-            @RequestBody @Valid final OrganizationCreateRequest organizationCreateRequest) {
+            @RequestBody @Valid final OrganizationCreateRequest organizationCreateRequest
+    ) {
         Organization organization = organizationService.createOrganization(organizationCreateRequest);
 
         return ResponseEntity.created(URI.create("/api/organizations/" + organization.getId()))

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationMemberEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationMemberEventController.java
@@ -1,7 +1,7 @@
 package com.ahmadda.presentation;
 
 
-import com.ahmadda.application.OrganizationMemberService;
+import com.ahmadda.application.OrganizationMemberEventService;
 import com.ahmadda.domain.Event;
 import com.ahmadda.presentation.dto.EventResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +18,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrganizationMemberEventController {
 
-    private final OrganizationMemberService organizationMemberService;
+    private final OrganizationMemberEventService organizationMemberEventService;
 
     @GetMapping("/{organizationMemberId}/owned-events")
     public ResponseEntity<List<EventResponse>> getOwnerEvents(@PathVariable final Long organizationMemberId) {
-        List<Event> organizationEvents = organizationMemberService.getOwnerEvents(organizationMemberId);
+        List<Event> organizationEvents = organizationMemberEventService.getOwnerEvents(organizationMemberId);
 
         List<EventResponse> eventResponses = organizationEvents.stream()
                 .map(EventResponse::from)
@@ -33,7 +33,7 @@ public class OrganizationMemberEventController {
 
     @GetMapping("/{organizationMemberId}/participated-events")
     public ResponseEntity<List<EventResponse>> getParticipantEvents(@PathVariable final Long organizationMemberId) {
-        List<Event> organizationEvents = organizationMemberService.getParticipantEvents(organizationMemberId);
+        List<Event> organizationEvents = organizationMemberEventService.getParticipantEvents(organizationMemberId);
 
         List<EventResponse> eventResponses = organizationEvents.stream()
                 .map(EventResponse::from)

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationMemberEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationMemberEventController.java
@@ -14,13 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/organization-member")
+@RequestMapping("/api/organization-members")
 @RequiredArgsConstructor
-public class OrganizationMemberController {
+public class OrganizationMemberEventController {
 
     private final OrganizationMemberService organizationMemberService;
 
-    @GetMapping("/{organizationMemberId}/event-owner")
+    @GetMapping("/{organizationMemberId}/owned-events")
     public ResponseEntity<List<EventResponse>> getOwnerEvents(@PathVariable final Long organizationMemberId) {
         List<Event> organizationEvents = organizationMemberService.getOwnerEvents(organizationMemberId);
 
@@ -31,7 +31,7 @@ public class OrganizationMemberController {
         return ResponseEntity.ok(eventResponses);
     }
 
-    @GetMapping("/{organizationMemberId}/event-participant")
+    @GetMapping("/{organizationMemberId}/participated-events")
     public ResponseEntity<List<EventResponse>> getParticipantEvents(@PathVariable final Long organizationMemberId) {
         List<Event> organizationEvents = organizationMemberService.getParticipantEvents(organizationMemberId);
 

--- a/server/src/main/java/com/ahmadda/presentation/dto/EventResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/EventResponse.java
@@ -28,7 +28,8 @@ public record EventResponse(
                 event.getPlace(),
                 event.getRegistrationStart(),
                 event.getRegistrationEnd(),
-                event.getOrganizer().getNickname()
+                event.getOrganizer()
+                        .getNickname()
         );
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberResponse.java
@@ -1,0 +1,16 @@
+package com.ahmadda.presentation.dto;
+
+import com.ahmadda.domain.OrganizationMember;
+
+public record OrganizationMemberResponse(
+        Long id,
+        String nickname
+) {
+
+    public static OrganizationMemberResponse from(final OrganizationMember organizationMember) {
+        return new OrganizationMemberResponse(
+                organizationMember.getId(),
+                organizationMember.getNickname()
+        );
+    }
+}

--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizationReadResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizationReadResponse.java
@@ -2,13 +2,19 @@ package com.ahmadda.presentation.dto;
 
 import com.ahmadda.domain.Organization;
 
-public record OrganizationReadResponse(Long id, String name, String description, String imageUrl) {
+public record OrganizationReadResponse(
+        Long id,
+        String name,
+        String description,
+        String imageUrl
+) {
 
     public static OrganizationReadResponse from(final Organization organization) {
-        return new OrganizationReadResponse(organization.getId(),
-                                            organization.getName(),
-                                            organization.getDescription(),
-                                            organization.getImageUrl()
+        return new OrganizationReadResponse(
+                organization.getId(),
+                organization.getName(),
+                organization.getDescription(),
+                organization.getImageUrl()
         );
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizationResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizationResponse.java
@@ -2,15 +2,15 @@ package com.ahmadda.presentation.dto;
 
 import com.ahmadda.domain.Organization;
 
-public record OrganizationReadResponse(
+public record OrganizationResponse(
         Long id,
         String name,
         String description,
         String imageUrl
 ) {
 
-    public static OrganizationReadResponse from(final Organization organization) {
-        return new OrganizationReadResponse(
+    public static OrganizationResponse from(final Organization organization) {
+        return new OrganizationResponse(
                 organization.getId(),
                 organization.getName(),
                 organization.getDescription(),

--- a/server/src/main/java/com/ahmadda/presentation/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/ahmadda/presentation/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.ahmadda.presentation.exception;
 import com.ahmadda.application.exception.BusinessFlowViolatedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.exception.BusinessRuleViolatedException;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpHeaders;
@@ -16,6 +15,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
@@ -30,14 +31,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 "서버에서 알 수 없는 오류가 발생했습니다.",
                 null,
                 null,
-                request);
+                request
+        );
 
         return super.handleExceptionInternal(ex, body, new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR, request);
     }
 
     @ExceptionHandler({BusinessRuleViolatedException.class, BusinessFlowViolatedException.class})
     public ResponseEntity<Object> handleUnprocessableEntity(final Exception ex, final WebRequest request) {
-        ProblemDetail body = super.createProblemDetail(ex, HttpStatus.UNPROCESSABLE_ENTITY, ex.getMessage(), null, null, request);
+        ProblemDetail body =
+                super.createProblemDetail(ex, HttpStatus.UNPROCESSABLE_ENTITY, ex.getMessage(), null, null, request);
 
         return super.handleExceptionInternal(ex, body, new HttpHeaders(), HttpStatus.UNPROCESSABLE_ENTITY, request);
     }
@@ -68,6 +71,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 problemDetail,
                 httpHeaders,
                 httpStatusCode,
-                request);
+                request
+        );
     }
 }

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -1,0 +1,142 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.Event;
+import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.Guest;
+import com.ahmadda.domain.GuestRepository;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
+import com.ahmadda.domain.Organization;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberRepository;
+import com.ahmadda.domain.OrganizationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class EventGuestServiceTest {
+
+    @Autowired
+    private EventGuestService sut;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private OrganizationMemberRepository organizationMemberRepository;
+
+    @Autowired
+    private GuestRepository guestRepository;
+
+    @Test
+    void 이벤트에_참여한_게스트들을_조회한다() {
+        // given
+        var organization = createAndSaveOrganization();
+        var organizer =
+                createAndSaveOrganizationMember("주최자", createAndSaveMember("홍길동", "host@email.com"), organization);
+        var event = createAndSaveEvent(organizer, organization);
+
+        var guest1 = createAndSaveOrganizationMember("게스트1", createAndSaveMember("게스트1", "g1@email.com"), organization);
+        var guest2 = createAndSaveOrganizationMember("게스트2", createAndSaveMember("게스트2", "g2@email.com"), organization);
+        createAndSaveGuest(event, guest1);
+        createAndSaveGuest(event, guest2);
+
+        // when
+        var result = sut.getGuestMembers(event.getId());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result)
+                    .hasSize(2);
+            softly.assertThat(result)
+                    .extracting(OrganizationMember::getNickname)
+                    .containsExactlyInAnyOrder("게스트1", "게스트2");
+        });
+    }
+
+    @Test
+    void 이벤트에_참여하지_않은_조직원들을_조회한다() {
+        // given
+        var org = createAndSaveOrganization();
+        var organizer = createAndSaveOrganizationMember("주최자", createAndSaveMember("홍길동", "host@email.com"), org);
+        var event = createAndSaveEvent(organizer, org);
+
+        var guest = createAndSaveOrganizationMember("게스트", createAndSaveMember("게스트", "g@email.com"), org);
+        var nonGuest1 = createAndSaveOrganizationMember("비게스트1", createAndSaveMember("비게스트1", "ng1@email.com"), org);
+        var nonGuest2 = createAndSaveOrganizationMember("비게스트2", createAndSaveMember("비게스트2", "ng2@email.com"), org);
+        createAndSaveGuest(event, guest);
+
+        // when
+        var result = sut.getNonGuestMembers(event.getId());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result)
+                    .hasSize(2);
+            softly.assertThat(result)
+                    .extracting(OrganizationMember::getNickname)
+                    .containsExactlyInAnyOrder("비게스트1", "비게스트2");
+        });
+    }
+
+    @Test
+    void 존재하지_않는_이벤트로_게스트_조회시_예외가_발생한다() {
+        assertThatThrownBy(() -> sut.getGuestMembers(999L))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void 존재하지_않는_이벤트로_비게스트_조회시_예외가_발생한다() {
+        assertThatThrownBy(() -> sut.getNonGuestMembers(999L))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    private Member createAndSaveMember(String name, String email) {
+        return memberRepository.save(Member.create(name, email));
+    }
+
+    private Organization createAndSaveOrganization() {
+        return organizationRepository.save(Organization.create("조직", "설명", "img.png"));
+    }
+
+    private OrganizationMember createAndSaveOrganizationMember(String nickname, Member member, Organization org) {
+        return organizationMemberRepository.save(OrganizationMember.create(nickname, member, org));
+    }
+
+    private Event createAndSaveEvent(OrganizationMember organizer, Organization organization) {
+        var now = LocalDateTime.now();
+        var event = Event.create(
+                "이벤트",
+                "설명",
+                "장소",
+                organizer,
+                organization,
+                now.minusDays(3),
+                now.minusDays(1),
+                now.plusDays(1),
+                now.plusDays(2),
+                100
+        );
+        
+        return eventRepository.save(event);
+    }
+
+    private Guest createAndSaveGuest(Event event, OrganizationMember member) {
+        return guestRepository.save(Guest.create(event, member));
+    }
+}

--- a/server/src/test/java/com/ahmadda/application/OrganizationMemberEventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationMemberEventServiceTest.java
@@ -251,6 +251,7 @@ class OrganizationMemberEventServiceTest {
 
     private Guest createAndSaveGuest(Event event, OrganizationMember participant) {
         var guest = Guest.create(event, participant);
+        
         return guestRepository.save(guest);
     }
 }

--- a/server/src/test/java/com/ahmadda/application/OrganizationMemberEventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationMemberEventServiceTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @Transactional
-class OrganizationMemberServiceTest {
+class OrganizationMemberEventServiceTest {
 
     @Autowired
     private EventRepository eventRepository;
@@ -41,7 +41,7 @@ class OrganizationMemberServiceTest {
     private GuestRepository guestRepository;
 
     @Autowired
-    private OrganizationMemberService sut;
+    private OrganizationMemberEventService sut;
 
     @Test
     void 조직원이_주최한_이벤트들을_조회한다() {
@@ -56,8 +56,10 @@ class OrganizationMemberServiceTest {
                 "장소1",
                 organizer,
                 organization,
-                LocalDateTime.now().plusDays(1),
-                LocalDateTime.now().plusDays(2),
+                LocalDateTime.now()
+                        .plusDays(1),
+                LocalDateTime.now()
+                        .plusDays(2),
                 50
         );
 
@@ -67,8 +69,10 @@ class OrganizationMemberServiceTest {
                 "장소2",
                 organizer,
                 organization,
-                LocalDateTime.now().plusDays(3),
-                LocalDateTime.now().plusDays(4),
+                LocalDateTime.now()
+                        .plusDays(3),
+                LocalDateTime.now()
+                        .plusDays(4),
                 30
         );
 
@@ -80,8 +84,10 @@ class OrganizationMemberServiceTest {
                 "다른장소",
                 otherOrganizer,
                 organization,
-                LocalDateTime.now().plusDays(5),
-                LocalDateTime.now().plusDays(6),
+                LocalDateTime.now()
+                        .plusDays(5),
+                LocalDateTime.now()
+                        .plusDays(6),
                 20
         );
 
@@ -91,17 +97,26 @@ class OrganizationMemberServiceTest {
         // then
         assertSoftly(softly -> {
             var firstEvent = result.get(0);
-            softly.assertThat(result).hasSize(2);
-            softly.assertThat(firstEvent.getTitle()).isEqualTo("주최 이벤트 1");
-            softly.assertThat(firstEvent.getDescription()).isEqualTo("첫 번째 주최 이벤트");
-            softly.assertThat(firstEvent.getPlace()).isEqualTo("장소1");
-            softly.assertThat(firstEvent.getMaxCapacity()).isEqualTo(50);
+            softly.assertThat(result)
+                    .hasSize(2);
+            softly.assertThat(firstEvent.getTitle())
+                    .isEqualTo("주최 이벤트 1");
+            softly.assertThat(firstEvent.getDescription())
+                    .isEqualTo("첫 번째 주최 이벤트");
+            softly.assertThat(firstEvent.getPlace())
+                    .isEqualTo("장소1");
+            softly.assertThat(firstEvent.getMaxCapacity())
+                    .isEqualTo(50);
 
             var secondEvent = result.get(1);
-            softly.assertThat(secondEvent.getTitle()).isEqualTo("주최 이벤트 2");
-            softly.assertThat(secondEvent.getDescription()).isEqualTo("두 번째 주최 이벤트");
-            softly.assertThat(secondEvent.getPlace()).isEqualTo("장소2");
-            softly.assertThat(secondEvent.getMaxCapacity()).isEqualTo(30);
+            softly.assertThat(secondEvent.getTitle())
+                    .isEqualTo("주최 이벤트 2");
+            softly.assertThat(secondEvent.getDescription())
+                    .isEqualTo("두 번째 주최 이벤트");
+            softly.assertThat(secondEvent.getPlace())
+                    .isEqualTo("장소2");
+            softly.assertThat(secondEvent.getMaxCapacity())
+                    .isEqualTo(30);
         });
     }
 
@@ -120,8 +135,10 @@ class OrganizationMemberServiceTest {
                 "장소1",
                 organizer,
                 organization,
-                LocalDateTime.now().plusDays(1),
-                LocalDateTime.now().plusDays(2),
+                LocalDateTime.now()
+                        .plusDays(1),
+                LocalDateTime.now()
+                        .plusDays(2),
                 50
         );
 
@@ -131,8 +148,10 @@ class OrganizationMemberServiceTest {
                 "장소2",
                 organizer,
                 organization,
-                LocalDateTime.now().plusDays(3),
-                LocalDateTime.now().plusDays(4),
+                LocalDateTime.now()
+                        .plusDays(3),
+                LocalDateTime.now()
+                        .plusDays(4),
                 30
         );
 
@@ -143,8 +162,10 @@ class OrganizationMemberServiceTest {
                 "미참여장소",
                 organizer,
                 organization,
-                LocalDateTime.now().plusDays(5),
-                LocalDateTime.now().plusDays(6),
+                LocalDateTime.now()
+                        .plusDays(5),
+                LocalDateTime.now()
+                        .plusDays(6),
                 20
         );
 
@@ -157,10 +178,13 @@ class OrganizationMemberServiceTest {
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(result).hasSize(2);
-            softly.assertThat(result).extracting(Event::getTitle)
+            softly.assertThat(result)
+                    .hasSize(2);
+            softly.assertThat(result)
+                    .extracting(Event::getTitle)
                     .containsExactlyInAnyOrder("참여 이벤트 1", "참여 이벤트 2");
-            softly.assertThat(result).extracting(Event::getPlace)
+            softly.assertThat(result)
+                    .extracting(Event::getPlace)
                     .containsExactlyInAnyOrder("장소1", "장소2");
         });
     }
@@ -189,29 +213,35 @@ class OrganizationMemberServiceTest {
         return memberRepository.save(member);
     }
 
-    private OrganizationMember createAndSaveOrganizationMember(String nickname,
-                                                               Member member,
-                                                               Organization organization) {
+    private OrganizationMember createAndSaveOrganizationMember(
+            String nickname,
+            Member member,
+            Organization organization
+    ) {
         var organizationMember = OrganizationMember.create(nickname, member, organization);
         return organizationMemberRepository.save(organizationMember);
     }
 
-    private Event createAndSaveEvent(String title,
-                                     String description,
-                                     String place,
-                                     OrganizationMember organizer,
-                                     Organization organization,
-                                     LocalDateTime eventStart,
-                                     LocalDateTime eventEnd,
-                                     int maxCapacity) {
+    private Event createAndSaveEvent(
+            String title,
+            String description,
+            String place,
+            OrganizationMember organizer,
+            Organization organization,
+            LocalDateTime eventStart,
+            LocalDateTime eventEnd,
+            int maxCapacity
+    ) {
         var event = Event.create(
                 title,
                 description,
                 place,
                 organizer,
                 organization,
-                LocalDateTime.now().minusDays(10), // registrationStart
-                LocalDateTime.now().minusDays(1),  // registrationEnd
+                LocalDateTime.now()
+                        .minusDays(10), // registrationStart
+                LocalDateTime.now()
+                        .minusDays(1),  // registrationEnd
                 eventStart,
                 eventEnd,
                 maxCapacity

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @Transactional
 class OrganizationServiceTest {
 
@@ -51,9 +51,12 @@ class OrganizationServiceTest {
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(found.getName()).isEqualTo("Org");
-            softly.assertThat(found.getDescription()).isEqualTo("Desc");
-            softly.assertThat(found.getImageUrl()).isEqualTo("img.png");
+            softly.assertThat(found.getName())
+                    .isEqualTo("Org");
+            softly.assertThat(found.getDescription())
+                    .isEqualTo("Desc");
+            softly.assertThat(found.getImageUrl())
+                    .isEqualTo("img.png");
         });
     }
 
@@ -69,10 +72,14 @@ class OrganizationServiceTest {
         var organizations = organizationRepository.findAll();
         assertSoftly(softly -> {
             var saved = organizations.get(0);
-            softly.assertThat(organizations).hasSize(1);
-            softly.assertThat(saved.getName()).isEqualTo("조직명");
-            softly.assertThat(saved.getDescription()).isEqualTo("조직 설명");
-            softly.assertThat(saved.getImageUrl()).isEqualTo("image.png");
+            softly.assertThat(organizations)
+                    .hasSize(1);
+            softly.assertThat(saved.getName())
+                    .isEqualTo("조직명");
+            softly.assertThat(saved.getDescription())
+                    .isEqualTo("조직 설명");
+            softly.assertThat(saved.getImageUrl())
+                    .isEqualTo("image.png");
         });
     }
 
@@ -117,11 +124,13 @@ class OrganizationServiceTest {
         return Organization.create(name, description, imageUrl);
     }
 
-    private Event createEvent(OrganizationMember organizer,
-                              Organization organization,
-                              String title,
-                              LocalDateTime start,
-                              LocalDateTime end) {
+    private Event createEvent(
+            OrganizationMember organizer,
+            Organization organization,
+            String title,
+            LocalDateTime start,
+            LocalDateTime end
+    ) {
 
         return Event.create(
                 title,
@@ -137,9 +146,11 @@ class OrganizationServiceTest {
         );
     }
 
-    private OrganizationCreateRequest createOrganizationCreateRequest(String name,
-                                                                      String description,
-                                                                      String imageUrl) {
+    private OrganizationCreateRequest createOrganizationCreateRequest(
+            String name,
+            String description,
+            String imageUrl
+    ) {
         return new OrganizationCreateRequest(name, description, imageUrl);
     }
 }

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -4,50 +4,112 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class EventTest {
 
-    private Member member;
-    private Organization organization;
-    private OrganizationMember organizer;
+    private Organization baseOrganization;
+    private OrganizationMember baseOrganizer;
 
     @BeforeEach
     void setUp() {
-        member = Member.create("테스트 멤버", "test@example.com");
-        organization = Organization.create("테스트 조직", "조직 설명", "image.png");
-        organizer = OrganizationMember.create("주최자", member, organization);
+        Member baseMember = createMember("테스트 멤버", "test@example.com");
+        baseOrganization = createOrganization();
+        baseOrganizer = createOrganizationMember("주최자", baseMember, baseOrganization);
     }
 
     @Test
     void 게스트가_이벤트에_참여했는지_알_수_있다() {
         // given
-        var event = createTestEvent();
-        var member1 = Member.create("참가자1", "guest1@example.com");
-        var member2 = Member.create("참가자2", "guest2@example.com");
-        var organizationMember = OrganizationMember.create("조직원", member1, organization);
-        var anotherOrganizationMember = OrganizationMember.create("다른 조직원", member2, organization);
-        event.getGuests().add(Guest.create(event, organizationMember));
+        var sut = createEvent();
+        var guest = createOrganizationMember("조직원", createMember("참가자1", "guest1@example.com"), baseOrganization);
+        var notGuest = createOrganizationMember("다른 조직원", createMember("참가자2", "guest2@example.com"), baseOrganization);
+        Guest.create(sut, guest);
 
         // when
-        var actual = event.hasGuest(organizationMember);
-        var unexpected = event.hasGuest(anotherOrganizationMember);
+        var actual = sut.hasGuest(guest);
+        var unexpected = sut.hasGuest(notGuest);
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(actual).isTrue();
-            softly.assertThat(unexpected).isFalse();
+            softly.assertThat(actual)
+                    .isTrue();
+            softly.assertThat(unexpected)
+                    .isFalse();
         });
     }
 
-    private Event createTestEvent() {
+    @Test
+    void 이벤트에_참여한_게스트들을_조회할_수_있다() {
+        // given
+        var sut = createEvent();
+        var guest1 = createOrganizationMember("게스트1", createMember("게스트1", "g1@email.com"), baseOrganization);
+        var guest2 = createOrganizationMember("게스트2", createMember("게스트2", "g2@email.com"), baseOrganization);
+        Guest.create(sut, guest1);
+        Guest.create(sut, guest2);
+
+        // when
+        var guests = sut.getGuestOrganizationMembers();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(guests)
+                    .hasSize(2);
+            softly.assertThat(guests)
+                    .extracting("nickname")
+                    .containsExactlyInAnyOrder("게스트1", "게스트2");
+        });
+    }
+
+    @Test
+    void 이벤트에_참여하지_않은_조직원을_조회할_수_있다() {
+        // given
+        var sut = createEvent();
+        var guest = createOrganizationMember("게스트", createMember("게스트", "guest@email.com"), baseOrganization);
+        var nonGuest1 = createOrganizationMember("비게스트1", createMember("비게스트1", "non1@email.com"), baseOrganization);
+        var nonGuest2 = createOrganizationMember("비게스트2", createMember("비게스트2", "non2@email.com"), baseOrganization);
+        Guest.create(sut, guest);
+        var allMembers = List.of(guest, nonGuest1, nonGuest2);
+
+        // when
+        var nonGuests = sut.getNonGuestOrganizationMembers(allMembers);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(nonGuests)
+                    .hasSize(2);
+            softly.assertThat(nonGuests)
+                    .extracting("nickname")
+                    .containsExactlyInAnyOrder("비게스트1", "비게스트2");
+        });
+    }
+
+    private Event createEvent() {
         var now = LocalDateTime.now();
+
         return Event.create(
-                "테스트 이벤트", "설명", "장소", organizer, organization,
+                "테스트 이벤트", "설명", "장소", baseOrganizer, baseOrganization,
                 now.plusDays(1), now.plusDays(5),
                 now.plusDays(10), now.plusDays(11),
                 50
         );
+    }
+
+    private Member createMember(String name, String email) {
+        return Member.create(name, email);
+    }
+
+    private Organization createOrganization() {
+        return Organization.create("테스트 조직", "설명", "image.png");
+    }
+
+    private OrganizationMember createOrganizationMember(
+            String nickname,
+            Member member,
+            Organization organization
+    ) {
+        return OrganizationMember.create(nickname, member, organization);
     }
 }

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -71,7 +71,7 @@ class EventTest {
         var nonGuest1 = createOrganizationMember("비게스트1", createMember("비게스트1", "non1@email.com"), baseOrganization);
         var nonGuest2 = createOrganizationMember("비게스트2", createMember("비게스트2", "non2@email.com"), baseOrganization);
         Guest.create(sut, guest);
-        var allMembers = List.of(guest, nonGuest1, nonGuest2);
+        var allMembers = List.of(baseOrganizer, guest, nonGuest1, nonGuest2);
 
         // when
         var nonGuests = sut.getNonGuestOrganizationMembers(allMembers);


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #86 

## ✨ 작업 내용

- 특정 이벤트의 게스트인 조직원 목록 조회 API 구현
- 특정 이벤트의 게스트가 아닌 조직원 목록 조회 API 구현

## 🙏 기타 참고 사항

앞으로 있을 많은 요구사항 변경에 유연하게 대응할 수 있도록, 
관련 로직은 도메인 내부에 아래와 같이 위임했습니다! 

```java
public List<OrganizationMember> getGuestOrganizationMembers() {
    return guests.stream()
            .map(Guest::getParticipant)
            .toList();
}

public List<OrganizationMember> getNonGuestOrganizationMembers(final List<OrganizationMember> organizationMembers) {
    Set<OrganizationMember> participants = guests.stream()
            .map(Guest::getParticipant)
            .collect(Collectors.toSet());
    participants.add(organizer);

    return organizationMembers.stream()
            .filter(organizationMember -> !participants.contains(organizationMember))
            .toList();
}
```