### PR TITLE
[FE] 이벤트 전체 조회 날짜 가까운순 정렬

### DIFF
--- a/client/src/features/Event/Overview/components/EventList.tsx
+++ b/client/src/features/Event/Overview/components/EventList.tsx
@@ -36,18 +36,15 @@ export const EventList = ({ events }: EventListProps) => {
             + 이벤트 생성
           </Button>
         </Flex>
-        {Object.entries(groupedEvents).map(
-          ([dateTitle, events]) =>
-            events.length > 0 && (
-              <EventSection key={dateTitle} title={dateTitle}>
-                <EventGrid>
-                  {events.map((event, index) => (
-                    <EventCard key={index} {...event} />
-                  ))}
-                </EventGrid>
-              </EventSection>
-            )
-        )}
+        {groupedEvents.map(({ label, events }) => (
+          <EventSection key={label} title={label}>
+            <EventGrid>
+              {events.map((event, index) => (
+                <EventCard key={index} {...event} />
+              ))}
+            </EventGrid>
+          </EventSection>
+        ))}
       </Flex>
     </EventContainer>
   );

--- a/client/src/features/Event/Overview/utils/groupEventsByDate.ts
+++ b/client/src/features/Event/Overview/utils/groupEventsByDate.ts
@@ -1,38 +1,47 @@
 import { Event } from '../../types/Event';
 
+type GroupEvent = {
+  label: string;
+  date: string;
+  events: Event[];
+};
+
+// S.TODO : 추후 날짜, sort 관련 로직을 utils로 분리
 export const groupEventsByDate = (events: Event[]) => {
   const today = new Date();
   const tomorrow = new Date(today);
   tomorrow.setDate(tomorrow.getDate() + 1);
 
-  const groups: Record<string, Event[]> = {
-    오늘: [],
-    내일: [],
-  };
+  const groups = new Map<string, GroupEvent>();
 
   events.forEach((event) => {
     const eventDate = new Date(event.registrationEnd);
+    const label = getLabel(eventDate, today, tomorrow);
+    const key = eventDate.toDateString();
 
-    if (eventDate.toDateString() === today.toDateString()) {
-      groups['오늘'].push(event);
-      return;
-    }
-    if (eventDate.toDateString() === tomorrow.toDateString()) {
-      groups['내일'].push(event);
-      return;
-    }
-
-    const dateKey = eventDate.toLocaleDateString('ko-KR', {
-      month: 'long',
-      day: 'numeric',
-    });
-
-    if (!groups[dateKey]) {
-      groups[dateKey] = [];
+    if (!groups.has(key)) {
+      groups.set(key, {
+        label,
+        date: key,
+        events: [],
+      });
     }
 
-    groups[dateKey].push(event);
+    groups.get(key)!.events.push(event);
   });
 
-  return groups;
+  return [...groups.values()].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+  );
+};
+
+const getLabel = (eventDate: Date, today: Date, tomorrow: Date): string => {
+  if (eventDate.toDateString() === today.toDateString()) {
+    return '오늘';
+  }
+  if (eventDate.toDateString() === tomorrow.toDateString()) {
+    return '내일';
+  }
+
+  return eventDate.toLocaleDateString();
 };


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #161

## ✨ 작업 내용

- 이벤트 전체 조회 시 날짜를 가까운순으로 정렬했습니다.
- Object.entries()가 객체의 키 순서를 보장하지 않는다고 하네요. 기존에는 객체를 사용해서 날짜별로 그룹핑했지만, 원하는 순서대로 렌더링하기 위해 별도 정렬 로직을 추가했습니다.
- Map으로 자료구조를 변경해서 key로는 날짜 문자열, value로는 GroupEvent 객체를 저장하도록 개선했습니다. 추후 그룹핑, 정렬 로직 분리 가능하도록 개선 하면 좋을 것 같아요.
