### PR TITLE
[BE] 우아한코스 조직 제공하도록 임시 api들 구현 

### DIFF
--- a/server/src/main/java/com/ahmadda/application/LoginService.java
+++ b/server/src/main/java/com/ahmadda/application/LoginService.java
@@ -49,11 +49,11 @@ public class LoginService {
     //TODO 07.25 이후 리팩터링 및 제거하기
     public void addMemberToWoowacourse(final Member member) {
         Optional<Organization> findOrganization =
-                organizationRepository.findByName("우아한테크코스");
+                organizationRepository.findByName(OrganizationService.WOOWACOURSE_NAME);
 
         Organization organization =
                 findOrganization.orElseGet(() -> organizationRepository.save(
-                        Organization.create("우아한테크코스",
+                        Organization.create(OrganizationService.WOOWACOURSE_NAME,
                                             "우아한테크코스입니당딩동",
                                             "imageUrl"
                         )

--- a/server/src/main/java/com/ahmadda/application/LoginService.java
+++ b/server/src/main/java/com/ahmadda/application/LoginService.java
@@ -54,15 +54,13 @@ public class LoginService {
         Organization organization =
                 findOrganization.orElseGet(() -> organizationRepository.save(
                         Organization.create(OrganizationService.WOOWACOURSE_NAME,
-                                            "우아한테크코스입니당딩동",
+                                            "우아한테크코스입니다",
                                             "imageUrl"
                         )
                 ));
 
-        Optional<OrganizationMember> existOrganizationMember = organization.getOrganizationMembers()
-                .stream()
-                .filter((findOrganizationMember) -> findOrganizationMember.getMember().isSameMember(member.getId()))
-                .findAny();
+        Optional<OrganizationMember> existOrganizationMember =
+                organizationMemberRepository.findByOrganizationIdAndMemberId(organization.getId(), member.getId());
 
         if (existOrganizationMember.isEmpty()) {
             OrganizationMember organizationMember = OrganizationMember.create(member.getName(), member, organization);

--- a/server/src/main/java/com/ahmadda/application/LoginService.java
+++ b/server/src/main/java/com/ahmadda/application/LoginService.java
@@ -19,6 +19,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class LoginService {
 
+    private static final String imageUrl = "techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/ah-madda/woowa.png";
+    
     private final MemberRepository memberRepository;
     private final GoogleOAuthProvider googleOAuthProvider;
     private final JwtTokenProvider jwtTokenProvider;
@@ -55,7 +57,7 @@ public class LoginService {
                 findOrganization.orElseGet(() -> organizationRepository.save(
                         Organization.create(OrganizationService.WOOWACOURSE_NAME,
                                             "우아한테크코스입니다",
-                                            "imageUrl"
+                                            imageUrl
                         )
                 ));
 

--- a/server/src/main/java/com/ahmadda/application/LoginService.java
+++ b/server/src/main/java/com/ahmadda/application/LoginService.java
@@ -2,12 +2,18 @@ package com.ahmadda.application;
 
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
+import com.ahmadda.domain.Organization;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberRepository;
+import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.infra.jwt.JwtTokenProvider;
 import com.ahmadda.infra.oauth.GoogleOAuthProvider;
 import com.ahmadda.infra.oauth.dto.OAuthUserInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,13 +22,16 @@ public class LoginService {
     private final MemberRepository memberRepository;
     private final GoogleOAuthProvider googleOAuthProvider;
     private final JwtTokenProvider jwtTokenProvider;
+    //TODO 07.25이후 사용하지않으면 삭제
+    private final OrganizationRepository organizationRepository;
+    private final OrganizationMemberRepository organizationMemberRepository;
 
     @Transactional
     public String login(final String code) {
         OAuthUserInfoResponse userInfo = googleOAuthProvider.getUserInfo(code);
 
         Member member = findOrCreateMember(userInfo.name(), userInfo.email());
-
+        addMemberToWoowacourse(member);
         return jwtTokenProvider.createToken(member);
     }
 
@@ -33,5 +42,31 @@ public class LoginService {
 
                     return memberRepository.save(newMember);
                 });
+    }
+
+    @Deprecated
+    @Transactional
+    //TODO 07.25 이후 리팩터링 및 제거하기
+    public void addMemberToWoowacourse(final Member member) {
+        Optional<Organization> findOrganization =
+                organizationRepository.findByName("우아한테크코스");
+
+        Organization organization =
+                findOrganization.orElseGet(() -> organizationRepository.save(
+                        Organization.create("우아한테크코스",
+                                            "우아한테크코스입니당딩동",
+                                            "imageUrl"
+                        )
+                ));
+
+        Optional<OrganizationMember> existOrganizationMember = organization.getOrganizationMembers()
+                .stream()
+                .filter((findOrganizationMember) -> findOrganizationMember.getMember().isSameMember(member.getId()))
+                .findAny();
+
+        if (existOrganizationMember.isEmpty()) {
+            OrganizationMember organizationMember = OrganizationMember.create(member.getName(), member, organization);
+            OrganizationMember savedOrganizationMember = organizationMemberRepository.save(organizationMember);
+        }
     }
 }

--- a/server/src/main/java/com/ahmadda/application/OrganizationService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationService.java
@@ -10,10 +10,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class OrganizationService {
+
+    private static final Organization woowacourse = Organization.create("우아한테크코스", "우아한테크코스입니당딩동", "imageUrl");
 
     private final OrganizationRepository organizationRepository;
 
@@ -37,5 +40,14 @@ public class OrganizationService {
         Organization organization = getOrganization(organizationId);
 
         return organization.getActiveEvents();
+    }
+
+    //TODO 07.25 이후 리팩터링 및 제거하기
+    @Transactional
+    @Deprecated
+    public Organization alwaysGetWoowacourse() {
+        Optional<Organization> organization = organizationRepository.findByName(woowacourse.getName());
+
+        return organization.orElseGet(() -> organizationRepository.save(woowacourse));
     }
 }

--- a/server/src/main/java/com/ahmadda/application/OrganizationService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationService.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class OrganizationService {
 
-    private static final Organization woowacourse = Organization.create("우아한테크코스", "우아한테크코스입니당딩동", "imageUrl");
+    public static final String WOOWACOURSE_NAME = "우아한테크코스";
 
     private final OrganizationRepository organizationRepository;
 
@@ -46,8 +46,11 @@ public class OrganizationService {
     @Transactional
     @Deprecated
     public Organization alwaysGetWoowacourse() {
-        Optional<Organization> organization = organizationRepository.findByName(woowacourse.getName());
+        Optional<Organization> organization = organizationRepository.findByName(WOOWACOURSE_NAME);
 
-        return organization.orElseGet(() -> organizationRepository.save(woowacourse));
+        return organization.orElseGet(() -> organizationRepository.save(Organization.create(WOOWACOURSE_NAME,
+                                                                                            "우아한테크코스입니다",
+                                                                                            "imageUrl"
+        )));
     }
 }

--- a/server/src/main/java/com/ahmadda/application/OrganizationService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationService.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 public class OrganizationService {
 
     public static final String WOOWACOURSE_NAME = "우아한테크코스";
+    private static final String imageUrl = "techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/ah-madda/woowa.png";
 
     private final OrganizationRepository organizationRepository;
 
@@ -50,7 +51,7 @@ public class OrganizationService {
 
         return organization.orElseGet(() -> organizationRepository.save(Organization.create(WOOWACOURSE_NAME,
                                                                                             "우아한테크코스입니다",
-                                                                                            "imageUrl"
+                                                                                            imageUrl
         )));
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
@@ -5,8 +5,6 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-import java.util.Optional;
-
 public interface OrganizationMemberRepository extends JpaRepository<OrganizationMember, Long> {
 
     @Query("""

--- a/server/src/main/java/com/ahmadda/domain/OrganizationRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationRepository.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 
 public interface OrganizationRepository extends JpaRepository<Organization, Long> {
 
-    Optional<Organization> findByName(String name);
+    Optional<Organization> findByName(final String name);
 }

--- a/server/src/main/java/com/ahmadda/domain/OrganizationRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationRepository.java
@@ -2,6 +2,9 @@ package com.ahmadda.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OrganizationRepository extends JpaRepository<Organization, Long> {
 
+    Optional<Organization> findByName(String name);
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -41,4 +41,14 @@ public class OrganizationController {
 
         return ResponseEntity.ok(organizationResponse);
     }
+
+    //TODO 07.25 이후 리팩터링 및 제거하기
+    @Deprecated
+    @GetMapping("/woowacourse")
+    public ResponseEntity<OrganizationResponse> getOrganization() {
+        Organization organization = organizationService.alwaysGetWoowacourse();
+        OrganizationResponse organizationResponse = OrganizationResponse.from(organization);
+
+        return ResponseEntity.ok(organizationResponse);
+    }
 }

--- a/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -103,10 +104,12 @@ class LoginServiceTest {
                 organizationMemberRepository.findByOrganizationIdAndMemberId(foundOrganization.getId(), member.getId())
                         .orElseThrow();
 
-        assertThat(foundOrganizationMember).isNotNull();
-        assertThat(foundOrganizationMember.getMember()).isEqualTo(member);
-        assertThat(foundOrganizationMember.getOrganization()).isEqualTo(foundOrganization);
-        assertThat(foundOrganization.getOrganizationMembers()).contains(foundOrganizationMember);
+        assertSoftly(softly -> {
+            softly.assertThat(foundOrganizationMember).isNotNull();
+            softly.assertThat(foundOrganizationMember.getMember()).isEqualTo(member);
+            softly.assertThat(foundOrganizationMember.getOrganization()).isEqualTo(foundOrganization);
+            softly.assertThat(foundOrganization.getOrganizationMembers()).contains(foundOrganizationMember);
+        });
     }
 
     @Test

--- a/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
@@ -100,7 +100,8 @@ class LoginServiceTest {
         // then
         var foundOrganization = organizationRepository.findByName(OrganizationService.WOOWACOURSE_NAME).orElseThrow();
         var foundOrganizationMember =
-                organizationMemberRepository.findByMemberAndOrganization(member, foundOrganization).orElseThrow();
+                organizationMemberRepository.findByOrganizationIdAndMemberId(foundOrganization.getId(), member.getId())
+                        .orElseThrow();
 
         assertThat(foundOrganizationMember).isNotNull();
         assertThat(foundOrganizationMember.getMember()).isEqualTo(member);

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -125,6 +125,27 @@ class OrganizationServiceTest {
                 .containsExactlyInAnyOrder("EventA1", "EventA2");
     }
 
+    @Test
+    void DEPRECATED_항상_우아한코스_조직을_반환한다() {
+        // when
+        var woowacourse = sut.alwaysGetWoowacourse();
+
+        // then
+        assertThat(woowacourse.getName()).isEqualTo("우아한테크코스");
+    }
+
+    @Test
+    void DEPRECATED_여러번_요청해도_항상_우아한코스_조직을_반환한다() {
+        //given
+        Organization woowacourse = Organization.create("우아한테크코스", "우아한테크코스입니당딩동", "imageUrl");
+        organizationRepository.save(woowacourse);
+        // when
+        var getWoowacourse = sut.alwaysGetWoowacourse();
+
+        // then
+        assertThat(getWoowacourse.getName()).isEqualTo("우아한테크코스");
+    }
+
     private Organization createOrganization(String name, String description, String imageUrl) {
         return Organization.create(name, description, imageUrl);
     }
@@ -158,26 +179,5 @@ class OrganizationServiceTest {
             String imageUrl
     ) {
         return new OrganizationCreateRequest(name, description, imageUrl);
-    }
-
-    @Test
-    void DEPRECATED_항상_우아한코스_조직을_반환한다() {
-        // when
-        var woowacourse = sut.alwaysGetWoowacourse();
-
-        // then
-        assertThat(woowacourse.getName()).isEqualTo("우아한테크코스");
-    }
-
-    @Test
-    void DEPRECATED_여러번_요청해도_항상_우아한코스_조직을_반환한다() {
-        //given
-        Organization woowacourse = Organization.create("우아한테크코스", "우아한테크코스입니당딩동", "imageUrl");
-        organizationRepository.save(woowacourse);
-        // when
-        var getWoowacourse = sut.alwaysGetWoowacourse();
-
-        // then
-        assertThat(getWoowacourse.getName()).isEqualTo("우아한테크코스");
     }
 }

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -131,19 +131,20 @@ class OrganizationServiceTest {
         var woowacourse = sut.alwaysGetWoowacourse();
 
         // then
-        assertThat(woowacourse.getName()).isEqualTo("우아한테크코스");
+        assertThat(woowacourse.getName()).isEqualTo(OrganizationService.WOOWACOURSE_NAME);
     }
 
     @Test
     void DEPRECATED_여러번_요청해도_항상_우아한코스_조직을_반환한다() {
         //given
-        Organization woowacourse = Organization.create("우아한테크코스", "우아한테크코스입니당딩동", "imageUrl");
+        Organization woowacourse =
+                Organization.create(OrganizationService.WOOWACOURSE_NAME, "우아한테크코스입니당딩동", "imageUrl");
         organizationRepository.save(woowacourse);
         // when
         var getWoowacourse = sut.alwaysGetWoowacourse();
 
         // then
-        assertThat(getWoowacourse.getName()).isEqualTo("우아한테크코스");
+        assertThat(getWoowacourse.getName()).isEqualTo(OrganizationService.WOOWACOURSE_NAME);
     }
 
     private Organization createOrganization(String name, String description, String imageUrl) {

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -159,4 +159,25 @@ class OrganizationServiceTest {
     ) {
         return new OrganizationCreateRequest(name, description, imageUrl);
     }
+
+    @Test
+    void DEPRECATED_항상_우아한코스_조직을_반환한다() {
+        // when
+        var woowacourse = sut.alwaysGetWoowacourse();
+
+        // then
+        assertThat(woowacourse.getName()).isEqualTo("우아한테크코스");
+    }
+
+    @Test
+    void DEPRECATED_여러번_요청해도_항상_우아한코스_조직을_반환한다() {
+        //given
+        Organization woowacourse = Organization.create("우아한테크코스", "우아한테크코스입니당딩동", "imageUrl");
+        organizationRepository.save(woowacourse);
+        // when
+        var getWoowacourse = sut.alwaysGetWoowacourse();
+
+        // then
+        assertThat(getWoowacourse.getName()).isEqualTo("우아한테크코스");
+    }
 }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #120

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
- /api/organizations/woowacourse 추가
  - 항상 우아한테크코스 조직을 반환하는 api 입니다
- 로그인시에 우아한테크코스 조직에 가입이 안되어있으면 가입되도록 구현

## 🙏 기타 참고 사항
임시 api를 구현하던 중 LoginService와 OrganizationService를 수정하였습니다
- 데모데이이후 임시 기능 삭제 및 리팩토링 요함 
<!-- 없다면 적지 않으셔도 됩니다. -->
