### PR TITLE
[BE] 새로운 유저 로그인시 슬랙 알람 기능 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/LoginService.java
+++ b/server/src/main/java/com/ahmadda/application/LoginService.java
@@ -10,6 +10,7 @@ import com.ahmadda.infra.jwt.JwtTokenProvider;
 import com.ahmadda.infra.oauth.GoogleOAuthProvider;
 import com.ahmadda.infra.oauth.dto.OAuthUserInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,7 @@ public class LoginService {
     //TODO 07.25이후 사용하지않으면 삭제
     private final OrganizationRepository organizationRepository;
     private final OrganizationMemberRepository organizationMemberRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public String login(final String code) {
@@ -41,6 +43,8 @@ public class LoginService {
         return memberRepository.findByEmail(email)
                 .orElseGet(() -> {
                     Member newMember = Member.create(name, email);
+
+                    eventPublisher.publishEvent(newMember);
 
                     return memberRepository.save(newMember);
                 });

--- a/server/src/main/java/com/ahmadda/application/MemberEventListener.java
+++ b/server/src/main/java/com/ahmadda/application/MemberEventListener.java
@@ -1,0 +1,19 @@
+package com.ahmadda.application;
+
+import com.ahmadda.domain.Member;
+import com.ahmadda.infra.slack.SlackReminder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberEventListener {
+
+    private final SlackReminder slackReminder;
+
+    @EventListener
+    public void handleMemberCreationEvent(final Member member) {
+        slackReminder.alarmMemberCreation(member);
+    }
+}

--- a/server/src/main/java/com/ahmadda/infra/slack/SlackReminder.java
+++ b/server/src/main/java/com/ahmadda/infra/slack/SlackReminder.java
@@ -1,0 +1,53 @@
+package com.ahmadda.infra.slack;
+
+import com.ahmadda.domain.Member;
+import com.ahmadda.infra.slack.config.SlackAlarmProperties;
+import com.ahmadda.infra.slack.dto.MemberCreationAlarmPayload;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+@Slf4j
+@Profile("prod")
+@EnableConfigurationProperties(SlackAlarmProperties.class)
+public class SlackReminder {
+
+    private final SlackAlarmProperties slackAlarmProperties;
+    private final RestClient restClient;
+
+    public SlackReminder(RestClient.Builder restClientBuilder, SlackAlarmProperties slackAlarmProperties) {
+        this.slackAlarmProperties = slackAlarmProperties;
+
+        restClientBuilder.requestFactory(simpleClientHttpRequestFactory());
+        restClientBuilder.baseUrl(slackAlarmProperties.getPostMessageUrl());
+        restClientBuilder.defaultHeaders(headers -> {
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(slackAlarmProperties.getBotToken());
+        });
+
+        restClient = restClientBuilder.build();
+    }
+
+    private SimpleClientHttpRequestFactory simpleClientHttpRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(slackAlarmProperties.getConnectTimeout());
+        factory.setReadTimeout(slackAlarmProperties.getReadTimeout());
+
+        return factory;
+    }
+
+    public void alarmMemberCreation(final Member member) {
+        try {
+            restClient.post()
+                    .body(MemberCreationAlarmPayload.create(member, slackAlarmProperties.getChannelId()));
+        } catch (RestClientException e) {
+            log.error("Slack 회원 가입 알림 전송에 실패했습니다. email={}, error={}", member.getEmail(), e.getMessage());
+        }
+    }
+}

--- a/server/src/main/java/com/ahmadda/infra/slack/config/SlackAlarmProperties.java
+++ b/server/src/main/java/com/ahmadda/infra/slack/config/SlackAlarmProperties.java
@@ -1,0 +1,17 @@
+package com.ahmadda.infra.slack.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "slack")
+@RequiredArgsConstructor
+@Getter
+public class SlackAlarmProperties {
+
+    private final String postMessageUrl;
+    private final String channelId;
+    private final String botToken;
+    private final int connectTimeout;
+    private final int readTimeout;
+}

--- a/server/src/main/java/com/ahmadda/infra/slack/dto/MemberCreationAlarmPayload.java
+++ b/server/src/main/java/com/ahmadda/infra/slack/dto/MemberCreationAlarmPayload.java
@@ -1,0 +1,44 @@
+package com.ahmadda.infra.slack.dto;
+
+import com.ahmadda.domain.Member;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record MemberCreationAlarmPayload(
+        List<Block> blocks,
+        String channel
+) {
+
+    private record Block(
+            String type,
+            @JsonProperty("text") // JSON 필드명과 일치시키기 위한 어노테이션
+            TextObject textObject
+    ) {
+
+    }
+
+    private record TextObject(
+            String type,
+            String text
+    ) {
+
+    }
+
+    public static MemberCreationAlarmPayload create(final Member member, final String channelId) {
+        var messageText = String.format(
+                """
+                        *🎉 새로운 회원 가입 알림*
+                        - *이름*: %s
+                        - *이메일*: %s
+                        """,
+                member.getName(),
+                member.getEmail()
+        );
+
+        var textObject = new TextObject("mrkdwn", messageText);
+        var mainBlock = new Block("section", textObject);
+
+        return new MemberCreationAlarmPayload(List.of(mainBlock), channelId);
+    }
+}

--- a/server/src/main/java/com/ahmadda/infra/slack/dto/MemberCreationAlarmPayload.java
+++ b/server/src/main/java/com/ahmadda/infra/slack/dto/MemberCreationAlarmPayload.java
@@ -12,7 +12,7 @@ public record MemberCreationAlarmPayload(
 
     private record Block(
             String type,
-            @JsonProperty("text") // JSON 필드명과 일치시키기 위한 어노테이션
+            @JsonProperty("text")
             TextObject textObject
     ) {
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
       - security/oauth.yml
       - security/jwt.yml
       - security/db.yml
+      - security/slack.yml
 
   application:
     name: ah-madda
@@ -37,3 +38,10 @@ oauth:
     user-uri: ${oauth.google.user-uri}
     connect-timeout: 3000
     read-timeout: 5000
+
+slack:
+  bot-token: ${slack.bot-token}
+  channel-id: ${slack.channel-id}
+  post-message-url: ${slack.post-message-url}
+  connect-timeout: 3000
+  read-timeout: 5000

--- a/server/src/test/java/com/ahmadda/infra/slack/SlackReminderTest.java
+++ b/server/src/test/java/com/ahmadda/infra/slack/SlackReminderTest.java
@@ -1,0 +1,27 @@
+package com.ahmadda.infra.slack;
+
+import com.ahmadda.domain.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Profile("prod")
+class SlackReminderTest {
+
+    @Autowired
+    private SlackReminder slackReminder;
+
+    @Test
+    void 로그인_생성_이벤트_발생시_슬랙에_알람을_보낸다() {
+
+        // given
+        var member = Member.create("test-user", "test-user@naver.com");
+
+        // when //then
+        assertDoesNotThrow(() -> slackReminder.alarmMemberCreation(member));
+    }
+}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #210 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
- 프로덕션 환경에서 슬랙에 로그인 알람이 가도록 구현하였습니다.

## 🙏 기타 참고 사항
- 프로퍼티값은 가이온군의 OAuth를 참고하였습니다.
- 세부적인 예외처리를 하지 않았습니다. (부가적인 기능이기 때문에)
- 해당 기능도 프로덕션 환경에서만 동작합니다. 테스트 또한 프로덕션 환경에서만 동작합니다. 
- 이벤트 방식을 사용하였습니다.
  - 이벤트 퍼블리싱시에 Dto를 따로 만들지 않은 이유는 역시 부가적인 기능이기 때문입니다. 
- 서브모듈을 업데이트하였으니 pull 바랍니다 
<!-- 없다면 적지 않으셔도 됩니다. -->
