### PR TITLE
[BE] 조직 참여 기능 구현 및 명세서 작성

### DIFF
--- a/server/src/main/java/com/ahmadda/application/LoginService.java
+++ b/server/src/main/java/com/ahmadda/application/LoginService.java
@@ -2,10 +2,6 @@ package com.ahmadda.application;
 
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
-import com.ahmadda.domain.Organization;
-import com.ahmadda.domain.OrganizationMember;
-import com.ahmadda.domain.OrganizationMemberRepository;
-import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.infra.jwt.JwtTokenProvider;
 import com.ahmadda.infra.oauth.GoogleOAuthProvider;
 import com.ahmadda.infra.oauth.dto.OAuthUserInfoResponse;
@@ -13,52 +9,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class LoginService {
 
-    private static final String imageUrl = "techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/ah-madda/woowa.png";
-
     private final MemberRepository memberRepository;
     private final GoogleOAuthProvider googleOAuthProvider;
     private final JwtTokenProvider jwtTokenProvider;
-    //TODO 07.25이후 사용하지않으면 삭제
-    private final OrganizationRepository organizationRepository;
-    private final OrganizationMemberRepository organizationMemberRepository;
 
     @Transactional
     public String login(final String code, final String redirectUri) {
         OAuthUserInfoResponse userInfo = googleOAuthProvider.getUserInfo(code, redirectUri);
 
         Member member = findOrCreateMember(userInfo.name(), userInfo.email());
-        addMemberToWoowacourse(member);
         return jwtTokenProvider.createToken(member.getId());
-    }
-
-    @Deprecated
-    @Transactional
-    //TODO 07.25 이후 리팩터링 및 제거하기
-    public void addMemberToWoowacourse(final Member member) {
-        Optional<Organization> findOrganization =
-                organizationRepository.findByName(OrganizationService.WOOWACOURSE_NAME);
-
-        Organization organization =
-                findOrganization.orElseGet(() -> organizationRepository.save(
-                        Organization.create(OrganizationService.WOOWACOURSE_NAME,
-                                            "우아한테크코스입니다",
-                                            imageUrl
-                        )
-                ));
-
-        Optional<OrganizationMember> existOrganizationMember =
-                organizationMemberRepository.findByOrganizationIdAndMemberId(organization.getId(), member.getId());
-
-        if (existOrganizationMember.isEmpty()) {
-            OrganizationMember organizationMember = OrganizationMember.create(member.getName(), member, organization);
-            OrganizationMember savedOrganizationMember = organizationMemberRepository.save(organizationMember);
-        }
     }
 
     private Member findOrCreateMember(final String name, final String email) {

--- a/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationMemberRepository.java
@@ -14,4 +14,11 @@ public interface OrganizationMemberRepository extends JpaRepository<Organization
                   and om.member.id = :memberId
             """)
     Optional<OrganizationMember> findByOrganizationIdAndMemberId(final Long organizationId, final Long memberId);
+
+    @Query("""
+                select case when count(om) > 0 then true else false end
+                from OrganizationMember om
+                where om.organization.id = :organizationId and om.member.id = :memberId
+            """)
+    boolean existsByOrganizationAndMember(final Long organizationId, final Long memberId);
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -158,6 +158,22 @@ public class OrganizationController {
                                             """
                             )
                     )
