### PR TITLE
[FE] Spacing 컴포넌트, 스토리북

### DIFF
--- a/client/src/shared/components/Spacing/Spacing.stories.tsx
+++ b/client/src/shared/components/Spacing/Spacing.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Spacing } from './Spacing';
+
+const meta = {
+  title: 'components/Spacing',
+  component: Spacing,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Spacing>;
+
+export default meta;
+type Story = StoryObj<typeof Spacing>;
+
+export const Basic: Story = {
+  args: {
+    height: '1px',
+    color: 'gray',
+  },
+  render: (args) => <Spacing {...args} />,
+};

--- a/client/src/shared/components/Spacing/Spacing.styled.ts
+++ b/client/src/shared/components/Spacing/Spacing.styled.ts
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+import { SpacingProps } from './Spacing';
+
+export const StyledSpacing = styled.div<SpacingProps>`
+  width: 100%;
+  height: ${({ height }) => height || '1px'};
+  background-color: ${({ color }) => color || 'transparent'};
+`;

--- a/client/src/shared/components/Spacing/Spacing.tsx
+++ b/client/src/shared/components/Spacing/Spacing.tsx
@@ -1,0 +1,17 @@
+import { StyledSpacing } from './Spacing.styled';
+
+export type SpacingProps = {
+  /**
+   * Height of the spacing element.
+   * @default '1px'
+   */
+  height?: string;
+  /**
+   * Background color of the spacing element.
+   * @default 'transparent'
+   */
+  color?: string;
+};
+export const Spacing = ({ height, color, ...props }: SpacingProps) => {
+  return <StyledSpacing height={height} color={color} {...props} />;
+};

--- a/client/src/shared/components/Spacing/index.ts
+++ b/client/src/shared/components/Spacing/index.ts
@@ -1,0 +1,1 @@
+export { Spacing } from './Spacing';


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #102

## ✨ 작업 내용

- Spcaing 컴포넌트 구현 했습니다.
- 레이아웃 사이의 구분선이 필요할 때, 콘텐츠 블럭 사이 여백이 필요하지만 margin/padding 대신 명시적 컴포넌트를 쓰고 싶을 때 요긴하게 사용 가능할 것 같습니다. 
![Jul-21-2025 13-57-15](https://github.com/user-attachments/assets/1948c7ed-e8cd-4c3d-baaa-ccdbf6877453)


