### PR TITLE
[BE] 자신의 회원/조직원 정보 조회 API 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -2,6 +2,7 @@ package com.ahmadda.application;
 
 import com.ahmadda.application.dto.AnswerCreateRequest;
 import com.ahmadda.application.dto.EventParticipateRequest;
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Event;
@@ -15,7 +16,6 @@ import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.Question;
 import com.ahmadda.domain.QuestionRepository;
-import com.ahmadda.presentation.dto.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/server/src/main/java/com/ahmadda/application/EventNotificationService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationService.java
@@ -1,5 +1,6 @@
 package com.ahmadda.application;
 
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.NotificationRequest;
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
@@ -9,7 +10,6 @@ import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
 import com.ahmadda.domain.NotificationMailer;
 import com.ahmadda.domain.OrganizationMember;
-import com.ahmadda.presentation.dto.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/server/src/main/java/com/ahmadda/application/MemberService.java
+++ b/server/src/main/java/com/ahmadda/application/MemberService.java
@@ -1,9 +1,9 @@
 package com.ahmadda.application;
 
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
-import com.ahmadda.presentation.dto.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/server/src/main/java/com/ahmadda/application/MemberService.java
+++ b/server/src/main/java/com/ahmadda/application/MemberService.java
@@ -1,0 +1,20 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
+import com.ahmadda.presentation.dto.LoginMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member getMember(final LoginMember loginMember) {
+        return memberRepository.findById(loginMember.memberId())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));
+    }
+}

--- a/server/src/main/java/com/ahmadda/application/OrganizationMemberService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationMemberService.java
@@ -1,0 +1,20 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberRepository;
+import com.ahmadda.presentation.dto.LoginMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrganizationMemberService {
+
+    private final OrganizationMemberRepository organizationMemberRepository;
+
+    public OrganizationMember getOrganizationMember(final Long organizationId, final LoginMember loginMember) {
+        return organizationMemberRepository.findByOrganizationIdAndMemberId(organizationId, loginMember.memberId())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 조직원입니다."));
+    }
+}