+            ),
+            @ApiResponse(
+                    responseCode = "422",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unprocessable Entity",
+                                              "status": 422,
+                                              "detail": "이미 참여한 조직입니다.",
+                                              "instance": "/api/organizations/{organizationId}/participation"
+                                            }
+                                            """
+                            )
+                    )
             )
     })
     @PostMapping("/{organizationId}/participation")

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -1,15 +1,5 @@
 package com.ahmadda.presentation;
 
-import java.net.URI;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.ahmadda.application.OrganizationService;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.OrganizationCreateRequest;
@@ -18,7 +8,6 @@ import com.ahmadda.presentation.dto.OrganizationCreateResponse;
 import com.ahmadda.presentation.dto.OrganizationResponse;
 import com.ahmadda.presentation.dto.ParticipateRequestDto;
 import com.ahmadda.presentation.resolver.AuthMember;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -27,6 +16,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @Tag(name = "Organization", description = "조직 관련 API")
 @RestController
@@ -180,7 +178,7 @@ public class OrganizationController {
     public ResponseEntity<OrganizationResponse> participateOrganization(
             @PathVariable final Long organizationId,
             @AuthMember final LoginMember loginMember,
-            @RequestBody final ParticipateRequestDto participateRequestDto
+            @Valid @RequestBody final ParticipateRequestDto participateRequestDto
     ) {
         organizationService.participateOrganization(organizationId, loginMember, participateRequestDto);
 

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -57,7 +57,7 @@ public class OrganizationController {
         return ResponseEntity.ok(organizationResponse);
     }
 
-    @PostMapping("/{organizationId}/participate")
+    @PostMapping("/{organizationId}/participation")
     public ResponseEntity<OrganizationResponse> participateOrganization(
             @PathVariable final Long organizationId,
             @AuthMember final LoginMember loginMember,
@@ -68,5 +68,4 @@ public class OrganizationController {
         return ResponseEntity.ok()
                 .build();
     }
-
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -1,22 +1,7 @@
 package com.ahmadda.presentation;
 
-import com.ahmadda.application.OrganizationService;
-import com.ahmadda.application.dto.LoginMember;
-import com.ahmadda.application.dto.OrganizationCreateRequest;
-import com.ahmadda.domain.Organization;
-import com.ahmadda.presentation.dto.OrganizationCreateResponse;
-import com.ahmadda.presentation.dto.OrganizationResponse;
-import com.ahmadda.presentation.dto.ParticipateRequestDto;
-import com.ahmadda.presentation.resolver.AuthMember;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+import java.net.URI;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,7 +10,23 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
+import com.ahmadda.application.OrganizationService;
+import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.application.dto.OrganizationCreateRequest;
+import com.ahmadda.domain.Organization;
+import com.ahmadda.presentation.dto.OrganizationCreateResponse;
+import com.ahmadda.presentation.dto.OrganizationResponse;
+import com.ahmadda.presentation.dto.ParticipateRequestDto;
+import com.ahmadda.presentation.resolver.AuthMember;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Organization", description = "조직 관련 API")
 @RestController
@@ -37,16 +38,9 @@ public class OrganizationController {
 
     @Operation(summary = "신규 조직 생성", description = "새로운 조직을 생성합니다.")
     @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "201",
-                    description = "조직 생성 성공",
-                    content = @Content(
-                            schema = @Schema(implementation = OrganizationCreateResponse.class)
-                    )
-            ),
+            @ApiResponse(responseCode = "201"),
             @ApiResponse(
                     responseCode = "400",
-                    description = "잘못된 요청",
                     content = @Content(
                             examples = @ExampleObject(
                                     value = """
@@ -54,7 +48,23 @@ public class OrganizationController {
                                               "type": "about:blank",
                                               "title": "Bad Request",
                                               "status": 400,
-                                              "detail": "Invalid request content.",
+                                              "detail": "이름은 공백이면 안됩니다.",
+                                              "instance": "/api/organizations"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "422",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unprocessable Entity",
+                                              "status": 422,
+                                              "detail": "이름의 길이는 2자 이상 20자 이하이어야 합니다.",
                                               "instance": "/api/organizations"
                                             }
                                             """
@@ -74,16 +84,9 @@ public class OrganizationController {
 
     @Operation(summary = "조직 정보 조회", description = "조직 ID로 특정 조직의 정보를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "OK",
-                    content = @Content(
-                            schema = @Schema(implementation = OrganizationResponse.class)
-                    )
-            ),
+            @ApiResponse(responseCode = "200"),
             @ApiResponse(
                     responseCode = "404",
-                    description = "존재하지 않는 조직",
                     content = @Content(
                             examples = @ExampleObject(
                                     value = """
