### PR TITLE
[FE] 프론트엔드 ci/cd 환경 설정

### DIFF
--- a/.github/workflows/fe-cicd-closed-prs.yml
+++ b/.github/workflows/fe-cicd-closed-prs.yml
@@ -1,4 +1,4 @@
-name: Ah-Madda-FE
+name: AhMadda FE CI/Cd
 
 on:
   push:

--- a/.github/workflows/fe-cicd-closed-prs.yml
+++ b/.github/workflows/fe-cicd-closed-prs.yml
@@ -1,0 +1,52 @@
+name: Ah-Madda-FE
+
+on:
+  push:
+    branches:
+      - fe/dev
+
+defaults:
+  run:
+    working-directory: ./client
+
+jobs:
+  build:
+    name: react build & deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: .env setting
+        run: |
+          echo "API_BASE_URL=${{ secrets.API_BASE_URL }}" >> .env
+          echo "GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/pnpm-setup-node
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run build
+        run: pnpm run build
+
+      - name: Run unit tests
+        run: pnpm run test
+
+      - name: Run type check
+        run: pnpm run type-check
+
+      - name: Upload to S3
+        run: |
+          aws s3 sync dist/ s3://${{ secrets.AWS_BUCKET_NAME}} --delete
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"
+        continue-on-error: true

--- a/.github/workflows/fe-cicd-closed-prs.yml
+++ b/.github/workflows/fe-cicd-closed-prs.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run build
-        run: pnpm run build
-
       - name: Run unit tests
         run: pnpm run test
 
       - name: Run type check
         run: pnpm run type-check
+
+      - name: Run build
+        run: pnpm run build
 
       - name: Upload to S3
         run: |

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "test": "vitest",
     "start": "NODE_ENV=development webpack serve --mode development",
     "build": "NODE_ENV=development webpack --mode development",
+    "type-check": "tsc --noEmit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "chromatic": "dotenv -- chromatic --project-token ${CHROMATIC_PROJECT_TOKEN}",

--- a/client/src/__test__/testing.test.tsx
+++ b/client/src/__test__/testing.test.tsx
@@ -1,10 +1,19 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
-import { App } from '@/App';
+import { HomePage } from '@/features/Home/page/HomePage';
 
 describe('RTL Test', () => {
   it('should render', () => {
-    render(<App />);
-    expect(screen.getByText('React + TypeScript + Webpack')).toBeInTheDocument();
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+    screen.debug();
+
+    expect(
+      screen.getByText('슬랙이나 메신저에서 참여하고 싶었던 이벤트를 놓친 경험 있으신가요?')
+    ).toBeInTheDocument();
   });
 });

--- a/client/src/features/Event/Detail/components/DescriptionCard.tsx
+++ b/client/src/features/Event/Detail/components/DescriptionCard.tsx
@@ -1,7 +1,7 @@
 import { Card } from '../../../../shared/components/Card';
 import { Flex } from '../../../../shared/components/Flex';
 import { Text } from '../../../../shared/components/Text';
-import type { EventDetail } from '../types/index';
+import { EventDetail } from '../../types/Event';
 
 type DescriptionCardProps = Pick<EventDetail, 'description'>;
 

--- a/client/src/features/Event/Overview/components/EventCard.tsx
+++ b/client/src/features/Event/Overview/components/EventCard.tsx
@@ -68,7 +68,7 @@ export const EventCard = ({
             {`${currentGuestCount}/${maxCapacity} 명`}
           </Text>
         </Flex>
-        <ProgressBar value={currentGuestCount} max={maxCapacity} color="black" />
+        <ProgressBar value={Number(currentGuestCount)} max={maxCapacity} color="black" />
       </Flex>
     </CardWrapper>
   );


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #79

## ✨ 작업 내용

- 임시로, fe/dev에 머지될 때 ci/cd가 돌도록 설정했습니다. 
- 임시로 test 구현해놨습니다.

### fe-cicd.yml 설명
1. 코드 체크아웃
```
- name: Checkout code
  uses: actions/checkout@v4
  with:
    fetch-depth: 0
```
2. 환경변수 설정 (.env 파일 생성)
```
- name: .env setting
  run: |
    echo "API_BASE_URL=${{ secrets.API_BASE_URL }}" >> .env
    echo "GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env
```
3. Node.js와 pnpm 설치
```
- name: Setup Node.js and pnpm
    uses: ./.github/actions/pnpm-setup-node
```
4. 의존성 설치 (pnpm install)
```
- name: Install dependencies
   run: pnpm install --frozen-lockfile
```
5. 테스트 실행 (pnpm run test)
```
- name: Run unit tests
  run: pnpm run test
```
6. 타입 체크 (pnpm run type-check)
```
- name: Run type check
  run: pnpm run type-check
```
7. 빌드 (pnpm run build)
```
- name: Run build
   run: pnpm run build
```
8. S3에 빌드 파일 업로드
```
- name: Upload to S3
  run: |
    aws s3 sync dist/ s3://${{ secrets.AWS_BUCKET_NAME }} --delete
```
9. CloudFront 캐시 무효화
```
- name: Invalidate CloudFront
  run: |
    aws cloudfront create-invalidation \
      --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
      --paths "/*"
        continue-on-error: true
```

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->


