### PR TITLE
[BE] 이벤트 생성시 폼과 함께 생성, 이벤트 참여시 폼 제출과 함께 참여 API 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -49,12 +49,12 @@ public class EventGuestService {
     @Transactional
     public void participantEvent(
             final Long eventId,
-            final Long organizationMemberId,
+            final Long memberId,
             final LocalDateTime currentDateTime,
             final EventParticipateRequest eventParticipateRequest
     ) {
         Event event = getEvent(eventId);
-        OrganizationMember organizationMember = getOrganizationMember(organizationMemberId);
+        OrganizationMember organizationMember = getOrganizationMember(eventId, memberId);
 
         Guest guest = Guest.create(event, organizationMember, currentDateTime);
 
@@ -69,8 +69,8 @@ public class EventGuestService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 이벤트입니다."));
     }
 
-    private OrganizationMember getOrganizationMember(final Long organizationMemberId) {
-        return organizationMemberRepository.findById(organizationMemberId)
+    private OrganizationMember getOrganizationMember(final Long eventId, final Long memberId) {
+        return organizationMemberRepository.findByOrganizationIdAndMemberId(eventId, memberId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 조직원입니다."));
     }
 

--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -60,7 +60,8 @@ public class EventGuestService {
             final EventParticipateRequest eventParticipateRequest
     ) {
         Event event = getEvent(eventId);
-        OrganizationMember organizationMember = getOrganizationMember(eventId, memberId);
+        Organization organization = event.getOrganization();
+        OrganizationMember organizationMember = getOrganizationMember(organization.getId(), memberId);
 
         Guest guest = Guest.create(event, organizationMember, currentDateTime);
 
@@ -84,8 +85,8 @@ public class EventGuestService {
         }
     }
 
-    private OrganizationMember getOrganizationMember(final Long organizationMemberId) {
-        return organizationMemberRepository.findById(organizationMemberId)
+    private OrganizationMember getOrganizationMember(final Long organizationId, final Long memberId) {
+        return organizationMemberRepository.findByOrganizationIdAndMemberId(organizationId, memberId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 조직원입니다."));
     }
 

--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -74,14 +74,14 @@ public class EventGuestService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 조직원입니다."));
     }
 
-    private Map<Question, String> getQuestionAnswers(List<AnswerCreateRequest> answerCreateRequests) {
+    private Map<Question, String> getQuestionAnswers(final List<AnswerCreateRequest> answerCreateRequests) {
         return answerCreateRequests
                 .stream()
                 .map(answerRequest -> Map.entry(getQuestion(answerRequest.questionId()), answerRequest.answerText()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private Question getQuestion(Long questionId) {
+    private Question getQuestion(final Long questionId) {
         return questionRepository.findById(questionId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 질문입니다."));
     }

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -84,7 +84,8 @@ public class EventService {
     ) {
         for (int i = 0; i < questionCreateRequests.size(); i++) {
             QuestionCreateRequest request = questionCreateRequests.get(i);
-            Question.create(event, request.questionText(), request.isRequired(), i);
+            Question question = Question.create(event, request.questionText(), request.isRequired(), i);
+            event.addQuestions(question);
         }
     }
 }

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -1,6 +1,7 @@
 package com.ahmadda.application;
 
 import com.ahmadda.application.dto.EventCreateRequest;
+import com.ahmadda.application.dto.QuestionCreateRequest;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventOperationPeriod;
@@ -10,11 +11,13 @@ import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.domain.Period;
+import com.ahmadda.domain.Question;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -43,6 +46,7 @@ public class EventService {
                 eventOperationPeriod,
                 eventCreateRequest.maxCapacity()
         );
+        addQuestionsToEvent(event, eventCreateRequest.questions());
 
         return eventRepository.save(event);
     }
@@ -72,5 +76,15 @@ public class EventService {
     private OrganizationMember getOrganizationMember(final Long organizationMemberId) {
         return organizationMemberRepository.findById(organizationMemberId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않은 조직원 정보입니다."));
+    }
+
+    private void addQuestionsToEvent(
+            final Event event,
+            final List<QuestionCreateRequest> questionCreateRequests
+    ) {
+        for (int i = 0; i < questionCreateRequests.size(); i++) {
+            QuestionCreateRequest request = questionCreateRequests.get(i);
+            Question.create(event, request.questionText(), request.isRequired(), i);
+        }
     }
 }

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -82,10 +83,11 @@ public class EventService {
             final Event event,
             final List<QuestionCreateRequest> questionCreateRequests
     ) {
-        for (int i = 0; i < questionCreateRequests.size(); i++) {
-            QuestionCreateRequest request = questionCreateRequests.get(i);
-            Question question = Question.create(event, request.questionText(), request.isRequired(), i);
-            event.addQuestions(question);
-        }
+        IntStream.range(0, questionCreateRequests.size())
+                .forEach(i -> {
+                    QuestionCreateRequest request = questionCreateRequests.get(i);
+                    Question question = Question.create(event, request.questionText(), request.isRequired(), i);
+                    event.addQuestions(question);
+                });
     }
 }

--- a/server/src/main/java/com/ahmadda/application/dto/AnswerCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/AnswerCreateRequest.java
@@ -1,10 +1,12 @@
 package com.ahmadda.application.dto;
 
 import jakarta.validation.constraints.NotNull;
+import org.springframework.lang.Nullable;
 
 public record AnswerCreateRequest(
         @NotNull
         Long questionId,
+        @Nullable
         String answerText
 ) {
 

--- a/server/src/main/java/com/ahmadda/application/dto/AnswerCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/AnswerCreateRequest.java
@@ -1,0 +1,11 @@
+package com.ahmadda.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AnswerCreateRequest(
+        @NotNull
+        Long questionId,
+        String answerText
+) {
+
+}

--- a/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
@@ -1,9 +1,11 @@
 package com.ahmadda.application.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record EventCreateRequest(
         @NotBlank
@@ -20,7 +22,9 @@ public record EventCreateRequest(
         LocalDateTime eventStart,
         @NotNull
         LocalDateTime eventEnd,
-        int maxCapacity
+        int maxCapacity,
+        @Valid
+        List<QuestionCreateRequest> questions
 ) {
 
 }

--- a/server/src/main/java/com/ahmadda/application/dto/EventParticipateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventParticipateRequest.java
@@ -1,0 +1,12 @@
+package com.ahmadda.application.dto;
+
+import jakarta.validation.Valid;
+
+import java.util.List;
+
+public record EventParticipateRequest(
+        @Valid
+        List<AnswerCreateRequest> answers
+) {
+
+}

--- a/server/src/main/java/com/ahmadda/application/dto/QuestionCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/QuestionCreateRequest.java
@@ -1,0 +1,11 @@
+package com.ahmadda.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record QuestionCreateRequest(
+        @NotBlank
+        String questionText,
+        boolean isRequired
+) {
+
+}

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -3,6 +3,7 @@ package com.ahmadda.domain;
 
 import com.ahmadda.domain.exception.BusinessRuleViolatedException;
 import com.ahmadda.domain.util.Assert;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -55,7 +56,7 @@ public class Event extends BaseEntity {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "event")
     private List<Guest> guests = new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "event")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Question> questions = new ArrayList<>();
 
     @Embedded

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -113,26 +113,6 @@ public class Event extends BaseEntity {
         );
     }
 
-    public LocalDateTime getRegistrationStart() {
-        return eventOperationPeriod.getRegistrationPeriod()
-                .start();
-    }
-
-    public LocalDateTime getRegistrationEnd() {
-        return eventOperationPeriod.getRegistrationPeriod()
-                .end();
-    }
-
-    public LocalDateTime getEventStart() {
-        return eventOperationPeriod.getEventPeriod()
-                .start();
-    }
-
-    public LocalDateTime getEventEnd() {
-        return eventOperationPeriod.getEventPeriod()
-                .end();
-    }
-
     public boolean hasGuest(final OrganizationMember organizationMember) {
         return guests.stream()
                 .anyMatch(guest -> guest.isSameOrganizationMember(organizationMember));
@@ -159,7 +139,7 @@ public class Event extends BaseEntity {
         this.guests.add(guest);
     }
 
-    public boolean hasQuestion(Question question) {
+    public boolean hasQuestion(final Question question) {
         return questions.contains(question);
     }
 
@@ -168,6 +148,10 @@ public class Event extends BaseEntity {
                 .stream()
                 .filter(Question::isRequired)
                 .collect(Collectors.toSet());
+    }
+
+    public void addQuestions(final Question... question) {
+        questions.addAll(List.of(question));
     }
 
     private void validateParticipate(final Guest guest, final LocalDateTime participantDateTime) {
@@ -215,5 +199,25 @@ public class Event extends BaseEntity {
         if (maxCapacity < MIN_CAPACITY || maxCapacity > MAX_CAPACITY) {
             throw new BusinessRuleViolatedException("최대 수용 인원은 1명보다 적거나 21억명 보다 클 수 없습니다.");
         }
+    }
+
+    public LocalDateTime getRegistrationStart() {
+        return eventOperationPeriod.getRegistrationPeriod()
+                .start();
+    }
+
+    public LocalDateTime getRegistrationEnd() {
+        return eventOperationPeriod.getRegistrationPeriod()
+                .end();
+    }
+
+    public LocalDateTime getEventStart() {
+        return eventOperationPeriod.getEventPeriod()
+                .start();
+    }
+
+    public LocalDateTime getEventEnd() {
+        return eventOperationPeriod.getEventPeriod()
+                .end();
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -159,6 +159,17 @@ public class Event extends BaseEntity {
         this.guests.add(guest);
     }
 
+    public boolean hasQuestion(Question question) {
+        return questions.contains(question);
+    }
+
+    public Set<Question> getRequiredQuestions() {
+        return getQuestions()
+                .stream()
+                .filter(Question::isRequired)
+                .collect(Collectors.toSet());
+    }
+
     private void validateParticipate(final Guest guest, final LocalDateTime participantDateTime) {
         if (eventOperationPeriod.canNotRegistration(participantDateTime)) {
             throw new BusinessRuleViolatedException("이벤트 신청 기간이 아닙니다.");

--- a/server/src/main/java/com/ahmadda/domain/Guest.java
+++ b/server/src/main/java/com/ahmadda/domain/Guest.java
@@ -88,6 +88,9 @@ public class Guest extends BaseEntity {
             if (!event.hasQuestion(question)) {
                 throw new BusinessRuleViolatedException("이벤트에 포함되지 않은 질문입니다.");
             }
+            if (answerText == null || answerText.isBlank()) {
+                return;
+            }
             this.answers.add(Answer.create(question, this, answerText));
         });
     }

--- a/server/src/main/java/com/ahmadda/domain/Guest.java
+++ b/server/src/main/java/com/ahmadda/domain/Guest.java
@@ -3,6 +3,7 @@ package com.ahmadda.domain;
 
 import com.ahmadda.domain.exception.BusinessRuleViolatedException;
 import com.ahmadda.domain.util.Assert;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,11 +12,16 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -34,6 +40,9 @@ public class Guest extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "participant_id", nullable = false)
     private OrganizationMember organizationMember;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "guest", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Answer> answers = new ArrayList<>();
 
     private Guest(final Event event, final OrganizationMember organizationMember, final LocalDateTime currentDateTime) {
         validateEvent(event);
@@ -56,6 +65,31 @@ public class Guest extends BaseEntity {
 
     public boolean isSameOrganizationMember(final OrganizationMember organizationMember) {
         return this.organizationMember.equals(organizationMember);
+    }
+
+    public void submitAnswers(final Map<Question, String> questionAnswers) {
+        validateRequiredQuestions(questionAnswers.keySet());
+
+        addAnswers(questionAnswers);
+    }
+
+    private void validateRequiredQuestions(Set<Question> answeredQuestions) {
+        Set<Question> requiredQuestions = event.getRequiredQuestions();
+
+        for (Question required : requiredQuestions) {
+            if (!answeredQuestions.contains(required)) {
+                throw new BusinessRuleViolatedException("필수 질문에 대한 답변이 누락되었습니다.");
+            }
+        }
+    }
+
+    private void addAnswers(Map<Question, String> answers) {
+        answers.forEach((question, answerText) -> {
+            if (!event.hasQuestion(question)) {
+                throw new BusinessRuleViolatedException("이벤트에 포함되지 않은 질문입니다.");
+            }
+            this.answers.add(Answer.create(question, this, answerText));
+        });
     }
 
     private void validateEvent(final Event event) {

--- a/server/src/main/java/com/ahmadda/domain/Guest.java
+++ b/server/src/main/java/com/ahmadda/domain/Guest.java
@@ -73,7 +73,7 @@ public class Guest extends BaseEntity {
         addAnswers(questionAnswers);
     }
 
-    private void validateRequiredQuestions(Set<Question> answeredQuestions) {
+    private void validateRequiredQuestions(final Set<Question> answeredQuestions) {
         Set<Question> requiredQuestions = event.getRequiredQuestions();
 
         for (Question required : requiredQuestions) {
@@ -83,7 +83,7 @@ public class Guest extends BaseEntity {
         }
     }
 
-    private void addAnswers(Map<Question, String> answers) {
+    private void addAnswers(final Map<Question, String> answers) {
         answers.forEach((question, answerText) -> {
             if (!event.hasQuestion(question)) {
                 throw new BusinessRuleViolatedException("이벤트에 포함되지 않은 질문입니다.");

--- a/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
@@ -2,6 +2,9 @@ package com.ahmadda.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OrganizationMemberRepository extends JpaRepository<OrganizationMember, Long> {
 
+    Optional<OrganizationMember> findByOrganizationIdAndMemberId(Long organizationId, Long memberId);
 }

--- a/server/src/main/java/com/ahmadda/domain/Question.java
+++ b/server/src/main/java/com/ahmadda/domain/Question.java
@@ -50,7 +50,7 @@ public class Question extends BaseEntity {
         this.questionText = questionText;
         this.isRequired = isRequired;
         this.orderIndex = orderIndex;
-        
+
         event.getQuestions()
                 .add(this);
     }

--- a/server/src/main/java/com/ahmadda/domain/Question.java
+++ b/server/src/main/java/com/ahmadda/domain/Question.java
@@ -50,6 +50,9 @@ public class Question extends BaseEntity {
         this.questionText = questionText;
         this.isRequired = isRequired;
         this.orderIndex = orderIndex;
+        
+        event.getQuestions()
+                .add(this);
     }
 
     public static Question create(

--- a/server/src/main/java/com/ahmadda/domain/Question.java
+++ b/server/src/main/java/com/ahmadda/domain/Question.java
@@ -50,9 +50,6 @@ public class Question extends BaseEntity {
         this.questionText = questionText;
         this.isRequired = isRequired;
         this.orderIndex = orderIndex;
-
-        event.getQuestions()
-                .add(this);
     }
 
     public static Question create(

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -1,15 +1,18 @@
 package com.ahmadda.presentation;
 
 import com.ahmadda.application.EventGuestService;
+import com.ahmadda.application.dto.EventParticipateRequest;
 import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.presentation.dto.GuestResponse;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -46,10 +49,18 @@ public class EventGuestController {
     }
 
     @PostMapping("/{eventId}/participation")
-    public ResponseEntity<Void> participateEvent(@PathVariable final Long eventId) {
+    public ResponseEntity<Void> participateEvent(
+            @PathVariable final Long eventId,
+            @RequestBody @Valid final EventParticipateRequest eventParticipateRequest
+    ) {
         Long fakeOrganizationMemberId = 1L;
 
-        eventGuestService.participantEvent(eventId, fakeOrganizationMemberId, LocalDateTime.now());
+        eventGuestService.participantEvent(
+                eventId,
+                fakeOrganizationMemberId,
+                LocalDateTime.now(),
+                eventParticipateRequest
+        );
 
         return ResponseEntity.ok()
                 .build();

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -5,7 +5,9 @@ import com.ahmadda.application.dto.EventParticipateRequest;
 import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.presentation.dto.GuestResponse;
+import com.ahmadda.presentation.dto.LoginMember;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
+import com.ahmadda.presentation.resolver.AuthMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -51,13 +53,12 @@ public class EventGuestController {
     @PostMapping("/{eventId}/participation")
     public ResponseEntity<Void> participateEvent(
             @PathVariable final Long eventId,
-            @RequestBody @Valid final EventParticipateRequest eventParticipateRequest
+            @RequestBody @Valid final EventParticipateRequest eventParticipateRequest,
+            @AuthMember final LoginMember loginMember
     ) {
-        Long fakeOrganizationMemberId = 1L;
-
         eventGuestService.participantEvent(
                 eventId,
-                fakeOrganizationMemberId,
+                loginMember.memberId(),
                 LocalDateTime.now(),
                 eventParticipateRequest
         );

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -128,15 +128,16 @@ class EventGuestServiceTest {
     void 조직원은_이벤트의_게스트로_참여할_수_있다() {
         // given
         var organization = createAndSaveOrganization();
-        var member = createAndSaveMember("name", "email@ahmadda.com");
-        var organizationMember1 = createAndSaveOrganizationMember("surf1", member, organization);
-        var organizationMember2 = createAndSaveOrganizationMember("surf2", member, organization);
+        var member1 = createAndSaveMember("name1", "email1@ahmadda.com");
+        var member2 = createAndSaveMember("name2", "email2@ahmadda.com");
+        var organizationMember1 = createAndSaveOrganizationMember("surf1", member1, organization);
+        var organizationMember2 = createAndSaveOrganizationMember("surf2", member2, organization);
         var event = createAndSaveEvent(organizationMember1, organization);
 
         // when
         sut.participantEvent(
                 event.getId(),
-                organizationMember2.getId(),
+                member2.getId(),
                 event.getRegistrationStart(),
                 new EventParticipateRequest(List.of())
         );
@@ -158,9 +159,10 @@ class EventGuestServiceTest {
     void 필수_질문에_모두_답변하면_참여할_수_있다() {
         // given
         var organization = createAndSaveOrganization();
-        var member = createAndSaveMember("name", "email@ahmadda.com");
-        var organizer = createAndSaveOrganizationMember("organizer", member, organization);
-        var participant = createAndSaveOrganizationMember("participant", member, organization);
+        var member1 = createAndSaveMember("name1", "email1@ahmadda.com");
+        var member2 = createAndSaveMember("name2", "email2@ahmadda.com");
+        var organizer = createAndSaveOrganizationMember("organizer", member1, organization);
+        var participant = createAndSaveOrganizationMember("participant", member2, organization);
         var event = createAndSaveEvent(organizer, organization);
 
         var question1 = createAndSaveQuestion(event, "필수 질문", true, 0);
@@ -173,7 +175,7 @@ class EventGuestServiceTest {
         ));
 
         // when
-        sut.participantEvent(event.getId(), participant.getId(), event.getRegistrationStart(), request);
+        sut.participantEvent(event.getId(), member2.getId(), event.getRegistrationStart(), request);
 
         // then
         var guest = guestRepository.findAll()
@@ -191,9 +193,10 @@ class EventGuestServiceTest {
     void 필수_질문이_누락되면_예외가_발생한다() {
         // given
         var organization = createAndSaveOrganization();
-        var member = createAndSaveMember("name", "email@ahmadda.com");
-        var organizer = createAndSaveOrganizationMember("organizer", member, organization);
-        var participant = createAndSaveOrganizationMember("participant", member, organization);
+        var member1 = createAndSaveMember("name1", "email1@ahmadda.com");
+        var member2 = createAndSaveMember("name2", "email2@ahmadda.com");
+        var organizer = createAndSaveOrganizationMember("organizer", member1, organization);
+        var participant = createAndSaveOrganizationMember("participant", member2, organization);
         var event = createAndSaveEvent(organizer, organization);
 
         var question1 = createAndSaveQuestion(event, "필수 질문", true, 0);
@@ -206,7 +209,7 @@ class EventGuestServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-                sut.participantEvent(event.getId(), participant.getId(), event.getRegistrationStart(), request)
+                sut.participantEvent(event.getId(), member2.getId(), event.getRegistrationStart(), request)
         )
                 .isInstanceOf(BusinessRuleViolatedException.class)
                 .hasMessageContaining("필수 질문에 대한 답변이 누락되었습니다");
@@ -216,9 +219,10 @@ class EventGuestServiceTest {
     void 존재하지_않는_질문에_답변하면_예외가_발생한다() {
         // given
         var organization = createAndSaveOrganization();
-        var member = createAndSaveMember("name", "email@ahmadda.com");
-        var organizer = createAndSaveOrganizationMember("organizer", member, organization);
-        var participant = createAndSaveOrganizationMember("participant", member, organization);
+        var member1 = createAndSaveMember("name1", "email1@ahmadda.com");
+        var member2 = createAndSaveMember("name2", "email2@ahmadda.com");
+        var organizer = createAndSaveOrganizationMember("organizer", member1, organization);
+        var participant = createAndSaveOrganizationMember("participant", member2, organization);
         var event = createAndSaveEvent(organizer, organization);
 
         var invalidQuestionId = 999L;
@@ -229,7 +233,7 @@ class EventGuestServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-                sut.participantEvent(event.getId(), participant.getId(), event.getRegistrationStart(), request)
+                sut.participantEvent(event.getId(), member2.getId(), event.getRegistrationStart(), request)
         )
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("존재하지 않는 질문입니다.");

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -190,7 +190,7 @@ class EventGuestServiceTest {
     }
 
     @Test
-    void 필수_질문이_누락되면_예외가_발생한다() {
+    void 필수_질문에_대한_답변이_누락되면_예외가_발생한다() {
         // given
         var organization = createAndSaveOrganization();
         var member1 = createAndSaveMember("name1", "email1@ahmadda.com");

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -165,6 +165,7 @@ class EventGuestServiceTest {
 
         var question1 = createAndSaveQuestion(event, "필수 질문", true, 0);
         var question2 = createAndSaveQuestion(event, "선택 질문", false, 1);
+        event.addQuestions(question1, question2);
 
         var request = new EventParticipateRequest(List.of(
                 new AnswerCreateRequest(question1.getId(), "답변1"),
@@ -197,6 +198,7 @@ class EventGuestServiceTest {
 
         var question1 = createAndSaveQuestion(event, "필수 질문", true, 0);
         var question2 = createAndSaveQuestion(event, "선택 질문", false, 1);
+        event.addQuestions(question1, question2);
 
         var request = new EventParticipateRequest(List.of(
                 new AnswerCreateRequest(question2.getId(), "선택 답변")

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -1,6 +1,7 @@
 package com.ahmadda.application;
 
 import com.ahmadda.application.dto.EventCreateRequest;
+import com.ahmadda.application.dto.QuestionCreateRequest;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.EventOperationPeriod;
 import com.ahmadda.domain.EventRepository;
@@ -11,12 +12,16 @@ import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.domain.Period;
+import com.ahmadda.domain.Question;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -55,7 +60,8 @@ class EventServiceTest {
                 "선릉",
                 now.plusDays(3), now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
-                100
+                100,
+                List.of(new QuestionCreateRequest("1번 질문", true), new QuestionCreateRequest("2번 질문", false))
         );
 
         //when
@@ -82,6 +88,11 @@ class EventServiceTest {
                                         Period.create(now.plusDays(5), now.plusDays(6)),
                                         now
                                 ));
+                        List<Question> questions = savedEvent.getQuestions();
+                        softly.assertThat(questions)
+                                .hasSize(2)
+                                .extracting("questionText", "isRequired", "orderIndex")
+                                .containsExactly(Tuple.tuple("1번 질문", true, 0), Tuple.tuple("2번 질문", false, 1));
                     });
                 });
     }
@@ -98,7 +109,8 @@ class EventServiceTest {
                 "선릉",
                 now.plusDays(3), now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
-                100
+                100,
+                List.of(new QuestionCreateRequest("1번 질문", true), new QuestionCreateRequest("2번 질문", false))
         );
 
         //when //then
@@ -119,7 +131,8 @@ class EventServiceTest {
                 "선릉",
                 now.plusDays(3), now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
-                100
+                100,
+                new ArrayList<>()
         );
 
         //when //then

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -180,6 +180,47 @@ class EventTest {
                 .hasMessage("이미 참여중인 게스트입니다.");
     }
 
+    @Test
+    void 이벤트에_질문이_포함되어있는지_확인할_수_있다() {
+        // given
+        var sut = createEvent("이벤트", 10);
+        var question = Question.create(sut, "필수 질문", true, 0);
+
+        var otherEvent = createEvent("이벤트2", 10);
+        var notIncludedQuestion = Question.create(otherEvent, "없는 질문", true, 1);
+
+        // when
+        var actual1 = sut.hasQuestion(question);
+        var actual2 = sut.hasQuestion(notIncludedQuestion);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(actual1)
+                    .isTrue();
+            softly.assertThat(actual2)
+                    .isFalse();
+        });
+    }
+
+    @Test
+    void 필수_질문만_조회할_수_있다() {
+        // given
+        var sut = createEvent("이벤트", 10);
+        var requiredQuestion = Question.create(sut, "필수 질문", true, 0);
+        var optionalQuestion = Question.create(sut, "선택 질문", false, 1);
+
+        // when
+        var result = sut.getRequiredQuestions();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result)
+                    .hasSize(1);
+            softly.assertThat(result)
+                    .containsExactly(requiredQuestion);
+        });
+    }
+
     private Event createEvent(final String title, final int maxCapacity) {
         var organization = createOrganization("우테코");
 

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -185,9 +185,11 @@ class EventTest {
         // given
         var sut = createEvent("이벤트", 10);
         var question = Question.create(sut, "필수 질문", true, 0);
+        sut.addQuestions(question);
 
         var otherEvent = createEvent("이벤트2", 10);
         var notIncludedQuestion = Question.create(otherEvent, "없는 질문", true, 1);
+        otherEvent.addQuestions(notIncludedQuestion);
 
         // when
         var actual1 = sut.hasQuestion(question);
@@ -208,6 +210,7 @@ class EventTest {
         var sut = createEvent("이벤트", 10);
         var requiredQuestion = Question.create(sut, "필수 질문", true, 0);
         var optionalQuestion = Question.create(sut, "선택 질문", false, 1);
+        sut.addQuestions(requiredQuestion, optionalQuestion);
 
         // when
         var result = sut.getRequiredQuestions();

--- a/server/src/test/java/com/ahmadda/domain/GuestTest.java
+++ b/server/src/test/java/com/ahmadda/domain/GuestTest.java
@@ -167,6 +167,7 @@ class GuestTest {
 
         var question1 = Question.create(event, "필수 질문1", true, 0);
         var question2 = Question.create(event, "선택 질문2", false, 1);
+        event.addQuestions(question1, question2);
 
         var guest = Guest.create(event, otherParticipant, now);
 
@@ -193,6 +194,7 @@ class GuestTest {
 
         var question1 = Question.create(event, "필수 질문1", true, 0);
         var question2 = Question.create(event, "선택 질문2", false, 1);
+        event.addQuestions(question1, question2);
 
         var guest = Guest.create(event, otherParticipant, now);
 


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #116 

## ✨ 작업 내용

- 이벤트 생성시 이벤트 폼과 함께 요청을 했다면 폼또한 생성되게 해주었습니다. 
- 이벤트 참여시 이벤트 폼이 있다면 답변이 있어야 참여되게 해주었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 생성 시 질문 목록을 추가할 수 있습니다.
  * 이벤트 참여 시 질문에 대한 답변을 제출할 수 있습니다. 필수 질문에 대한 답변이 누락되면 참여가 제한됩니다.

* **버그 수정**
  * 이벤트와 질문, 답변 간의 연관관계 및 유효성 검증이 강화되었습니다.

* **테스트**
  * 이벤트 생성 및 참여 시 질문과 답변 처리에 대한 다양한 테스트가 추가되어 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->