@@ -111,12 +114,7 @@ public class OrganizationController {
     @Deprecated
     @Operation(summary = "우아코스 조직 정보 조회 (임시)", description = "항상 우아코스 조직 정보를 반환하는 임시 API입니다. 추후 제거될 예정입니다.")
     @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    content = @Content(
-                            schema = @Schema(implementation = OrganizationResponse.class)
-                    )
-            )
+            @ApiResponse(responseCode = "200")
     })
     @GetMapping("/woowacourse")
     public ResponseEntity<OrganizationResponse> getOrganization() {
@@ -128,13 +126,9 @@ public class OrganizationController {
 
     @Operation(summary = "조직 참여", description = "사용자가 특정 조직에 참여합니다.")
     @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "OK"
-            ),
+            @ApiResponse(responseCode = "200"),
             @ApiResponse(
                     responseCode = "401",
-                    description = "Unauthorized",
                     content = @Content(
                             examples = @ExampleObject(
                                     value = """
@@ -151,7 +145,6 @@ public class OrganizationController {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "Not Found",
                     content = @Content(
                             examples = @ExampleObject(
                                     value = """

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -8,6 +8,12 @@ import com.ahmadda.presentation.dto.OrganizationCreateResponse;
 import com.ahmadda.presentation.dto.OrganizationResponse;
 import com.ahmadda.presentation.dto.ParticipateRequestDto;
 import com.ahmadda.presentation.resolver.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +35,33 @@ public class OrganizationController {
 
     private final OrganizationService organizationService;
 
+    @Operation(summary = "신규 조직 생성", description = "새로운 조직을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "조직 생성 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = OrganizationCreateResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Bad Request",
+                                              "status": 400,
+                                              "detail": "Invalid request content.",
+                                              "instance": "/api/organizations"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @PostMapping
     public ResponseEntity<OrganizationCreateResponse> createOrganization(
             @RequestBody @Valid final OrganizationCreateRequest organizationCreateRequest
@@ -39,6 +72,33 @@ public class OrganizationController {
                 .body(new OrganizationCreateResponse(organization.getId()));
     }
 
+    @Operation(summary = "조직 정보 조회", description = "조직 ID로 특정 조직의 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "OK",
+                    content = @Content(
+                            schema = @Schema(implementation = OrganizationResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 조직",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Not Found",
+                                              "status": 404,
+                                              "detail": "존재하지 않는 조직입니다.",
+                                              "instance": "/api/organizations/{organizationId}"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/{organizationId}")
     public ResponseEntity<OrganizationResponse> readOrganization(@PathVariable final Long organizationId) {
         Organization organization = organizationService.getOrganization(organizationId);
@@ -49,6 +109,15 @@ public class OrganizationController {
 
     //TODO 07.25 이후 리팩터링 및 제거하기
     @Deprecated
+    @Operation(summary = "우아코스 조직 정보 조회 (임시)", description = "항상 우아코스 조직 정보를 반환하는 임시 API입니다. 추후 제거될 예정입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    content = @Content(
+                            schema = @Schema(implementation = OrganizationResponse.class)
+                    )
+            )
+    })
     @GetMapping("/woowacourse")
     public ResponseEntity<OrganizationResponse> getOrganization() {
         Organization organization = organizationService.alwaysGetWoowacourse();
@@ -57,6 +126,47 @@ public class OrganizationController {
         return ResponseEntity.ok(organizationResponse);
     }
 
+    @Operation(summary = "조직 참여", description = "사용자가 특정 조직에 참여합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "OK"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/organizations/{organizationId}/participation"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Not Found",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Not Found",
+                                              "status": 404,
+                                              "detail": "존재하지 않는 조직입니다.",
+                                              "instance": "/api/organizations/{organizationId}/participation"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @PostMapping("/{organizationId}/participation")
     public ResponseEntity<OrganizationResponse> participateOrganization(
             @PathVariable final Long organizationId,

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -1,10 +1,13 @@
 package com.ahmadda.presentation;
 
 import com.ahmadda.application.OrganizationService;
+import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.OrganizationCreateRequest;
 import com.ahmadda.domain.Organization;
 import com.ahmadda.presentation.dto.OrganizationCreateResponse;
 import com.ahmadda.presentation.dto.OrganizationResponse;
+import com.ahmadda.presentation.dto.ParticipateRequestDto;
+import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -53,4 +56,17 @@ public class OrganizationController {
 
         return ResponseEntity.ok(organizationResponse);
     }
+
+    @PostMapping("/{organizationId}/participate")
+    public ResponseEntity<OrganizationResponse> participateOrganization(
+            @PathVariable final Long organizationId,
+            @AuthMember final LoginMember loginMember,
+            @RequestBody final ParticipateRequestDto participateRequestDto
+    ) {
+        organizationService.participateOrganization(organizationId, loginMember, participateRequestDto);
+
+        return ResponseEntity.ok()
+                .build();
+    }
+
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -77,6 +77,22 @@ public class OrganizationEventController {
                                             """
                             )
                     )
+            ),
+            @ApiResponse(
+                    responseCode = "422",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unprocessable Entity",
+                                              "status": 422,
+                                              "detail": "조직에 참여하지 않아 권한이 없습니다.",
+                                              "instance": "/api/organizations/{organizationId}/events"
+                                            }
+                                            """
+                            )
+                    )
             )
     })
     @GetMapping("/{organizationId}/events")
@@ -120,6 +136,22 @@ public class OrganizationEventController {
                                               "title": "Unauthorized",
                                               "status": 401,
                                               "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Forbidden",
+                                              "status": 403,
+                                              "detail": "조직에 소속되지 않은 멤버입니다.",
                                               "instance": "/api/organizations/{organizationId}/events"
                                             }
                                             """
@@ -188,7 +220,7 @@ public class OrganizationEventController {
                                               "type": "about:blank",
                                               "title": "Not Found",
                                               "status": 404,
-                                              "detail": "존재하지 않는 이벤트입니다.",
+                                              "detail": "존재하지 않은 이벤트 정보입니다.",
                                               "instance": "/api/organizations/events/{eventId}"
                                             }
                                             """
@@ -231,7 +263,7 @@ public class OrganizationEventController {
                                               "type": "about:blank",
                                               "title": "Not Found",
                                               "status": 404,
-                                              "detail": "존재하지 않는 조직입니다.",
+                                              "detail": "존재하지 않은 조직원 정보입니다.",
                                               "instance": "/api/organizations/{organizationId}/events/owned"
                                             }
                                             """
@@ -281,7 +313,7 @@ public class OrganizationEventController {
                                               "type": "about:blank",
                                               "title": "Not Found",
                                               "status": 404,
-                                              "detail": "존재하지 않는 조직입니다.",
+                                              "detail": "존재하지 않은 조직원 정보입니다.",
                                               "instance": "/api/organizations/{organizationId}/events/participated"
                                             }
                                             """

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -36,8 +36,9 @@ public class OrganizationEventController {
     private final EventService eventService;
 
     @GetMapping("/{organizationId}/events")
-    public ResponseEntity<List<EventResponse>> getOrganizationEvents(@PathVariable final Long organizationId) {
-        List<Event> organizationEvents = organizationService.getOrganizationEvents(organizationId);
+    public ResponseEntity<List<EventResponse>> getOrganizationEvents(@PathVariable final Long organizationId,
+                                                                     @AuthMember final LoginMember loginMember) {
+        List<Event> organizationEvents = organizationService.getOrganizationEvents(organizationId, loginMember);
 
         List<EventResponse> eventResponses = organizationEvents.stream()
                 .map(EventResponse::from)

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -11,6 +11,13 @@ import com.ahmadda.presentation.dto.EventCreateResponse;
 import com.ahmadda.presentation.dto.EventDetailResponse;
 import com.ahmadda.presentation.dto.EventResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,8 +44,11 @@ public class OrganizationEventController {
     private final EventService eventService;
 
     @GetMapping("/{organizationId}/events")
-    public ResponseEntity<List<EventResponse>> getOrganizationEvents(@PathVariable final Long organizationId) {
-        List<Event> organizationEvents = organizationService.getOrganizationEvents(organizationId);
+    public ResponseEntity<List<EventResponse>> getOrganizationEvents(
+            @PathVariable final Long organizationId,
+            @AuthMember final LoginMember loginMember
+    ) {
+        List<Event> organizationEvents = organizationService.getOrganizationEvents(organizationId, loginMember);
 
         List<EventResponse> eventResponses = organizationEvents.stream()
                 .map(EventResponse::from)

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -1,6 +1,18 @@
 package com.ahmadda.presentation;
 
 
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.ahmadda.application.EventService;
 import com.ahmadda.application.OrganizationMemberEventService;
 import com.ahmadda.application.OrganizationService;
@@ -11,20 +23,15 @@ import com.ahmadda.presentation.dto.EventCreateResponse;
 import com.ahmadda.presentation.dto.EventDetailResponse;
 import com.ahmadda.presentation.dto.EventResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.net.URI;
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Tag(name = "Organization Event", description = "조직 이벤트 관련 API")
 @RestController
@@ -36,6 +43,42 @@ public class OrganizationEventController {
     private final OrganizationMemberEventService organizationMemberEventService;
     private final EventService eventService;
 
+    @Operation(summary = "조직 이벤트 목록 조회", description = "특정 조직의 모든 이벤트 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Not Found",
+                                              "status": 404,
+                                              "detail": "존재하지 않는 조직입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/{organizationId}/events")
     public ResponseEntity<List<EventResponse>> getOrganizationEvents(@PathVariable final Long organizationId,
                                                                      @AuthMember final LoginMember loginMember) {
@@ -48,6 +91,74 @@ public class OrganizationEventController {
         return ResponseEntity.ok(eventResponses);
     }
 
+    @Operation(summary = "조직 이벤트 생성", description = "특정 조직에서 새로운 이벤트를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(
+                    responseCode = "400",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Bad Request",
+                                              "status": 400,
+                                              "detail": "제목은 공백이면 안됩니다.",
+                                              "instance": "/api/organizations/{organizationId}/events"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Not Found",
+                                              "status": 404,
+                                              "detail": "존재하지 않는 조직입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "422",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unprocessable Entity",
+                                              "status": 422,
+                                              "detail": "자신이 속한 조직에서만 이벤트를 생성할 수 있습니다.",
+                                              "instance": "/api/organizations/{organizationId}/events"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @PostMapping("/{organizationId}/events")
     public ResponseEntity<EventCreateResponse> createOrganizationEvent(
             @PathVariable final Long organizationId,
@@ -65,6 +176,26 @@ public class OrganizationEventController {
                 .body(new EventCreateResponse(event.getId()));
     }
 
+    @Operation(summary = "이벤트 상세 조회", description = "이벤트 ID로 특정 이벤트의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Not Found",
+                                              "status": 404,
+                                              "detail": "존재하지 않는 이벤트입니다.",
+                                              "instance": "/api/organizations/events/{eventId}"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/events/{eventId}")
     public ResponseEntity<EventDetailResponse> getOrganizationEvent(@PathVariable final Long eventId) {
         Event event = eventService.getEvent(eventId);
@@ -72,6 +203,42 @@ public class OrganizationEventController {
         return ResponseEntity.ok(EventDetailResponse.from(event));
     }
 
+    @Operation(summary = "내가 주최한 이벤트 목록 조회", description = "로그인한 사용자가 주최한 이벤트 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events/owned"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Not Found",
+                                              "status": 404,
+                                              "detail": "존재하지 않는 조직입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events/owned"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/{organizationId}/events/owned")
     public ResponseEntity<List<EventResponse>> getOwnerEvents(
             @PathVariable final Long organizationId,
@@ -86,6 +253,42 @@ public class OrganizationEventController {
         return ResponseEntity.ok(eventResponses);
     }
 
+    @Operation(summary = "내가 참가한 이벤트 목록 조회", description = "로그인한 사용자가 참가한 이벤트 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events/participated"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Not Found",
+                                              "status": 404,
+                                              "detail": "존재하지 않는 조직입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events/participated"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/{organizationId}/events/participated")
     public ResponseEntity<List<EventResponse>> getParticipantEvents(
             @PathVariable final Long organizationId,

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "OrganizationMember", description = "조직원 관련 API")
+@Tag(name = "Organization Member", description = "조직원 관련 API")
 @RestController
 @RequestMapping("/api/organizations")
 @RequiredArgsConstructor
@@ -31,6 +31,7 @@ public class OrganizationMemberController {
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
+                    description = "OK",
                     content = @Content(
                             schema = @Schema(
                                     implementation = OrganizationMemberResponse.class
@@ -39,6 +40,7 @@ public class OrganizationMemberController {
             ),
             @ApiResponse(
                     responseCode = "401",
+                    description = "Unauthorized",
                     content = @Content(
                             examples = @ExampleObject(
                                     value = """
@@ -55,6 +57,7 @@ public class OrganizationMemberController {
             ),
             @ApiResponse(
                     responseCode = "404",
+                    description = "Not Found",
                     content = @Content(
                             examples = @ExampleObject(
                                     value = """

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
@@ -1,23 +1,24 @@
 package com.ahmadda.presentation;
 
-import com.ahmadda.application.OrganizationMemberService;
-import com.ahmadda.application.dto.LoginMember;
-import com.ahmadda.domain.OrganizationMember;
-import com.ahmadda.presentation.dto.OrganizationMemberResponse;
-import com.ahmadda.presentation.resolver.AuthMember;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.ahmadda.application.OrganizationMemberService;
+import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.presentation.dto.OrganizationMemberResponse;
+import com.ahmadda.presentation.resolver.AuthMember;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Organization Member", description = "조직원 관련 API")
 @RestController
@@ -29,18 +30,9 @@ public class OrganizationMemberController {
 
     @Operation(summary = "자신의 조직원 프로필 조회", description = "로그인한 사용자가 속한 조직에서의 자신의 정보를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "OK",
-                    content = @Content(
-                            schema = @Schema(
-                                    implementation = OrganizationMemberResponse.class
-                            )
-                    )
-            ),
+            @ApiResponse(responseCode = "200"),
             @ApiResponse(
                     responseCode = "401",
-                    description = "Unauthorized",
                     content = @Content(
                             examples = @ExampleObject(
                                     value = """
@@ -57,7 +49,6 @@ public class OrganizationMemberController {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "Not Found",
                     content = @Content(
                             examples = @ExampleObject(
                                     value = """

--- a/server/src/main/java/com/ahmadda/presentation/dto/ParticipateRequestDto.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/ParticipateRequestDto.java
@@ -1,5 +1,9 @@
 package com.ahmadda.presentation.dto;
 
-public record ParticipateRequestDto(String nickname) {
+import jakarta.validation.constraints.NotBlank;
+
+public record ParticipateRequestDto(
+        @NotBlank String nickname
+) {
 
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/ParticipateRequestDto.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/ParticipateRequestDto.java
@@ -1,0 +1,5 @@
+package com.ahmadda.presentation.dto;
+
+public record ParticipateRequestDto(String nickname) {
+
+}

--- a/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
@@ -2,7 +2,6 @@ package com.ahmadda.application;
 
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
-import com.ahmadda.domain.Organization;
 import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.infra.jwt.JwtTokenProvider;
@@ -15,7 +14,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -86,55 +84,5 @@ class LoginServiceTest {
 
         // then
         assertThat(memberRepository.count()).isEqualTo(1);
-    }
-
-    @Test
-    void 조직에_회원을_성공적으로_등록한다() {
-        // given
-        var member = Member.create("테스트멤버", "test@test.com");
-        memberRepository.save(member);
-
-        var organization = Organization.create(OrganizationService.WOOWACOURSE_NAME, "우아한테크코스 설명", "http://image.url");
-        organizationRepository.save(organization);
-
-        // when
-        sut.addMemberToWoowacourse(member);
-
-        // then
-        var foundOrganization = organizationRepository.findByName(OrganizationService.WOOWACOURSE_NAME)
-                .orElseThrow();
-        var foundOrganizationMember =
-                organizationMemberRepository.findByOrganizationIdAndMemberId(foundOrganization.getId(), member.getId())
-                        .orElseThrow();
-
-        assertSoftly(softly -> {
-            softly.assertThat(foundOrganizationMember)
-                    .isNotNull();
-            softly.assertThat(foundOrganizationMember.getMember())
-                    .isEqualTo(member);
-            softly.assertThat(foundOrganizationMember.getOrganization())
-                    .isEqualTo(foundOrganization);
-            softly.assertThat(foundOrganization.getOrganizationMembers())
-                    .contains(foundOrganizationMember);
-        });
-    }
-
-    @Test
-    void 이미_등록된_회원이면_조직에_다시_등록하지_않는다() {
-        // given
-        var member = Member.create("테스트멤버", "test@test.com");
-        memberRepository.save(member);
-
-        // 최초 등록
-        sut.addMemberToWoowacourse(member);
-
-        // when
-        sut.addMemberToWoowacourse(member);
-
-        // then
-        var foundOrganization =
-                organizationRepository.findByName(OrganizationService.WOOWACOURSE_NAME)
-                        .orElseThrow();
-        assertThat(foundOrganization.getOrganizationMembers()).hasSize(1);
     }
 }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #217 

## 체크리스트
- 참여 기능 구현을 한다
- restapi 설계, 객체지향을 고려한다
- swagger 적용했는지 확인한다
- 테스트 작성했는지 확인한다
- 전체 테스트 돌렸는지 확인한다

## ✨ 작업 내용

- 조직 참여 api 추가
- 누락된 스웨거 명세서 추가
  - 에러 메시지 동일한가
  - response 부분에서 description은 OK 정도로만 작성
  
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
<img width="415" height="53" alt="image" src="https://github.com/user-attachments/assets/93e19a3c-211a-4e46-9338-dc59b462984a" />

## 🙏 기타 참고 사항
- 로그인시에 우아코스에 등록하던 로직 삭제(우아코스 조회시에는 우아코스 생성하는 로직은 살림 - 혹시 몰라서)
- 조직 이벤트 조회시에 조직원인지 확인하는 로직을 추가하였습니다 @abc5259 
- OrganizationMemberRepository existsByOrganizationAndMember에 성능을 고려한 쿼리를 작성하였습니다 
<!-- 없다면 적지 않으셔도 됩니다. -->
