### PR TITLE
[BE] Swagger 초기 세팅

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'com.github.joon6093:jpa-nplus1-detector:3.0.0'
 
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/server/src/main/java/com/ahmadda/infra/mail/SmtpNotificationMailer.java
+++ b/server/src/main/java/com/ahmadda/infra/mail/SmtpNotificationMailer.java
@@ -5,10 +5,12 @@ import com.ahmadda.infra.mail.exception.MailSendFailedException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 
+@Slf4j
 @RequiredArgsConstructor
 public class SmtpNotificationMailer implements NotificationMailer {
 
@@ -32,6 +34,7 @@ public class SmtpNotificationMailer implements NotificationMailer {
             helper.setSubject(subject);
             helper.setText(content, true);
         } catch (MessagingException e) {
+            log.error("mailError : {} ", e.getMessage(), e);
             throw new MailSendFailedException("이메일 발송에 실패했습니다.", e);
         }
 

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -9,6 +9,7 @@ import com.ahmadda.presentation.dto.GuestResponse;
 import com.ahmadda.presentation.dto.GuestStatusResponse;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Tag(name = "Event Guest", description = "이벤트 게스트 관련 API")
 @RestController
 @RequestMapping("/api/events")
 @RequiredArgsConstructor

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
@@ -4,6 +4,7 @@ import com.ahmadda.application.EventNotificationService;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.NotificationRequest;
 import com.ahmadda.presentation.resolver.AuthMember;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Event Notification", description = "이벤트 알림 관련 API")
 @RestController
 @RequestMapping("/api/events")
 @RequiredArgsConstructor

--- a/server/src/main/java/com/ahmadda/presentation/LoginController.java
+++ b/server/src/main/java/com/ahmadda/presentation/LoginController.java
@@ -3,6 +3,7 @@ package com.ahmadda.presentation;
 import com.ahmadda.application.LoginService;
 import com.ahmadda.presentation.dto.AccessTokenResponse;
 import com.ahmadda.presentation.dto.LoginRequest;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Login", description = "로그인 관련 API")
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor

--- a/server/src/main/java/com/ahmadda/presentation/MemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/MemberController.java
@@ -6,6 +6,11 @@ import com.ahmadda.domain.Member;
 import com.ahmadda.presentation.dto.MemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +27,33 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/profile")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "OK",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = MemberResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Not Found",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Not Found",
+                                              "status": 404,
+                                              "detail": "존재하지 않는 회원입니다.",
+                                              "instance": "/api/members/profile"
+                                            }
+                                            """
+                            )
+                    )
+            )})
     public ResponseEntity<MemberResponse> getMemberProfile(@Parameter(hidden = true) @AuthMember final LoginMember loginMember) {
         Member member = memberService.getMember(loginMember);
 

--- a/server/src/main/java/com/ahmadda/presentation/MemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/MemberController.java
@@ -53,7 +53,8 @@ public class MemberController {
                                             """
                             )
                     )
-            )})
+            )
+    })
     public ResponseEntity<MemberResponse> getMemberProfile(@Parameter(hidden = true) @AuthMember final LoginMember loginMember) {
         Member member = memberService.getMember(loginMember);
 

--- a/server/src/main/java/com/ahmadda/presentation/MemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/MemberController.java
@@ -5,12 +5,15 @@ import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.domain.Member;
 import com.ahmadda.presentation.dto.MemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Member", description = "회원 관련 API")
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
@@ -19,7 +22,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/profile")
-    public ResponseEntity<MemberResponse> getMemberProfile(@AuthMember final LoginMember loginMember) {
+    public ResponseEntity<MemberResponse> getMemberProfile(@Parameter(hidden = true) @AuthMember final LoginMember loginMember) {
         Member member = memberService.getMember(loginMember);
 
         MemberResponse response = MemberResponse.from(member);

--- a/server/src/main/java/com/ahmadda/presentation/MemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/MemberController.java
@@ -5,7 +5,6 @@ import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.domain.Member;
 import com.ahmadda.presentation.dto.MemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -55,7 +54,7 @@ public class MemberController {
                     )
             )
     })
