### PR TITLE
[FE] guest status API 연결, 모집중/모집전 Badge 추가

### DIFF
--- a/client/src/api/mutations/useParticipateEvent.ts
+++ b/client/src/api/mutations/useParticipateEvent.ts
@@ -1,11 +1,24 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { postEventParticipation } from '../queries/event';
+import { fetcher } from '../fetcher';
+import { eventQueryKeys } from '../queries/event';
 import { Answer } from '../types/event';
 
+export const postEventParticipation = (eventId: number, answers: Answer[]) => {
+  return fetcher.post<void>(`events/${eventId}/participation`, {
+    json: { answers },
+  });
+};
+
 export const useParticipateEvent = (eventId: number) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
-    mutationKey: ['participate', eventId],
     mutationFn: (answers: Answer[]) => postEventParticipation(eventId, answers),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [...eventQueryKeys.guestStatus(), eventId],
+      });
+    },
   });
 };

--- a/client/src/api/queries/event.ts
+++ b/client/src/api/queries/event.ts
@@ -4,12 +4,11 @@ import { Guest, NonGuest } from '../../features/Event/Manage/types';
 import { CreateEventAPIRequest, EventDetail } from '../../features/Event/types/Event';
 import { fetcher } from '../fetcher';
 import { postAlarm } from '../mutations/useAddAlarm';
+import { GuestStatusAPIResponse } from '../types/event';
 
 type CreateEventAPIResponse = {
   eventId: number;
 };
