### PR TITLE
[BE] Event 생성 요청시에 받고있는 이벤트 신청 시작시간 삭제

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -35,12 +35,13 @@ public class EventService {
     public Event createEvent(
             final Long organizationId,
             final Long memberId,
-            final EventCreateRequest eventCreateRequest
+            final EventCreateRequest eventCreateRequest,
+            final LocalDateTime currentDateTime
     ) {
         Organization organization = getOrganization(organizationId);
         OrganizationMember organizer = validateAccessToOrganization(organizationId, memberId);
 
-        EventOperationPeriod eventOperationPeriod = createEventOperationPeriod(eventCreateRequest);
+        EventOperationPeriod eventOperationPeriod = createEventOperationPeriod(eventCreateRequest, currentDateTime);
         Event event = Event.create(
                 eventCreateRequest.title(),
                 eventCreateRequest.description(),
@@ -61,15 +62,17 @@ public class EventService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않은 이벤트 정보입니다."));
     }
 
-    private EventOperationPeriod createEventOperationPeriod(final EventCreateRequest eventCreateRequest) {
-        Period registrationPeriod =
-                Period.create(eventCreateRequest.registrationStart(), eventCreateRequest.registrationEnd());
+    private EventOperationPeriod createEventOperationPeriod(
+            final EventCreateRequest eventCreateRequest,
+            final LocalDateTime currentDateTime
+    ) {
+        Period registrationPeriod = Period.create(currentDateTime, eventCreateRequest.registrationEnd());
         Period eventPeriod = Period.create(eventCreateRequest.eventStart(), eventCreateRequest.eventEnd());
 
         return EventOperationPeriod.create(
                 registrationPeriod,
                 eventPeriod,
-                LocalDateTime.now()
+                currentDateTime
         );
     }
 

--- a/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
@@ -15,8 +15,6 @@ public record EventCreateRequest(
         @NotBlank
         String place,
         @NotNull
-        LocalDateTime registrationStart,
-        @NotNull
         LocalDateTime registrationEnd,
         @NotNull
         LocalDateTime eventStart,

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -193,13 +193,13 @@ public class Event extends BaseEntity {
 
     private void validateParticipate(final Guest guest, final LocalDateTime participantDateTime) {
         if (eventOperationPeriod.canNotRegistration(participantDateTime)) {
-            throw new BusinessRuleViolatedException("이벤트 신청 기간이 아닙니다.");
+            throw new BusinessRuleViolatedException("이벤트 신청은 신청 시작 시간부터 신청 마감 시간까지 가능합니다.");
         }
         if (guests.size() >= maxCapacity) {
             throw new BusinessRuleViolatedException("수용 인원이 가득차 이벤트에 참여할 수 없습니다.");
         }
         if (hasGuest(guest.getOrganizationMember())) {
-            throw new BusinessRuleViolatedException("이미 참여중인 게스트입니다.");
+            throw new BusinessRuleViolatedException("이미 해당 이벤트에 참여중인 게스트입니다.");
         }
         if (guest.isSameOrganizationMember(organizer)) {
             throw new BusinessRuleViolatedException("이벤트의 주최자는 게스트로 참여할 수 없습니다.");

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Tag(name = "Organization Event", description = "조직 이벤트 관련 API")
@@ -52,7 +53,12 @@ public class OrganizationEventController {
             @RequestBody @Valid final EventCreateRequest eventCreateRequest,
             @AuthMember final LoginMember loginMember
     ) {
-        Event event = eventService.createEvent(organizationId, loginMember.memberId(), eventCreateRequest);
+        Event event = eventService.createEvent(
+                organizationId,
+                loginMember.memberId(),
+                eventCreateRequest,
+                LocalDateTime.now()
+        );
 
         return ResponseEntity.created(URI.create("/api/organizations/" + organizationId + "/events/" + event.getId()))
                 .body(new EventCreateResponse(event.getId()));

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -60,7 +60,7 @@ class EventServiceTest {
                 "UI/UX 이벤트",
                 "UI/UX 이벤트 입니다",
                 "선릉",
-                now.plusDays(3), now.plusDays(4),
+                now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
                 "이벤트 근로",
                 100,
@@ -68,7 +68,7 @@ class EventServiceTest {
         );
 
         //when
-        var event = sut.createEvent(organization.getId(), organizationMember.getId(), eventCreateRequest);
+        var event = sut.createEvent(organization.getId(), organizationMember.getId(), eventCreateRequest, now);
 
         //then
         assertThat(eventRepository.findById(event.getId()))
@@ -87,7 +87,7 @@ class EventServiceTest {
                                 .isEqualTo(organizationMember);
                         softly.assertThat(savedEvent.getEventOperationPeriod())
                                 .isEqualTo(EventOperationPeriod.create(
-                                        Period.create(now.plusDays(3), now.plusDays(4)),
+                                        Period.create(now, now.plusDays(4)),
                                         Period.create(now.plusDays(5), now.plusDays(6)),
                                         now
                                 ));
@@ -110,7 +110,7 @@ class EventServiceTest {
                 "UI/UX 이벤트",
                 "UI/UX 이벤트 입니다",
                 "선릉",
-                now.plusDays(3), now.plusDays(4),
+                now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
                 "이벤트 근로",
                 100,
@@ -118,7 +118,7 @@ class EventServiceTest {
         );
 
         //when //then
-        assertThatThrownBy(() -> sut.createEvent(999L, organizationMember.getId(), eventCreateRequest))
+        assertThatThrownBy(() -> sut.createEvent(999L, organizationMember.getId(), eventCreateRequest, now))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않은 조직 정보입니다.");
     }
@@ -133,7 +133,7 @@ class EventServiceTest {
                 "UI/UX 이벤트",
                 "UI/UX 이벤트 입니다",
                 "선릉",
-                now.plusDays(3), now.plusDays(4),
+                now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
                 "이밴트 근로",
                 100,
@@ -141,7 +141,7 @@ class EventServiceTest {
         );
 
         //when //then
-        assertThatThrownBy(() -> sut.createEvent(organization.getId(), 999L, eventCreateRequest))
+        assertThatThrownBy(() -> sut.createEvent(organization.getId(), 999L, eventCreateRequest, now))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 회원입니다.");
     }
@@ -159,7 +159,7 @@ class EventServiceTest {
                 "UI/UX 이벤트",
                 "UI/UX 이벤트 입니다",
                 "선릉",
-                now.plusDays(3), now.plusDays(4),
+                now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
                 "이밴트 근로",
                 100,
@@ -167,7 +167,7 @@ class EventServiceTest {
         );
 
         //when //then
-        assertThatThrownBy(() -> sut.createEvent(organization1.getId(), member.getId(), eventCreateRequest))
+        assertThatThrownBy(() -> sut.createEvent(organization1.getId(), member.getId(), eventCreateRequest, now))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("조직에 소속되지 않은 멤버입니다.");
     }

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -177,7 +177,7 @@ class EventTest {
         //when //then
         assertThatThrownBy(() -> sut.participate(guest, registrationPeriod.start()))
                 .isInstanceOf(BusinessRuleViolatedException.class)
-                .hasMessage("이미 참여중인 게스트입니다.");
+                .hasMessage("이미 해당 이벤트에 참여중인 게스트입니다.");
     }
 
     @Test

--- a/server/src/test/java/com/ahmadda/domain/GuestTest.java
+++ b/server/src/test/java/com/ahmadda/domain/GuestTest.java
@@ -160,7 +160,7 @@ class GuestTest {
                         .minusDays(1)
         ))
                 .isInstanceOf(BusinessRuleViolatedException.class)
-                .hasMessage("이벤트 신청 기간이 아닙니다.");
+                .hasMessage("이벤트 신청은 신청 시작 시간부터 신청 마감 시간까지 가능합니다.");
     }
 
     @Test


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #208 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
Event 생성 요청시에 받고있는 이벤트 신청 시작시간을 삭제했습니다.
이벤트를 생성한 시점부터 이벤트 신청이 가능하도록 리팩터링 했습니다.

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
UI 상으로 이벤트 생성시 입력할 값이 너무 많아 이벤트 생성하는데 리소스가 많이 든다는 의견이 있어 팀 내부에서 어떻게 하면 더 간편하게 이벤트를 생성할 수 있을지 논의했습니다.
그 결과 이벤트 신청 시작 기간이라는 필드는 불필요하다고 판단을 내렸고, 그 이유로는 다음과 같습니다

- 대부분의 이벤트가 이벤트 생성 시점부터 이벤트 신청이 시작되는 경우가 많아, 신청 시작 시간을 별도로 설정하는 것이 오히려 UX를 복잡하게 만든다고 판단했습니다.
- 이벤트 신청 마감 시간 또한 삭제할지 논의하였지만, 이벤트 신청 마감 시간을 필요로 하는 이벤트가 많다는 것을 조사하였고, 이에 따라 이벤트 마감 시간은 없애지 않는쪽으로 결론을 내렸습니다.
