### PR TITLE
[BE] 주최한 이벤트의 게스트 현황, 비게스트 조직원에게 이메일 전송의 인증/인가 검증 추가

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -32,11 +32,12 @@ public class EventGuestService {
         return event.getGuests();
     }
 
-    // TODO. 추후 주최자에 대한 인가 처리 필요
-    public List<OrganizationMember> getNonGuestOrganizationMembers(final Long eventId) {
-        final Event event = getEvent(eventId);
-        final Organization organization = event.getOrganization();
-        final List<OrganizationMember> allMembers = organization.getOrganizationMembers();
+    public List<OrganizationMember> getNonGuestOrganizationMembers(final Long eventId, final LoginMember loginMember) {
+        Event event = getEvent(eventId);
+        validateOrganizer(event, loginMember.memberId());
+
+        Organization organization = event.getOrganization();
+        List<OrganizationMember> allMembers = organization.getOrganizationMembers();
 
         return event.getNonGuestOrganizationMembers(allMembers);
     }

--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -6,6 +6,8 @@ import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventRepository;
 import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.GuestRepository;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
 import com.ahmadda.domain.Organization;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
@@ -24,6 +26,7 @@ public class EventGuestService {
     private final GuestRepository guestRepository;
     private final EventRepository eventRepository;
     private final OrganizationMemberRepository organizationMemberRepository;
+    private final MemberRepository memberRepository;
 
     public List<Guest> getGuests(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
@@ -62,7 +65,10 @@ public class EventGuestService {
     }
 
     private void validateOrganizer(final Event event, final Long memberId) {
-        if (!event.isOrganizer(memberId)) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));
+
+        if (!event.isOrganizer(member)) {
             throw new AccessDeniedException("이벤트 주최자가 아닙니다.");
         }
     }

--- a/server/src/main/java/com/ahmadda/application/EventNotificationService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationService.java
@@ -1,10 +1,13 @@
 package com.ahmadda.application;
 
+import com.ahmadda.application.dto.NotificationRequest;
+import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventRepository;
 import com.ahmadda.domain.NotificationMailer;
 import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.presentation.dto.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,21 +20,31 @@ public class EventNotificationService {
     private final EventRepository eventRepository;
     private final NotificationMailer notificationMailer;
 
-    // TODO. 추후 주최자에 대한 인가 처리 필요
-    public void notifyNonGuestOrganizationMembers(final Long eventId, final String content) {
+    public void notifyNonGuestOrganizationMembers(
+            final Long eventId,
+            final NotificationRequest request,
+            final LoginMember loginMember
+    ) {
         Event event = getEvent(eventId);
+        validateOrganizer(event, loginMember.memberId());
         List<OrganizationMember> organizationMembers = event.getOrganization()
                 .getOrganizationMembers();
 
         List<OrganizationMember> recipients = event.getNonGuestOrganizationMembers(organizationMembers);
         String subject = generateSubject(event);
 
-        sendNotificationToRecipients(recipients, subject, content);
+        sendNotificationToRecipients(recipients, subject, request.content());
     }
 
     private Event getEvent(final Long eventId) {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 이벤트입니다."));
+    }
+
+    private void validateOrganizer(final Event event, final Long memberId) {
+        if (!event.isOrganizer(memberId)) {
+            throw new AccessDeniedException("이벤트 주최자가 아닙니다.");
+        }
     }
 
     private String generateSubject(final Event event) {

--- a/server/src/main/java/com/ahmadda/application/EventNotificationService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationService.java
@@ -5,6 +5,8 @@ import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
 import com.ahmadda.domain.NotificationMailer;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.presentation.dto.LoginMember;
@@ -19,6 +21,7 @@ public class EventNotificationService {
 
     private final EventRepository eventRepository;
     private final NotificationMailer notificationMailer;
+    private final MemberRepository memberRepository;
 
     public void notifyNonGuestOrganizationMembers(
             final Long eventId,
@@ -42,7 +45,10 @@ public class EventNotificationService {
     }
 
     private void validateOrganizer(final Event event, final Long memberId) {
-        if (!event.isOrganizer(memberId)) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));
+
+        if (!event.isOrganizer(member)) {
             throw new AccessDeniedException("이벤트 주최자가 아닙니다.");
         }
     }

--- a/server/src/main/java/com/ahmadda/application/exception/AccessDeniedException.java
+++ b/server/src/main/java/com/ahmadda/application/exception/AccessDeniedException.java
@@ -1,0 +1,8 @@
+package com.ahmadda.application.exception;
+
+public class AccessDeniedException extends BusinessFlowViolatedException {
+
+    public AccessDeniedException(final String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -158,6 +158,12 @@ public class Event extends BaseEntity {
         this.guests.add(guest);
     }
 
+    public boolean isOrganizer(final Long memberId) {
+        return organizer.getMember()
+                .getId()
+                .equals(memberId);
+    }
+
     private void validateParticipate(final Guest guest, final LocalDateTime participantDateTime) {
         if (eventOperationPeriod.canNotRegistration(participantDateTime)) {
             throw new BusinessRuleViolatedException("이벤트 신청 기간이 아닙니다.");

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -158,10 +158,9 @@ public class Event extends BaseEntity {
         this.guests.add(guest);
     }
 
-    public boolean isOrganizer(final Long memberId) {
+    public boolean isOrganizer(final Member member) {
         return organizer.getMember()
-                .getId()
-                .equals(memberId);
+                .equals(member);
     }
 
     private void validateParticipate(final Guest guest, final LocalDateTime participantDateTime) {

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -4,7 +4,9 @@ import com.ahmadda.application.EventGuestService;
 import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.presentation.dto.GuestResponse;
+import com.ahmadda.presentation.dto.LoginMember;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
+import com.ahmadda.presentation.resolver.AuthMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,8 +26,11 @@ public class EventGuestController {
     private final EventGuestService eventGuestService;
 
     @GetMapping("/{eventId}/guests")
-    public ResponseEntity<List<GuestResponse>> getGuests(@PathVariable final Long eventId) {
-        List<Guest> guestMembers = eventGuestService.getGuests(eventId);
+    public ResponseEntity<List<GuestResponse>> getGuests(
+            @PathVariable final Long eventId,
+            @AuthMember final LoginMember loginMember
+    ) {
+        List<Guest> guestMembers = eventGuestService.getGuests(eventId, loginMember);
 
         List<GuestResponse> responses = guestMembers.stream()
                 .map(GuestResponse::from)

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -40,8 +40,12 @@ public class EventGuestController {
     }
 
     @GetMapping("/{eventId}/non-guests")
-    public ResponseEntity<List<OrganizationMemberResponse>> getNonGuests(@PathVariable final Long eventId) {
-        List<OrganizationMember> nonGuestMembers = eventGuestService.getNonGuestOrganizationMembers(eventId);
+    public ResponseEntity<List<OrganizationMemberResponse>> getNonGuests(
+            @PathVariable final Long eventId,
+            @AuthMember final LoginMember loginMember
+    ) {
+        List<OrganizationMember> nonGuestMembers =
+                eventGuestService.getNonGuestOrganizationMembers(eventId, loginMember);
 
         List<OrganizationMemberResponse> responses = nonGuestMembers.stream()
                 .map(OrganizationMemberResponse::from)

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
@@ -2,6 +2,8 @@ package com.ahmadda.presentation;
 
 import com.ahmadda.application.EventNotificationService;
 import com.ahmadda.application.dto.NotificationRequest;
+import com.ahmadda.presentation.dto.LoginMember;
+import com.ahmadda.presentation.resolver.AuthMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,9 +23,10 @@ public class EventNotificationController {
     @PostMapping("/{eventId}/notify-non-guests")
     public ResponseEntity<Void> notifyNonGuests(
             @PathVariable final Long eventId,
-            @RequestBody @Valid final NotificationRequest request
+            @RequestBody @Valid final NotificationRequest request,
+            @AuthMember final LoginMember loginMember
     ) {
-        eventNotificationService.notifyNonGuestOrganizationMembers(eventId, request.content());
+        eventNotificationService.notifyNonGuestOrganizationMembers(eventId, request, loginMember);
 
         return ResponseEntity.ok()
                 .build();

--- a/server/src/main/java/com/ahmadda/presentation/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/ahmadda/presentation/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.ahmadda.presentation.exception;
 
+import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.BusinessFlowViolatedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.exception.BusinessRuleViolatedException;
@@ -59,6 +60,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 super.createProblemDetail(ex, HttpStatus.UNAUTHORIZED, ex.getMessage(), null, null, request);
 
         return super.handleExceptionInternal(ex, body, new HttpHeaders(), HttpStatus.UNAUTHORIZED, request);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Object> handleAccessDenied(final Exception ex, final WebRequest request) {
+        ProblemDetail body = super.createProblemDetail(ex, HttpStatus.FORBIDDEN, ex.getMessage(), null, null, request);
+
+        return super.handleExceptionInternal(ex, body, new HttpHeaders(), HttpStatus.FORBIDDEN, request);
     }
 
     @Override

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -1,5 +1,6 @@
 package com.ahmadda.application;
 
+import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventOperationPeriod;
@@ -13,6 +14,7 @@ import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.domain.Period;
+import com.ahmadda.presentation.dto.LoginMember;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -63,7 +65,7 @@ class EventGuestServiceTest {
         );
 
         // when
-        var result = sut.getGuests(event.getId());
+        var result = sut.getGuests(event.getId(), createLoginMember(organizer));
 
         // then
         assertSoftly(softly -> {
@@ -72,6 +74,30 @@ class EventGuestServiceTest {
             softly.assertThat(result)
                     .containsExactlyInAnyOrder(guest1, guest2);
         });
+    }
+
+    @Test
+    void 존재하지_않는_이벤트로_게스트_조회시_예외가_발생한다() {
+        // when // then
+        assertThatThrownBy(() -> sut.getGuests(999L, null))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 이벤트입니다.");
+    }
+
+    @Test
+    void 주최자가_아닌_회원이_게스트_조회시_예외가_발생한다() {
+        // given
+        var organization = createAndSaveOrganization();
+        var organizer =
+                createAndSaveOrganizationMember("주최자", createAndSaveMember("홍길동", "host@email.com"), organization);
+        var otherMember =
+                createAndSaveOrganizationMember("다른사람", createAndSaveMember("user", "user@email.com"), organization);
+        var event = createAndSaveEvent(organizer, organization);
+
+        // when // then
+        assertThatThrownBy(() -> sut.getGuests(event.getId(), createLoginMember(otherMember)))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("이벤트 주최자가 아닙니다.");
     }
 
     @Test
@@ -87,7 +113,7 @@ class EventGuestServiceTest {
         createAndSaveGuest(event, guest);
 
         // when
-        var result = sut.getNonGuestOrganizationMembers(event.getId());
+        var result = sut.getNonGuestOrganizationMembers(event.getId(), createLoginMember(organizer));
 
         // then
         assertSoftly(softly -> {
@@ -99,9 +125,9 @@ class EventGuestServiceTest {
     }
 
     @Test
-    void 존재하지_않는_이벤트로_게스트_조회시_예외가_발생한다() {
+    void 존재하지_않는_이벤트로_비게스트_조회시_예외가_발생한다() {
         // when // then
-        assertThatThrownBy(() -> sut.getGuests(999L))
+        assertThatThrownBy(() -> sut.getNonGuestOrganizationMembers(999L, null))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 이벤트입니다.");
     }
@@ -174,5 +200,11 @@ class EventGuestServiceTest {
 
     private Guest createAndSaveGuest(Event event, OrganizationMember member) {
         return guestRepository.save(Guest.create(event, member, event.getRegistrationStart()));
+    }
+
+    private LoginMember createLoginMember(OrganizationMember organizationMember) {
+        var member = organizationMember.getMember();
+
+        return new LoginMember(member.getId(), member.getName(), member.getEmail());
     }
 }

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -133,11 +133,19 @@ class EventGuestServiceTest {
     }
 
     @Test
-    void 존재하지_않는_이벤트로_비게스트_조회시_예외가_발생한다() {
+    void 주최자가_아닌_회원이_비게스트_조회시_예외가_발생한다() {
+        // given
+        var organization = createAndSaveOrganization();
+        var organizer =
+                createAndSaveOrganizationMember("주최자", createAndSaveMember("홍길동", "host@email.com"), organization);
+        var otherMember =
+                createAndSaveOrganizationMember("다른사람", createAndSaveMember("user", "user@email.com"), organization);
+        var event = createAndSaveEvent(organizer, organization);
+
         // when // then
-        assertThatThrownBy(() -> sut.getNonGuestOrganizationMembers(999L))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 이벤트입니다.");
+        assertThatThrownBy(() -> sut.getNonGuestOrganizationMembers(event.getId(), createLoginMember(otherMember)))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("이벤트 주최자가 아닙니다.");
     }
 
     @Test

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -78,8 +78,14 @@ class EventGuestServiceTest {
 
     @Test
     void 존재하지_않는_이벤트로_게스트_조회시_예외가_발생한다() {
+        // given
+        var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
+        var organizer =
+                createAndSaveOrganizationMember("주최자", createAndSaveMember("주최자", "host@email.com"), organization);
+        var loginMember = createLoginMember(organizer);
+
         // when // then
-        assertThatThrownBy(() -> sut.getGuests(999L, null))
+        assertThatThrownBy(() -> sut.getGuests(999L, loginMember))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 이벤트입니다.");
     }
@@ -126,8 +132,14 @@ class EventGuestServiceTest {
 
     @Test
     void 존재하지_않는_이벤트로_비게스트_조회시_예외가_발생한다() {
+        // given
+        var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
+        var organizer =
+                createAndSaveOrganizationMember("주최자", createAndSaveMember("주최자", "host@email.com"), organization);
+        var loginMember = createLoginMember(organizer);
+
         // when // then
-        assertThatThrownBy(() -> sut.getNonGuestOrganizationMembers(999L, null))
+        assertThatThrownBy(() -> sut.getNonGuestOrganizationMembers(999L, loginMember))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 이벤트입니다.");
     }

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -180,6 +180,32 @@ class EventTest {
                 .hasMessage("이미 참여중인 게스트입니다.");
     }
 
+    @Test
+    void 이벤트의_주최자인지_판단한다() {
+        // given
+        var now = LocalDateTime.now();
+        var registrationPeriod = Period.create(
+                LocalDateTime.now()
+                        .plusDays(1),
+                LocalDateTime.now()
+                        .plusDays(2)
+        );
+        var sut = createEvent(now, registrationPeriod);
+        var nonOrganizer = createOrganizationMember("다른 조직원", createMember(), baseOrganization);
+
+        // when
+        var isOrganizer = sut.isOrganizer(baseOrganizer.getMember());
+        var isNotOrganizer = sut.isOrganizer(nonOrganizer.getMember());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(isOrganizer)
+                    .isTrue();
+            softly.assertThat(isNotOrganizer)
+                    .isFalse();
+        });
+    }
+
     private Event createEvent(final String title, final int maxCapacity) {
         var organization = createOrganization("우테코");
 


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #114
close #115

## ✨ 작업 내용

- 게스트 목록 조회 API에 인증/인가 검증 추가
- 비게스트 조직원 목록 조회 API에 인증/인가 검증 추가
- 비게스트 조직원에게 이메일 전송 API에 인증/인가 검증 추가

## 🙏 기타 참고 사항
- 추후 spring aop를 이용하여 인가로직을 분리해보죠~ 물론, 조금 더 복잡해지면요~
- 인증/인가 검증이 처음으로 포함된 PR이라, 혹여 놓친 부분은 없는지 꼼꼼하고 엄격하게 리뷰 부탁드립니다!
<img width="166" height="229" alt="image" src="https://github.com/user-attachments/assets/8214e528-f4d8-4e8b-9fe0-892e948343a0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 주최자만 게스트 및 비게스트 조직원 목록 조회, 알림 발송이 가능하도록 권한 검증이 추가되었습니다.
  * 권한이 없는 사용자는 접근 시 접근 거부 예외가 발생합니다.

* **버그 수정**
  * 존재하지 않는 이벤트에 대한 요청 시 적절한 예외 메시지가 반환됩니다.

* **테스트**
  * 주최자가 아닌 사용자의 접근 및 알림 발송 시 예외가 발생하는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->