-    public ResponseEntity<MemberResponse> getMemberProfile(@Parameter(hidden = true) @AuthMember final LoginMember loginMember) {
+    public ResponseEntity<MemberResponse> getMemberProfile(@AuthMember final LoginMember loginMember) {
         Member member = memberService.getMember(loginMember);
 
         MemberResponse response = MemberResponse.from(member);

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -5,6 +5,7 @@ import com.ahmadda.application.dto.OrganizationCreateRequest;
 import com.ahmadda.domain.Organization;
 import com.ahmadda.presentation.dto.OrganizationCreateResponse;
 import com.ahmadda.presentation.dto.OrganizationResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 
+@Tag(name = "Organization", description = "조직 관련 API")
 @RestController
 @RequestMapping("/api/organizations")
 @RequiredArgsConstructor

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -11,6 +11,7 @@ import com.ahmadda.presentation.dto.EventCreateResponse;
 import com.ahmadda.presentation.dto.EventDetailResponse;
 import com.ahmadda.presentation.dto.EventResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.net.URI;
 import java.util.List;
 
+@Tag(name = "Organization Event", description = "조직 이벤트 관련 API")
 @RestController
 @RequestMapping("/api/organizations")
 @RequiredArgsConstructor

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
@@ -5,6 +5,7 @@ import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "OrganizationMember", description = "조직원 관련 API")
 @RestController
 @RequestMapping("/api/organizations")
 @RequiredArgsConstructor

--- a/server/src/main/java/com/ahmadda/presentation/config/SwaggerConfig.java
+++ b/server/src/main/java/com/ahmadda/presentation/config/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.ahmadda.presentation.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "JWT";
+
+    @Bean
+    public OpenAPI openApi() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement())
+                .components(securityComponents());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Ahmadda API")
+                .description("Ahmadda API 명세서")
+                .version("v0.0.0");
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList(SECURITY_SCHEME_NAME);
+    }
+
+    private Components securityComponents() {
+        SecurityScheme scheme = new SecurityScheme()
+                .name("Authorization")
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("Bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER);
+
+        return new Components()
+                .addSecuritySchemes(SECURITY_SCHEME_NAME, scheme);
+    }
+}

--- a/server/src/main/java/com/ahmadda/presentation/resolver/AuthMember.java
+++ b/server/src/main/java/com/ahmadda/presentation/resolver/AuthMember.java
@@ -1,10 +1,13 @@
 package com.ahmadda.presentation.resolver;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@Parameter(hidden = true)
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthMember {

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -37,3 +37,9 @@ oauth:
     user-uri: ${oauth.google.user-uri}
     connect-timeout: 3000
     read-timeout: 5000
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    path: /specification


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈
close #205

## ✨ 작업 내용
지금까지는 Notion을 기반으로 API 문서를 관리해왔지만,  
최근 들어 팀 내부에서 **Notion 문서 관리가 번거롭고 한계에 도달했다는 의견**이 많았죠~~

초기에는 양방향 커뮤니케이션에 적합했지만,  
이제는 **안정된 API 명세를 코드에 기반해 자동으로 관리할 필요성**이 커졌다고 느낀 시점입니다!

그래서 Swagger를 도입하여,
- 명세 자동화 기반을 만들고,
- API 문서 관리의 효율성과 일관성을 높이기 위한 작업을 진행했습니다!

## 🙏 기타 참고 사항
Swagger 명세를 어떻게 작성하면 좋을지 고민해보다가,  
아래와 같이 성공/실패 응답을 함께 명시하는 방식을 예시로 작성해봤습니다!

```java
@ApiResponses(value = {
    @ApiResponse(
        responseCode = "200",
        description = "OK",
        content = @Content(
            schema = @Schema(implementation = MemberResponse.class)
        )
    ),
    @ApiResponse(
        responseCode = "404",
        description = "Not Found",
        content = @Content(
            examples = @ExampleObject(
                value = """
                        {
                          "type": "about:blank",
                          "title": "Not Found",
                          "status": 404,
                          "detail": "존재하지 않는 회원입니다.",
                          "instance": "/api/members/profile"
                        }
                        """
            )
        )
    )
})
```

그리고 실제 Swagger 화면은 이렇게 나옵니다~~

<img width="736" height="453" alt="image" src="https://github.com/user-attachments/assets/7e623715-3537-4f2e-9d34-ee7b54c85552" />

가장 중요한건 명세를 어느 정도까지 작성할지는 클라이언트 분들과도 함께 논의가 필요할 것 같아요~~

일단 각자 코드를 Pull 받아 Swagger 명세를 가볍게 만져보시고, 월요일쯤 함께 정리하는 시간을 가지면 좋을 것 같습니다 🙌

[기술 스택 정리 위키](https://github.com/woowacourse-teams/2025-ah-madda/wiki/%E2%9A%99%EF%B8%8F-BE-%EA%B8%B0%EC%88%A0-%EC%8A%A4%ED%83%9D)에 관련 내용도 업데이트 했습니다~~ 