-
-type Answer = { questionId: number; answerText: string };
 
 export const eventQueryKeys = {
   all: () => ['event'],
@@ -17,6 +16,8 @@ export const eventQueryKeys = {
   alarm: () => [...eventQueryKeys.all(), 'alarm'],
   guests: () => [...eventQueryKeys.all(), 'guests'],
   nonGuests: () => [...eventQueryKeys.all(), 'nonGuests'],
+  guestStatus: () => [...eventQueryKeys.all(), 'guestStatus'],
+  participation: () => [...eventQueryKeys.all(), 'participation'],
 };
 
 export const eventQueryOptions = {
@@ -29,24 +30,29 @@ export const eventQueryOptions = {
     mutationKey: [...eventQueryKeys.alarm(), eventId],
     mutationFn: (content: string) => postAlarm(eventId, content),
   }),
-  guests: (eventId: number) => ({
-    queryKey: [...eventQueryKeys.guests(), eventId],
-    queryFn: () => getGuests(eventId),
-  }),
-  nonGuests: (eventId: number) => ({
-    queryKey: [...eventQueryKeys.nonGuests(), eventId],
-    queryFn: () => getNonGuests(eventId),
-  }),
+  guests: (eventId: number) =>
+    queryOptions({
+      queryKey: [...eventQueryKeys.guests(), eventId],
+      queryFn: () => getGuests(eventId),
+    }),
+  nonGuests: (eventId: number) =>
+    queryOptions({
+      queryKey: [...eventQueryKeys.nonGuests(), eventId],
+      queryFn: () => getNonGuests(eventId),
+    }),
+  guestStatus: (eventId: number) =>
+    queryOptions({
+      queryKey: [...eventQueryKeys.guestStatus(), eventId],
+      queryFn: () => getGuestStatus(eventId),
+    }),
 };
 
 const getGuests = async (eventId: number) => {
-  const response = await fetcher.get<Guest[]>(`events/${eventId}/guests`);
-  return response;
+  return await fetcher.get<Guest[]>(`events/${eventId}/guests`);
 };
 
 const getNonGuests = async (eventId: number) => {
-  const response = await fetcher.get<NonGuest[]>(`events/${eventId}/non-guests`);
-  return response;
+  return await fetcher.get<NonGuest[]>(`events/${eventId}/non-guests`);
 };
 
 export const createEventAPI = (organizationId: number, data: CreateEventAPIRequest) => {
@@ -59,8 +65,6 @@ const getEventDetailAPI = (eventId: number) => {
   return fetcher.get<EventDetail>(`organizations/events/${eventId}`);
 };
 
-export const postEventParticipation = (eventId: number, answers: Answer[]) => {
-  return fetcher.post<void>(`events/${eventId}/participation`, {
-    json: { answers },
-  });
+const getGuestStatus = async (eventId: number) => {
+  return await fetcher.get<GuestStatusAPIResponse>(`events/${eventId}/guest-status`);
 };

--- a/client/src/api/types/event.ts
+++ b/client/src/api/types/event.ts
@@ -2,3 +2,7 @@ export type Answer = {
   questionId: number;
   answerText: string;
 };
+
+export type GuestStatusAPIResponse = {
+  isGuest: boolean;
+};

--- a/client/src/features/Event/Detail/components/EventDetailContent.tsx
+++ b/client/src/features/Event/Detail/components/EventDetailContent.tsx
@@ -2,9 +2,11 @@ import { useState } from 'react';
 
 import { css } from '@emotion/react';
 
-import { Answer } from '../../../../api/types/event';
-import { Flex } from '../../../../shared/components/Flex';
-import { EventDetail } from '../../../Event/types/Event';
+import { GuestStatusAPIResponse } from '@/api/types/event';
+import { Answer } from '@/api/types/event';
+import { Flex } from '@/shared/components/Flex';
+
+import { EventDetail } from '../../types/Event';
 import { formatKoreanDateTime } from '../utils/formatKoreanDateTime';
 
 import { DescriptionCard } from './DescriptionCard';
@@ -15,7 +17,7 @@ import { PreQuestionCard } from './PreQuestionCard';
 import { SubmitButtonCard } from './SubmitButtonCard';
 import { TimeInfoCard } from './TimeInfoCard';
 
-type EventDetailContentProps = EventDetail;
+type EventDetailContentProps = EventDetail & GuestStatusAPIResponse;
 
 export const EventDetailContent = ({
   eventId,
@@ -29,6 +31,7 @@ export const EventDetailContent = ({
   maxCapacity,
   description,
   questions,
+  isGuest,
 }: EventDetailContentProps) => {
   const [answers, setAnswers] = useState<Answer[]>(
     questions.map(({ questionId }) => ({
@@ -60,8 +63,6 @@ export const EventDetailContent = ({
         gap="24px"
         width="100%"
         css={css`
-          display: flex;
-
           @media (max-width: 768px) {
             flex-direction: column;
           }
@@ -83,7 +84,12 @@ export const EventDetailContent = ({
         onChangeAnswer={handleChangeAnswer}
       />
 
-      <SubmitButtonCard registrationEnd={registrationEnd} eventId={eventId} answers={answers} />
+      <SubmitButtonCard
+        isGuest={isGuest}
+        registrationEnd={registrationEnd}
+        eventId={eventId}
+        answers={answers}
+      />
     </Flex>
   );
 };

--- a/client/src/features/Event/Detail/components/SubmitButtonCard.tsx
+++ b/client/src/features/Event/Detail/components/SubmitButtonCard.tsx
@@ -1,19 +1,24 @@
-import { useParticipateEvent } from '../../../../api/mutations/useParticipateEvent';
-import { Answer } from '../../../../api/types/event';
-import { Button } from '../../../../shared/components/Button';
-import { Card } from '../../../../shared/components/Card';
+import { useParticipateEvent } from '@/api/mutations/useParticipateEvent';
+import { Answer, GuestStatusAPIResponse } from '@/api/types/event';
+import { Button } from '@/shared/components/Button';
+import { Flex } from '@/shared/components/Flex';
 
 type SubmitBUttonCardProps = {
   eventId: number;
   registrationEnd: string;
   answers: Answer[];
-};
+} & GuestStatusAPIResponse;
 
-export const SubmitButtonCard = ({ eventId, registrationEnd, answers }: SubmitBUttonCardProps) => {
+export const SubmitButtonCard = ({
+  eventId,
+  answers,
+  registrationEnd,
+  isGuest,
+}: SubmitBUttonCardProps) => {
   const now = new Date();
   const isBeforeDeadline = now <= new Date(registrationEnd);
 
-  const { mutate, isPending } = useParticipateEvent(eventId);
+  const { mutate } = useParticipateEvent(eventId);
 
   const handleClick = () => {
     mutate(answers, {
@@ -27,15 +32,15 @@ export const SubmitButtonCard = ({ eventId, registrationEnd, answers }: SubmitBU
   };
 
   return (
-    <Card>
+    <Flex margin="10px 0 40px">
       <Button
         width="100%"
-        color={isBeforeDeadline ? '#2563EB' : 'gray'}
-        disabled={!isBeforeDeadline || isPending}
+        color={!isGuest || isBeforeDeadline ? '#2563EB' : 'gray'}
+        disabled={!isBeforeDeadline || isGuest}
         onClick={handleClick}
       >
-        {isBeforeDeadline ? (isPending ? '신청 중...' : '참가 신청하기') : '신청 마감'}
+        {isBeforeDeadline ? (!isGuest ? '신청 하기' : '신청 완료') : '신청 마감'}
       </Button>
-    </Card>
+    </Flex>
   );
 };

--- a/client/src/features/Event/Detail/pages/EventDetailPage.tsx
+++ b/client/src/features/Event/Detail/pages/EventDetailPage.tsx
@@ -1,19 +1,24 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQueries } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { eventQueryOptions } from '@/api/queries/event';
+import { Flex } from '@/shared/components/Flex';
+import { Header } from '@/shared/components/Header';
+import { IconButton } from '@/shared/components/IconButton';
+import { PageLayout } from '@/shared/components/PageLayout';
+import { Text } from '@/shared/components/Text';
 
-import { Flex } from '../../../../shared/components/Flex';
-import { Header } from '../../../../shared/components/Header';
-import { IconButton } from '../../../../shared/components/IconButton';
-import { PageLayout } from '../../../../shared/components/PageLayout';
-import { Text } from '../../../../shared/components/Text';
 import { EventDetailContent } from '../components/EventDetailContent';
 
 export const EventDetailPage = () => {
   const navigate = useNavigate();
   const { eventId } = useParams();
-  const { data: event } = useQuery(eventQueryOptions.detail(Number(eventId)));
+  const [{ data: event }, { data: guestStatus }] = useSuspenseQueries({
+    queries: [
+      eventQueryOptions.detail(Number(eventId)),
+      eventQueryOptions.guestStatus(Number(eventId)),
+    ],
+  });
 
   if (!event) {
     return (
@@ -38,7 +43,7 @@ export const EventDetailPage = () => {
         />
       }
     >
-      <EventDetailContent {...event} />
+      <EventDetailContent isGuest={guestStatus.isGuest} {...event} />
     </PageLayout>
   );
 };

--- a/client/src/features/Event/Overview/components/EventCard.tsx
+++ b/client/src/features/Event/Overview/components/EventCard.tsx
@@ -14,6 +14,7 @@ export const EventCard = ({
   eventId,
   title,
   description,
+  registrationStart,
   registrationEnd,
   eventStart,
   eventEnd,
@@ -23,12 +24,18 @@ export const EventCard = ({
   maxCapacity,
 }: Event) => {
   const navigate = useNavigate();
+
   return (
     <CardWrapper onClick={() => navigate(`/event/${eventId}`)}>
       <Flex dir="column" gap="8px">
-        <Text type="Title" color="#ffffff" weight="semibold">
-          {title}
-        </Text>
+        <Flex justifyContent="space-between" alignItems="center" gap="8px">
+          <Text type="Title" color="#ffffff" weight="semibold">
+            {title}
+          </Text>
+          <Badge isRegistrationOpen={new Date(registrationStart) < new Date()}>
+            {new Date(registrationStart) > new Date() ? '모집전' : '모집중'}
+          </Badge>
+        </Flex>
         <Text type="caption" color="#99A1AF">
           {description}
         </Text>
@@ -93,4 +100,12 @@ const Spacing = styled.hr`
   background-color: rgb(218, 218, 218);
   border: none;
   margin: 0;
+`;
+
+const Badge = styled.span<{ isRegistrationOpen: boolean }>`
+  background-color: ${({ isRegistrationOpen }) => (isRegistrationOpen ? '#2563EB' : 'gray')};
+  color: #ffffff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
 `;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #180 

## ✨ 작업 내용

- guest status API를 연동하고, 전체 조회 시 모집중/모집 전 상태에 따라 Badge를 표시하도록 추가했습니다.
- 누락되어 있던 queryOptions 항목들을 보완해 추가했습니다.
- 신청 이후 queryClient.invalidateQueries를 통해 관련 데이터를 무효화하고, 이를 다시 fetch하여 상태가 ‘신청 마감’으로 갱신되도록 수정했습니다.
- 추후 Date 처리하는 부분 수정하면 좋을 것 같아요.

![Jul-25-2025 01-55-42](https://github.com/user-attachments/assets/9fb63346-603b-4ec8-aec8-45074c8b8b33)

### useSuspenseQueries를 사용해 이벤트 상세와 게스트 상태 데이터를 병렬로 요청하도록 구성했습니다.
- 기존에 await를 사용한 순차 요청 방식은 첫 번째 요청이 완료되어야 두 번째 요청을 시작합니다. 반면 병렬 요청은 두 API를 동시에 보내기 때문에, 느린 API의 시간만큼만 기다리면 전체 데이터가 준비됩니다.
  - 순차 요청: 300ms(이벤트 상세) + 400ms(게스트 상태) = 700ms
  - 병렬 요청: max(300ms, 400ms) = 400ms

따라서 병렬 요청을 사용하면 두 데이터를 동시에 받아 화면을 한 번에 렌더링할 수 있어 응답 속도와 사용자 경험이 모두 향상됩니다. 이러한 이유로`useSuspenseQueries`를 사용했습니다.

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

