### PR TITLE
[BE] 이벤트 생성 시 주최자 이름을 입력받도록 API 수정

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -45,6 +45,7 @@ public class EventService {
                 organizer,
                 organization,
                 eventOperationPeriod,
+                eventCreateRequest.organizerNickname(),
                 eventCreateRequest.maxCapacity()
         );
         addQuestionsToEvent(event, eventCreateRequest.questions());

--- a/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
@@ -22,6 +22,8 @@ public record EventCreateRequest(
         LocalDateTime eventStart,
         @NotNull
         LocalDateTime eventEnd,
+        @NotBlank
+        String organizerNickname,
         int maxCapacity,
         @Valid
         List<QuestionCreateRequest> questions

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -56,7 +56,7 @@ public class Event extends BaseEntity {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "event")
     private List<Guest> guests = new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Question> questions = new ArrayList<>();
 
     @Embedded
@@ -76,7 +76,8 @@ public class Event extends BaseEntity {
             final Organization organization,
             final EventOperationPeriod eventOperationPeriod,
             final String organizerNickname,
-            final int maxCapacity
+            final int maxCapacity,
+            final List<Question> questions
     ) {
         validateTitle(title);
         validateDescription(description);
@@ -97,6 +98,7 @@ public class Event extends BaseEntity {
         this.maxCapacity = maxCapacity;
 
         organization.addEvent(this);
+        this.questions.addAll(questions);
     }
 
     public static Event create(
@@ -107,7 +109,8 @@ public class Event extends BaseEntity {
             final Organization organization,
             final EventOperationPeriod eventOperationPeriod,
             final String organizerNickname,
-            final int maxCapacity
+            final int maxCapacity,
+            final Question... questions
     ) {
         return new Event(
                 title,
@@ -117,7 +120,32 @@ public class Event extends BaseEntity {
                 organization,
                 eventOperationPeriod,
                 organizerNickname,
-                maxCapacity
+                maxCapacity,
+                new ArrayList<>(List.of(questions))
+        );
+    }
+
+    public static Event create(
+            final String title,
+            final String description,
+            final String place,
+            final OrganizationMember organizer,
+            final Organization organization,
+            final EventOperationPeriod eventOperationPeriod,
+            final String organizerNickname,
+            final int maxCapacity,
+            final List<Question> questions
+    ) {
+        return new Event(
+                title,
+                description,
+                place,
+                organizer,
+                organization,
+                eventOperationPeriod,
+                organizerNickname,
+                maxCapacity,
+                questions
         );
     }
 
@@ -156,10 +184,6 @@ public class Event extends BaseEntity {
                 .stream()
                 .filter(Question::isRequired)
                 .collect(Collectors.toSet());
-    }
-
-    public void addQuestions(final Question... question) {
-        questions.addAll(List.of(question));
     }
 
     public boolean isOrganizer(final Member member) {

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -63,6 +63,9 @@ public class Event extends BaseEntity {
     private EventOperationPeriod eventOperationPeriod;
 
     @Column(nullable = false)
+    private String organizerNickname;
+
+    @Column(nullable = false)
     private int maxCapacity;
 
     private Event(
@@ -72,6 +75,7 @@ public class Event extends BaseEntity {
             final OrganizationMember organizer,
             final Organization organization,
             final EventOperationPeriod eventOperationPeriod,
+            final String organizerNickname,
             final int maxCapacity
     ) {
         validateTitle(title);
@@ -80,6 +84,7 @@ public class Event extends BaseEntity {
         validateOrganizer(organizer);
         validateOrganization(organization);
         validateBelongToOrganization(organizer, organization);
+        validateOrganizerNickname(organizerNickname);
         validateMaxCapacity(maxCapacity);
 
         this.title = title;
@@ -88,6 +93,7 @@ public class Event extends BaseEntity {
         this.organizer = organizer;
         this.organization = organization;
         this.eventOperationPeriod = eventOperationPeriod;
+        this.organizerNickname = organizerNickname;
         this.maxCapacity = maxCapacity;
 
         organization.addEvent(this);
@@ -100,6 +106,7 @@ public class Event extends BaseEntity {
             final OrganizationMember organizer,
             final Organization organization,
             final EventOperationPeriod eventOperationPeriod,
+            final String organizerNickname,
             final int maxCapacity
     ) {
         return new Event(
@@ -109,6 +116,7 @@ public class Event extends BaseEntity {
                 organizer,
                 organization,
                 eventOperationPeriod,
+                organizerNickname,
                 maxCapacity
         );
     }
@@ -153,7 +161,7 @@ public class Event extends BaseEntity {
     public void addQuestions(final Question... question) {
         questions.addAll(List.of(question));
     }
-  
+
     public boolean isOrganizer(final Member member) {
         return organizer.getMember()
                 .equals(member);
@@ -198,6 +206,10 @@ public class Event extends BaseEntity {
         if (!organizer.isBelongTo(organization)) {
             throw new BusinessRuleViolatedException("자신이 속한 조직에서만 이벤트를 생성할 수 있습니다.");
         }
+    }
+
+    private void validateOrganizerNickname(String organizerNickname) {
+        Assert.notBlank(organizerNickname, "주최자 이름은 공백이면 안됩니다.");
     }
 
     private void validateMaxCapacity(final int maxCapacity) {

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -208,7 +208,7 @@ public class Event extends BaseEntity {
         }
     }
 
-    private void validateOrganizerNickname(String organizerNickname) {
+    private void validateOrganizerNickname(final String organizerNickname) {
         Assert.notBlank(organizerNickname, "주최자 이름은 공백이면 안됩니다.");
     }
 

--- a/server/src/main/java/com/ahmadda/domain/Question.java
+++ b/server/src/main/java/com/ahmadda/domain/Question.java
@@ -4,12 +4,9 @@ package com.ahmadda.domain;
 import com.ahmadda.domain.util.Assert;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,10 +21,6 @@ public class Question extends BaseEntity {
     @Column(name = "question_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id", nullable = false)
-    private Event event;
-
     @Column(nullable = false)
     private String questionText;
 
@@ -38,31 +31,23 @@ public class Question extends BaseEntity {
     private int orderIndex;
 
     private Question(
-            final Event event,
             final String questionText,
             final boolean isRequired,
             final int orderIndex
     ) {
-        validateEvent(event);
         validateQuestionText(questionText);
 
-        this.event = event;
         this.questionText = questionText;
         this.isRequired = isRequired;
         this.orderIndex = orderIndex;
     }
 
     public static Question create(
-            final Event event,
             final String questionText,
             final boolean isRequired,
             final int orderIndex
     ) {
-        return new Question(event, questionText, isRequired, orderIndex);
-    }
-
-    private void validateEvent(final Event event) {
-        Assert.notNull(event, "이벤트는 null이 되면 안됩니다.");
+        return new Question(questionText, isRequired, orderIndex);
     }
 
     private void validateQuestionText(final String questionText) {

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -4,10 +4,12 @@ package com.ahmadda.presentation;
 import com.ahmadda.application.EventService;
 import com.ahmadda.application.OrganizationService;
 import com.ahmadda.application.dto.EventCreateRequest;
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.domain.Event;
 import com.ahmadda.presentation.dto.EventCreateResponse;
 import com.ahmadda.presentation.dto.EventDetailResponse;
 import com.ahmadda.presentation.dto.EventResponse;
+import com.ahmadda.presentation.resolver.AuthMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -43,11 +45,10 @@ public class OrganizationEventController {
     @PostMapping("/{organizationId}/events")
     public ResponseEntity<EventCreateResponse> createOrganizationEvent(
             @PathVariable final Long organizationId,
-            @RequestBody @Valid final EventCreateRequest eventCreateRequest
+            @RequestBody @Valid final EventCreateRequest eventCreateRequest,
+            @AuthMember final LoginMember loginMember
     ) {
-        Long fakeOrganizerId = 1L;
-
-        Event event = eventService.createEvent(organizationId, fakeOrganizerId, eventCreateRequest);
+        Event event = eventService.createEvent(organizationId, loginMember.memberId(), eventCreateRequest);
 
         return ResponseEntity.created(URI.create("/api/organizations/" + organizationId + "/events/" + event.getId()))
                 .body(new EventCreateResponse(event.getId()));

--- a/server/src/main/java/com/ahmadda/presentation/dto/EventDetailResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/EventDetailResponse.java
@@ -44,8 +44,7 @@ public record EventDetailResponse(
                 event.getTitle(),
                 event.getDescription(),
                 event.getPlace(),
-                event.getOrganizer()
-                        .getNickname(),
+                event.getOrganizerNickname(),
                 event.getEventStart(),
                 event.getEventEnd(),
                 event.getRegistrationStart(),

--- a/server/src/main/java/com/ahmadda/presentation/dto/EventResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/EventResponse.java
@@ -31,8 +31,7 @@ public record EventResponse(
                 event.getPlace(),
                 event.getRegistrationStart(),
                 event.getRegistrationEnd(),
-                event.getOrganizer()
-                        .getNickname()
+                event.getOrganizerNickname()
         );
     }
 }

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -19,7 +19,6 @@ import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.domain.Period;
 import com.ahmadda.domain.Question;
-import com.ahmadda.domain.QuestionRepository;
 import com.ahmadda.domain.exception.BusinessRuleViolatedException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,9 +43,6 @@ class EventGuestServiceTest {
 
     @Autowired
     private MemberRepository memberRepository;
-
-    @Autowired
-    private QuestionRepository questionRepository;
 
     @Autowired
     private OrganizationRepository organizationRepository;
@@ -209,11 +205,11 @@ class EventGuestServiceTest {
         var member2 = createAndSaveMember("name2", "email2@ahmadda.com");
         var organizer = createAndSaveOrganizationMember("organizer", member1, organization);
         var participant = createAndSaveOrganizationMember("participant", member2, organization);
-        var event = createAndSaveEvent(organizer, organization);
 
-        var question1 = createAndSaveQuestion(event, "필수 질문", true, 0);
-        var question2 = createAndSaveQuestion(event, "선택 질문", false, 1);
-        event.addQuestions(question1, question2);
+        var question1 = Question.create("필수 질문", true, 0);
+        var question2 = Question.create("선택 질문", false, 1);
+        var event = createAndSaveEvent(organizer, organization, question1, question2);
+
 
         var request = new EventParticipateRequest(List.of(
                 new AnswerCreateRequest(question1.getId(), "답변1"),
@@ -243,11 +239,15 @@ class EventGuestServiceTest {
         var member2 = createAndSaveMember("name2", "email2@ahmadda.com");
         var organizer = createAndSaveOrganizationMember("organizer", member1, organization);
         var participant = createAndSaveOrganizationMember("participant", member2, organization);
-        var event = createAndSaveEvent(organizer, organization);
 
-        var question1 = createAndSaveQuestion(event, "필수 질문", true, 0);
-        var question2 = createAndSaveQuestion(event, "선택 질문", false, 1);
-        event.addQuestions(question1, question2);
+        Question question1 = Question.create("필수 질문", true, 0);
+        Question question2 = Question.create("선택 질문", false, 1);
+        var event = createAndSaveEvent(
+                organizer,
+                organization,
+                question1,
+                question2
+        );
 
         var request = new EventParticipateRequest(List.of(
                 new AnswerCreateRequest(question2.getId(), "선택 답변")
@@ -297,7 +297,7 @@ class EventGuestServiceTest {
         return organizationMemberRepository.save(OrganizationMember.create(nickname, member, org));
     }
 
-    private Event createAndSaveEvent(OrganizationMember organizer, Organization organization) {
+    private Event createAndSaveEvent(OrganizationMember organizer, Organization organization, Question... questions) {
         var now = LocalDateTime.now();
         var event = Event.create(
                 "이벤트",
@@ -311,7 +311,8 @@ class EventGuestServiceTest {
                         now.minusDays(6)
                 ),
                 organizer.getNickname(),
-                100
+                100,
+                questions
         );
 
         return eventRepository.save(event);
@@ -319,10 +320,6 @@ class EventGuestServiceTest {
 
     private Guest createAndSaveGuest(Event event, OrganizationMember member) {
         return guestRepository.save(Guest.create(event, member, event.getRegistrationStart()));
-    }
-
-    private Question createAndSaveQuestion(Event event, String text, boolean required, int order) {
-        return questionRepository.save(Question.create(event, text, required, order));
     }
 
     private LoginMember createLoginMember(OrganizationMember organizationMember) {

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -310,6 +310,7 @@ class EventGuestServiceTest {
                         Period.create(now.plusDays(1), now.plusDays(2)),
                         now.minusDays(6)
                 ),
+                organizer.getNickname(),
                 100
         );
 

--- a/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
@@ -79,6 +79,7 @@ class EventNotificationServiceTest {
                         Period.create(now.plusDays(1), now.plusDays(2)),
                         now.minusDays(3)
                 ),
+                organizerNickname,
                 100
         ));
 
@@ -153,6 +154,7 @@ class EventNotificationServiceTest {
                         Period.create(now.plusDays(2), now.plusDays(3)),
                         now.minusDays(2)
                 ),
+                organizer.getNickname(),
                 100
         ));
 

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -2,6 +2,7 @@ package com.ahmadda.application;
 
 import com.ahmadda.application.dto.EventCreateRequest;
 import com.ahmadda.application.dto.QuestionCreateRequest;
+import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.EventOperationPeriod;
 import com.ahmadda.domain.EventRepository;
@@ -141,7 +142,33 @@ class EventServiceTest {
         //when //then
         assertThatThrownBy(() -> sut.createEvent(organization.getId(), 999L, eventCreateRequest))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않은 조직원 정보입니다.");
+                .hasMessage("존재하지 않는 회원입니다.");
+    }
+
+    @Test
+    void 이벤트_생성시_요청한_조직에_소속되지_않았다면_예외가_발생한다() {
+        //given
+        var organization1 = appendOrganization();
+        var organization2 = appendOrganization();
+        Member member = appendMember();
+        appendOrganizationMember(organization2, member);
+
+        var now = LocalDateTime.now();
+        var eventCreateRequest = new EventCreateRequest(
+                "UI/UX 이벤트",
+                "UI/UX 이벤트 입니다",
+                "선릉",
+                now.plusDays(3), now.plusDays(4),
+                now.plusDays(5), now.plusDays(6),
+                "이밴트 근로",
+                100,
+                new ArrayList<>()
+        );
+
+        //when //then
+        assertThatThrownBy(() -> sut.createEvent(organization1.getId(), member.getId(), eventCreateRequest))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("조직에 소속되지 않은 멤버입니다.");
     }
 
     private Organization appendOrganization() {

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -60,6 +60,7 @@ class EventServiceTest {
                 "선릉",
                 now.plusDays(3), now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
+                "이벤트 근로",
                 100,
                 List.of(new QuestionCreateRequest("1번 질문", true), new QuestionCreateRequest("2번 질문", false))
         );
@@ -109,6 +110,7 @@ class EventServiceTest {
                 "선릉",
                 now.plusDays(3), now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
+                "이벤트 근로",
                 100,
                 List.of(new QuestionCreateRequest("1번 질문", true), new QuestionCreateRequest("2번 질문", false))
         );
@@ -131,6 +133,7 @@ class EventServiceTest {
                 "선릉",
                 now.plusDays(3), now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
+                "이밴트 근로",
                 100,
                 new ArrayList<>()
         );

--- a/server/src/test/java/com/ahmadda/application/OrganizationMemberEventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationMemberEventServiceTest.java
@@ -256,6 +256,7 @@ class OrganizationMemberEventServiceTest {
                         LocalDateTime.now()
                                 .minusDays(20)
                 ),
+                organizer.getNickname(),
                 maxCapacity
         );
         return eventRepository.save(event);

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -148,6 +148,7 @@ class OrganizationServiceTest {
                         Period.create(end.plusHours(1), end.plusHours(2)),
                         start.minusDays(1)
                 ),
+                organizer.getNickname(),
                 100
         );
     }

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -183,13 +183,11 @@ class EventTest {
     @Test
     void 이벤트에_질문이_포함되어있는지_확인할_수_있다() {
         // given
-        var sut = createEvent("이벤트", 10);
-        var question = Question.create(sut, "필수 질문", true, 0);
-        sut.addQuestions(question);
+        var question = Question.create("필수 질문", true, 0);
+        var sut = createEvent("이벤트", 10, question);
 
-        var otherEvent = createEvent("이벤트2", 10);
-        var notIncludedQuestion = Question.create(otherEvent, "없는 질문", true, 1);
-        otherEvent.addQuestions(notIncludedQuestion);
+        var notIncludedQuestion = Question.create("없는 질문", true, 1);
+        var otherEvent = createEvent("이벤트2", 10, notIncludedQuestion);
 
         // when
         var actual1 = sut.hasQuestion(question);
@@ -204,6 +202,7 @@ class EventTest {
         });
     }
 
+    @Test
     void 이벤트의_주최자인지_판단한다() {
         // given
         var now = LocalDateTime.now();
@@ -232,10 +231,9 @@ class EventTest {
     @Test
     void 필수_질문만_조회할_수_있다() {
         // given
-        var sut = createEvent("이벤트", 10);
-        var requiredQuestion = Question.create(sut, "필수 질문", true, 0);
-        var optionalQuestion = Question.create(sut, "선택 질문", false, 1);
-        sut.addQuestions(requiredQuestion, optionalQuestion);
+        var requiredQuestion = Question.create("필수 질문", true, 0);
+        var optionalQuestion = Question.create("선택 질문", false, 1);
+        var sut = createEvent("이벤트", 10, requiredQuestion, optionalQuestion);
 
         // when
         var result = sut.getRequiredQuestions();
@@ -249,7 +247,7 @@ class EventTest {
         });
     }
 
-    private Event createEvent(final String title, final int maxCapacity) {
+    private Event createEvent(final String title, final int maxCapacity, Question... questions) {
         var organization = createOrganization("우테코");
 
         return Event.create(
@@ -274,7 +272,8 @@ class EventTest {
                         LocalDateTime.now()
                 ),
                 "이벤트 근로",
-                maxCapacity
+                maxCapacity,
+                questions
         );
     }
 

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -203,7 +203,7 @@ class EventTest {
                     .isFalse();
         });
     }
-  
+
     void 이벤트의_주최자인지_판단한다() {
         // given
         var now = LocalDateTime.now();
@@ -273,6 +273,7 @@ class EventTest {
                         ),
                         LocalDateTime.now()
                 ),
+                "이벤트 근로",
                 maxCapacity
         );
     }
@@ -289,6 +290,7 @@ class EventTest {
                         Period.create(now.plusDays(3), now.plusDays(4)),
                         now
                 ),
+                "이벤트 근로",
                 10
         );
     }
@@ -319,6 +321,7 @@ class EventTest {
                 createOrganizationMember(createMember(), organization),
                 organization,
                 eventOperationPeriod,
+                "이벤트 근로",
                 100
         );
     }
@@ -349,6 +352,7 @@ class EventTest {
                         Period.create(now.plusDays(3), now.plusDays(4)),
                         now
                 ),
+                "이벤트 근로",
                 10
         );
     }

--- a/server/src/test/java/com/ahmadda/domain/GuestTest.java
+++ b/server/src/test/java/com/ahmadda/domain/GuestTest.java
@@ -167,11 +167,10 @@ class GuestTest {
     void 필수_질문에_대한_답변이_모두_있다면_정상적으로_답변이_등록된다() {
         // given
         var now = LocalDateTime.now();
-        var event = createEvent("이벤트", participant, now);
 
-        var question1 = Question.create(event, "필수 질문1", true, 0);
-        var question2 = Question.create(event, "선택 질문2", false, 1);
-        event.addQuestions(question1, question2);
+        var question1 = Question.create("필수 질문1", true, 0);
+        var question2 = Question.create("선택 질문2", false, 1);
+        var event = createEvent("이벤트", participant, now, question1, question2);
 
         var guest = Guest.create(event, otherParticipant, now);
 
@@ -194,11 +193,10 @@ class GuestTest {
     void 필수_질문에_대한_답변이_누락되면_예외가_발생한다() {
         // given
         var now = LocalDateTime.now();
-        var event = createEvent("이벤트", participant, now);
 
-        var question1 = Question.create(event, "필수 질문1", true, 0);
-        var question2 = Question.create(event, "선택 질문2", false, 1);
-        event.addQuestions(question1, question2);
+        var question1 = Question.create("필수 질문1", true, 0);
+        var question2 = Question.create("선택 질문2", false, 1);
+        var event = createEvent("이벤트", participant, now, question1, question2);
 
         var guest = Guest.create(event, otherParticipant, now);
 
@@ -220,8 +218,8 @@ class GuestTest {
         var event = createEvent("이벤트", participant, now);
         var guest = Guest.create(event, otherParticipant, now);
 
-        var otherEvent = createEvent("다른 이벤트", participant, now);
-        var externalQuestion = Question.create(otherEvent, "외부 질문", true, 0);
+        var externalQuestion = Question.create("외부 질문", true, 0);
+        var otherEvent = createEvent("다른 이벤트", participant, now, externalQuestion);
 
         var answers = Map.of(
                 externalQuestion, "외부 답변"
@@ -236,7 +234,8 @@ class GuestTest {
     private Event createEvent(
             String title,
             OrganizationMember organizer,
-            LocalDateTime now
+            LocalDateTime now,
+            Question... questions
     ) {
         return Event.create(
                 title, "설명", "장소", organizer,
@@ -247,7 +246,8 @@ class GuestTest {
                         now
                 ),
                 organizer.getNickname(),
-                10
+                10,
+                questions
         );
     }
 }

--- a/server/src/test/java/com/ahmadda/domain/GuestTest.java
+++ b/server/src/test/java/com/ahmadda/domain/GuestTest.java
@@ -30,6 +30,7 @@ class GuestTest {
                         Period.create(now.plusDays(10), now.plusDays(11)),
                         now
                 ),
+                organizer.getNickname(),
                 50
         );
         member = Member.create("참가자 멤버", "guest@example.com");
@@ -89,6 +90,7 @@ class GuestTest {
                         Period.create(now.plusDays(10), now.plusDays(11)),
                         now
                 ),
+                organizationMember1.getNickname(),
                 50
         );
 
@@ -112,6 +114,7 @@ class GuestTest {
                         Period.create(now.plusDays(10), now.plusDays(11)),
                         now
                 ),
+                organizationMember.getNickname(),
                 50
         );
 
@@ -137,6 +140,7 @@ class GuestTest {
                         Period.create(now.plusDays(10), now.plusDays(11)),
                         now
                 ),
+                organizationMember1.getNickname(),
                 1
         );
         Guest.create(event, organizationMember2, event.getRegistrationStart());
@@ -242,6 +246,7 @@ class GuestTest {
                         Period.create(now.plusDays(2), now.plusDays(3)),
                         now
                 ),
+                organizer.getNickname(),
                 10
         );
     }

--- a/server/src/test/java/com/ahmadda/domain/OrganizationMemberTest.java
+++ b/server/src/test/java/com/ahmadda/domain/OrganizationMemberTest.java
@@ -52,6 +52,7 @@ class OrganizationMemberTest {
                         Period.create(now.plusDays(10), now.plusDays(11)),
                         now
                 ),
+                "이벤트 근로",
                 50
         );
     }

--- a/server/src/test/java/com/ahmadda/domain/OrganizationTest.java
+++ b/server/src/test/java/com/ahmadda/domain/OrganizationTest.java
@@ -49,6 +49,7 @@ class OrganizationTest {
                         Period.create(start, end),
                         start.minusDays(6)
                 ),
+                organizer.getNickname(),
                 50
         );
     }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #123 

## ✨ 작업 내용

이벤트 생성시에 주최자 이름을 필수록 받도록 수정했습니다! 
수정하는 과정에서 이벤트 엔티티에 주최자닉네임 필드를 가지게 변경했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 생성 시 주최자 닉네임을 필수 입력값으로 추가하였습니다.
  * 이벤트 상세 및 목록 조회 시 주최자 닉네임이 직접적으로 표시됩니다.

* **버그 수정**
  * 테스트 코드에서 이벤트 생성 시 주최자 닉네임이 누락되지 않도록 일관성 있게 반영하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->