### PR TITLE
[FE] 참여 이벤트 탭 내에서는 이벤트 상세 페이지로 이동

### DIFF
--- a/client/src/api/queries/my.ts
+++ b/client/src/api/queries/my.ts
@@ -1,4 +1,4 @@
-import { Event, EventType } from '@/features/Event/types/Event';
+import { Event } from '@/features/Event/types/Event';
 
 import { fetcher } from '../fetcher';
 
@@ -20,11 +20,9 @@ export const myEventQueryOptions = {
 };
 
 const getHostEvents = async (organizationId: number): Promise<Event[]> => {
-  return await fetcher.get<Event[] & EventType>(`organizations/${organizationId}/events/owned`);
+  return await fetcher.get<Event[]>(`organizations/${organizationId}/events/owned`);
 };
 
 const getParticipateEvents = async (organizationId: number): Promise<Event[]> => {
-  return await fetcher.get<Event[] & EventType>(
-    `organizations/${organizationId}/events/participated`
-  );
+  return await fetcher.get<Event[]>(`organizations/${organizationId}/events/participated`);
 };

--- a/client/src/api/queries/my.ts
+++ b/client/src/api/queries/my.ts
@@ -1,4 +1,4 @@
-import { Event } from '@/features/Event/types/Event';
+import { Event, EventType } from '@/features/Event/types/Event';
 
 import { fetcher } from '../fetcher';
 
@@ -20,9 +20,11 @@ export const myEventQueryOptions = {
 };
 
 const getHostEvents = async (organizationId: number): Promise<Event[]> => {
-  return await fetcher.get<Event[]>(`organizations/${organizationId}/events/owned`);
+  return await fetcher.get<Event[] & EventType>(`organizations/${organizationId}/events/owned`);
 };
 
 const getParticipateEvents = async (organizationId: number): Promise<Event[]> => {
-  return await fetcher.get<Event[]>(`organizations/${organizationId}/events/participated`);
+  return await fetcher.get<Event[] & EventType>(
+    `organizations/${organizationId}/events/participated`
+  );
 };

--- a/client/src/features/Event/My/components/EventCard.tsx
+++ b/client/src/features/Event/My/components/EventCard.tsx
@@ -11,6 +11,10 @@ import { formatDateTime } from '../../Overview/utils/formatDateTime';
 import { formatTime } from '../../Overview/utils/formatTime';
 import { Event } from '../../types/Event';
 
+type EventCardProps = Event & {
+  cardType: 'host' | 'participate';
+};
+
 export const EventCard = ({
   eventId,
   title,
@@ -22,11 +26,20 @@ export const EventCard = ({
   place,
   currentGuestCount,
   maxCapacity,
-}: Event) => {
+  cardType,
+}: EventCardProps) => {
   const navigate = useNavigate();
 
+  const handleClick = () => {
+    if (cardType === 'host') {
+      navigate(`/event/manage/${eventId}`);
+    } else {
+      navigate(`/event/${eventId}`);
+    }
+  };
+
   return (
-    <EventCardWrapper onClick={() => navigate(`/event/manage/${eventId}`)}>
+    <EventCardWrapper onClick={handleClick}>
       <Flex dir="column" gap="3.5px">
         <Text type="Title" weight="semibold" color="white">
           {title}

--- a/client/src/features/Event/My/components/EventCard.tsx
+++ b/client/src/features/Event/My/components/EventCard.tsx
@@ -10,9 +10,10 @@ import { Text } from '@/shared/components/Text';
 import { formatDateTime } from '../../Overview/utils/formatDateTime';
 import { formatTime } from '../../Overview/utils/formatTime';
 import { Event } from '../../types/Event';
+import { TAB_VALUES } from '../constants';
 
 type EventCardProps = Event & {
-  cardType: 'host' | 'participate';
+  cardType: (typeof TAB_VALUES)[keyof typeof TAB_VALUES];
 };
 
 export const EventCard = ({

--- a/client/src/features/Event/My/components/EventSection.tsx
+++ b/client/src/features/Event/My/components/EventSection.tsx
@@ -12,9 +12,10 @@ type EventSectionProps = {
   events: Event[];
   title: string;
   emptyMessage: string;
+  cardType: 'host' | 'participate';
 };
 
-export const EventSection = ({ events, title, emptyMessage }: EventSectionProps) => {
+export const EventSection = ({ events, title, emptyMessage, cardType }: EventSectionProps) => {
   return (
     <Flex dir="column" gap="16px">
       <Flex alignItems="center" gap="8px">
@@ -27,7 +28,7 @@ export const EventSection = ({ events, title, emptyMessage }: EventSectionProps)
       {events.length > 0 ? (
         <EventCardContainer>
           {events.map((event) => (
-            <EventCard key={event.eventId} {...event} />
+            <EventCard key={event.eventId} {...event} cardType={cardType} />
           ))}
         </EventCardContainer>
       ) : (

--- a/client/src/features/Event/My/components/EventTabs.tsx
+++ b/client/src/features/Event/My/components/EventTabs.tsx
@@ -33,7 +33,7 @@ export const EventTabs = () => {
           events={hostEvents}
           title={UI_LABELS.ONGOING_HOST_EVENTS}
           emptyMessage={STATUS_MESSAGES.NO_HOST_EVENTS}
-          cardType="host"
+          cardType={TAB_VALUES.HOST}
         />
       </Tabs.Content>
 
@@ -47,7 +47,7 @@ export const EventTabs = () => {
           events={participateEvents}
           title={UI_LABELS.PARTICIPATING_EVENTS}
           emptyMessage={STATUS_MESSAGES.NO_PARTICIPATE_EVENTS}
-          cardType="participate"
+          cardType={TAB_VALUES.PARTICIPATE}
         />
       </Tabs.Content>
     </Tabs>

--- a/client/src/features/Event/My/components/EventTabs.tsx
+++ b/client/src/features/Event/My/components/EventTabs.tsx
@@ -33,6 +33,7 @@ export const EventTabs = () => {
           events={hostEvents}
           title={UI_LABELS.ONGOING_HOST_EVENTS}
           emptyMessage={STATUS_MESSAGES.NO_HOST_EVENTS}
+          cardType="host"
         />
       </Tabs.Content>
 
@@ -46,6 +47,7 @@ export const EventTabs = () => {
           events={participateEvents}
           title={UI_LABELS.PARTICIPATING_EVENTS}
           emptyMessage={STATUS_MESSAGES.NO_PARTICIPATE_EVENTS}
+          cardType="participate"
         />
       </Tabs.Content>
     </Tabs>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #193 

## ✨ 작업 내용

- 참여 이벤트 탭에서는 이벤트 관리 페이지가 아닌 이벤트 상세 페이지로 가게 수정하였습니다.
- tab의 value에 따라 값 구분하여 navigate하였습니다!


## 🙏 기타 참고 사항

-  shout out to 세라~