--- a/server/src/main/java/com/ahmadda/application/OrganizationMemberService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationMemberService.java
@@ -1,9 +1,9 @@
 package com.ahmadda.application;
 
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
-import com.ahmadda.presentation.dto.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/server/src/main/java/com/ahmadda/application/dto/LoginMember.java
+++ b/server/src/main/java/com/ahmadda/application/dto/LoginMember.java
@@ -1,4 +1,4 @@
-package com.ahmadda.presentation.dto;
+package com.ahmadda.application.dto;
 
 public record LoginMember(
         Long memberId,

--- a/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
@@ -1,10 +1,17 @@
 package com.ahmadda.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface OrganizationMemberRepository extends JpaRepository<OrganizationMember, Long> {
 
+    @Query("""
+                select om
+                from OrganizationMember om
+                where om.organization.id = :organizationId
+                  and om.member.id = :memberId
+            """)
     Optional<OrganizationMember> findByOrganizationIdAndMemberId(final Long organizationId, final Long memberId);
 }

--- a/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
@@ -2,6 +2,9 @@ package com.ahmadda.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OrganizationMemberRepository extends JpaRepository<OrganizationMember, Long> {
 
+    Optional<OrganizationMember> findByOrganizationIdAndMemberId(final Long organizationId, final Long memberId);
 }

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -2,10 +2,10 @@ package com.ahmadda.presentation;
 
 import com.ahmadda.application.EventGuestService;
 import com.ahmadda.application.dto.EventParticipateRequest;
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.presentation.dto.GuestResponse;
-import com.ahmadda.presentation.dto.LoginMember;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import jakarta.validation.Valid;

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
@@ -1,8 +1,8 @@
 package com.ahmadda.presentation;
 
 import com.ahmadda.application.EventNotificationService;
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.NotificationRequest;
-import com.ahmadda.presentation.dto.LoginMember;
 import com.ahmadda.presentation.resolver.AuthMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/server/src/main/java/com/ahmadda/presentation/LoginController.java
+++ b/server/src/main/java/com/ahmadda/presentation/LoginController.java
@@ -1,21 +1,24 @@
 package com.ahmadda.presentation;
 
 import com.ahmadda.application.LoginService;
+import com.ahmadda.presentation.dto.AccessTokenResponse;
 import com.ahmadda.presentation.dto.LoginRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/members")
 @RequiredArgsConstructor
 public class LoginController {
 
     private final LoginService loginService;
 
     @PostMapping("/login")
-    public ResponseEntity<AccessTokenResponse> login(final @RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<AccessTokenResponse> login(@RequestBody final LoginRequest loginRequest) {
         String authTokens = loginService.login(loginRequest.code());
 
         AccessTokenResponse accessTokenResponse = new AccessTokenResponse(authTokens);

--- a/server/src/main/java/com/ahmadda/presentation/MemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/MemberController.java
@@ -1,0 +1,29 @@
+package com.ahmadda.presentation;
+
+import com.ahmadda.application.MemberService;
+import com.ahmadda.domain.Member;
+import com.ahmadda.presentation.dto.LoginMember;
+import com.ahmadda.presentation.dto.MemberResponse;
+import com.ahmadda.presentation.resolver.AuthMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/profile")
+    public ResponseEntity<MemberResponse> getMemberProfile(@AuthMember final LoginMember loginMember) {
+        Member member = memberService.getMember(loginMember);
+        
+        MemberResponse response = MemberResponse.from(member);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/server/src/main/java/com/ahmadda/presentation/MemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/MemberController.java
@@ -1,13 +1,13 @@
 package com.ahmadda.presentation;
 
 import com.ahmadda.application.MemberService;
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.domain.Member;
-import com.ahmadda.presentation.dto.LoginMember;
 import com.ahmadda.presentation.dto.MemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,10 +18,10 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping("/profile")
+    @GetMapping("/profile")
     public ResponseEntity<MemberResponse> getMemberProfile(@AuthMember final LoginMember loginMember) {
         Member member = memberService.getMember(loginMember);
-        
+
         MemberResponse response = MemberResponse.from(member);
 
         return ResponseEntity.ok(response);

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
@@ -1,8 +1,8 @@
 package com.ahmadda.presentation;
 
 import com.ahmadda.application.OrganizationMemberService;
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.domain.OrganizationMember;
-import com.ahmadda.presentation.dto.LoginMember;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class OrganizationMemberController {
     private final OrganizationMemberService organizationMemberService;
 
     @GetMapping("/{organizationId}/profile")
-    public ResponseEntity<OrganizationMemberResponse> getOrganizationProfile(
+    public ResponseEntity<OrganizationMemberResponse> getOrganizationMemberProfile(
             @PathVariable final Long organizationId,
             @AuthMember final LoginMember loginMember
     ) {

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
@@ -21,7 +21,7 @@ public class OrganizationMemberController {
 
     @GetMapping("/{organizationId}/profile")
     public ResponseEntity<OrganizationMemberResponse> getOrganizationProfile(
-            @PathVariable Long organizationId,
+            @PathVariable final Long organizationId,
             @AuthMember final LoginMember loginMember
     ) {
         OrganizationMember organizationMember =

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
@@ -1,0 +1,34 @@
+package com.ahmadda.presentation;
+
+import com.ahmadda.application.OrganizationMemberService;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.presentation.dto.LoginMember;
+import com.ahmadda.presentation.dto.OrganizationMemberResponse;
+import com.ahmadda.presentation.resolver.AuthMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/organizations")
+@RequiredArgsConstructor
+public class OrganizationMemberController {
+
+    private final OrganizationMemberService organizationMemberService;
+
+    @GetMapping("/{organizationId}/profile")
+    public ResponseEntity<OrganizationMemberResponse> getOrganizationProfile(
+            @PathVariable Long organizationId,
+            @AuthMember final LoginMember loginMember
+    ) {
+        OrganizationMember organizationMember =
+                organizationMemberService.getOrganizationMember(organizationId, loginMember);
+
+        OrganizationMemberResponse response = OrganizationMemberResponse.from(organizationMember);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/server/src/main/java/com/ahmadda/presentation/dto/AccessTokenResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/AccessTokenResponse.java
@@ -1,4 +1,4 @@
-package com.ahmadda.presentation;
+package com.ahmadda.presentation.dto;
 
 public record AccessTokenResponse(
         String accessToken

--- a/server/src/main/java/com/ahmadda/presentation/dto/MemberResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/MemberResponse.java
@@ -1,0 +1,18 @@
+package com.ahmadda.presentation.dto;
+
+import com.ahmadda.domain.Member;
+
+public record MemberResponse(
+        Long id,
+        String name,
+        String email
+) {
+
+    public static MemberResponse from(final Member member) {
+        return new MemberResponse(
+                member.getId(),
+                member.getName(),
+                member.getEmail()
+        );
+    }
+}

--- a/server/src/main/java/com/ahmadda/presentation/resolver/MemberArgumentResolver.java
+++ b/server/src/main/java/com/ahmadda/presentation/resolver/MemberArgumentResolver.java
@@ -1,8 +1,8 @@
 package com.ahmadda.presentation.resolver;
 
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.infra.jwt.JwtTokenProvider;
 import com.ahmadda.infra.oauth.dto.MemberPayload;
-import com.ahmadda.presentation.dto.LoginMember;
 import com.ahmadda.presentation.exception.InvalidAuthorizationException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -2,6 +2,7 @@ package com.ahmadda.application;
 
 import com.ahmadda.application.dto.AnswerCreateRequest;
 import com.ahmadda.application.dto.EventParticipateRequest;
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Answer;
@@ -20,7 +21,6 @@ import com.ahmadda.domain.Period;
 import com.ahmadda.domain.Question;
 import com.ahmadda.domain.QuestionRepository;
 import com.ahmadda.domain.exception.BusinessRuleViolatedException;
-import com.ahmadda.presentation.dto.LoginMember;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -319,11 +319,11 @@ class EventGuestServiceTest {
     private Guest createAndSaveGuest(Event event, OrganizationMember member) {
         return guestRepository.save(Guest.create(event, member, event.getRegistrationStart()));
     }
-  
+
     private Question createAndSaveQuestion(Event event, String text, boolean required, int order) {
         return questionRepository.save(Question.create(event, text, required, order));
     }
-  
+
     private LoginMember createLoginMember(OrganizationMember organizationMember) {
         var member = organizationMember.getMember();
 

--- a/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.ahmadda.application;
 
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.NotificationRequest;
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
@@ -15,7 +16,6 @@ import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.domain.Period;
-import com.ahmadda.presentation.dto.LoginMember;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/server/src/test/java/com/ahmadda/application/MemberServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/MemberServiceTest.java
@@ -1,0 +1,55 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
+import com.ahmadda.presentation.dto.LoginMember;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService sut;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 자신의_회원_정보를_조회한다() {
+        // given
+        var member = memberRepository.save(Member.create("홍길동", "hong@gildong.com"));
+        var loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail());
+
+        // when
+        var result = sut.getMember(loginMember);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getId())
+                    .isEqualTo(member.getId());
+            softly.assertThat(result.getName())
+                    .isEqualTo(member.getName());
+            softly.assertThat(result.getEmail())
+                    .isEqualTo(member.getEmail());
+        });
+    }
+
+    @Test
+    void 존재하지_않는_회원이면_예외가_발생한다() {
+        // given
+        var loginMember = new LoginMember(999L, "이름", "email@none.com");
+
+        // when // then
+        assertThatThrownBy(() -> sut.getMember(loginMember))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 회원입니다.");
+    }
+}

--- a/server/src/test/java/com/ahmadda/application/MemberServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/MemberServiceTest.java
@@ -1,9 +1,9 @@
 package com.ahmadda.application;
 
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
-import com.ahmadda.presentation.dto.LoginMember;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/server/src/test/java/com/ahmadda/application/OrganizationMemberServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationMemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.ahmadda.application;
 
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
@@ -7,7 +8,6 @@ import com.ahmadda.domain.Organization;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
-import com.ahmadda.presentation.dto.LoginMember;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/server/src/test/java/com/ahmadda/application/OrganizationMemberServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationMemberServiceTest.java
@@ -1,0 +1,73 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
+import com.ahmadda.domain.Organization;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberRepository;
+import com.ahmadda.domain.OrganizationRepository;
+import com.ahmadda.presentation.dto.LoginMember;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class OrganizationMemberServiceTest {
+
+    @Autowired
+    private OrganizationMemberService sut;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private OrganizationMemberRepository organizationMemberRepository;
+
+    @Test
+    void 자신의_조직원_정보를_조회한다() {
+        // given
+        var member = memberRepository.save(Member.create("홍길동", "hong@email.com"));
+        var organization = organizationRepository.save(Organization.create("우테코", "설명", "img.png"));
+        var organizationMember = organizationMemberRepository.save(
+                OrganizationMember.create("닉네임", member, organization)
+        );
+        var loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail());
+
+        // when
+        var result = sut.getOrganizationMember(organization.getId(), loginMember);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getId())
+                    .isEqualTo(organizationMember.getId());
+            softly.assertThat(result.getMember()
+                            .getId())
+                    .isEqualTo(member.getId());
+            softly.assertThat(result.getOrganization()
+                            .getId())
+                    .isEqualTo(organization.getId());
+        });
+    }
+
+    @Test
+    void 존재하지_않는_조직원이면_예외가_발생한다() {
+        // given
+        var member = memberRepository.save(Member.create("홍길동", "hong@email.com"));
+        var organization = organizationRepository.save(Organization.create("우테코", "설명", "img.png"));
+        var loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail());
+
+        // when // then
+        assertThatThrownBy(() -> sut.getOrganizationMember(organization.getId(), loginMember))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 조직원입니다.");
+    }
+}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #119

## ✨ 작업 내용

- 자신의 회원 정보 조회 API 구현
- 자신의 조직원 정보 조회 API 구현

## 🙏 기타 참고 사항

이번 API는 기능적으로 매우 기본적인 역할만을 수행하며,
앞으로 요구사항이 크게 변경될 가능성은 낮다고 감히 감히 판단했습니다~!

따라서 기존처럼 객체 중심의 탐색 방식보다는,
보다 간결하고 명확한 쿼리 기반 처리 방식으로 구현했습니다 🙇‍♂️


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원 프로필 조회 및 반환을 위한 API 엔드포인트가 추가되었습니다.
  * 조직원 프로필 조회 및 반환을 위한 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 없음

* **테스트**
  * 회원 서비스 및 조직원 서비스에 대한 통합 테스트가 추가되어 정상 동작 및 예외 상황을 검증합니다.

* **기타**
  * 일부 DTO의 패키지 구조가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->