### PR TITLE
[FE] 이벤트 생성 폼 입력 필드 간소화

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -23,6 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 
-.env
+.env*
 *storybook.log
 storybook-static

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -1,11 +1,12 @@
 import { css } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
 
-import { Button } from '../../../../shared/components/Button';
-import { Card } from '../../../../shared/components/Card';
-import { Flex } from '../../../../shared/components/Flex';
-import { Input } from '../../../../shared/components/Input';
-import { Text } from '../../../../shared/components/Text';
+import { Button } from '@/shared/components/Button';
+import { Card } from '@/shared/components/Card';
+import { Flex } from '@/shared/components/Flex';
+import { Input } from '@/shared/components/Input';
+import { Text } from '@/shared/components/Text';
+
 import { useAddEvent } from '../hooks/useAddEvent';
 import { useEventForm } from '../hooks/useEventForm';
 import { convertToISOString } from '../utils/convertToISOString';

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -14,6 +14,7 @@ import { convertToISOString } from '../utils/convertToISOString';
 import { QuestionForm } from './QuestionForm';
 
 const ORGANIZATION_ID = 1; // 임시
+const ORGANIZER_NICKNAME = '임시닉네임'; // 추후 유저 설정 닉네임으로 대체
 
 export const EventCreateForm = () => {
   const navigate = useNavigate();
@@ -29,6 +30,7 @@ export const EventCreateForm = () => {
       eventStart: convertToISOString(formData.eventStart),
       eventEnd: convertToISOString(formData.eventEnd),
       registrationEnd: convertToISOString(formData.registrationEnd),
+      organizerNickname: ORGANIZER_NICKNAME,
     };
 
     addEvent(payload, {
@@ -99,23 +101,14 @@ export const EventCreateForm = () => {
               onChange={handleChange('description')}
             />
 
-            <Flex gap="16px">
-              <Input
-                id="author"
-                label="주최자 이름"
-                placeholder="주최자 이름을 입력해 주세요"
-                value={formData.organizerNickname}
-                onChange={handleChange('organizerNickname')}
-              />
-              <Input
-                id="maxCapacity"
-                label="수용 인원"
-                placeholder="최대 참가 인원을 입력해 주세요"
-                type="number"
-                value={formData.maxCapacity.toString()}
-                onChange={handleChange('maxCapacity')}
-              />
-            </Flex>
+            <Input
+              id="maxCapacity"
+              label="수용 인원"
+              placeholder="최대 참가 인원을 입력해 주세요"
+              type="number"
+              value={formData.maxCapacity.toString()}
+              onChange={handleChange('maxCapacity')}
+            />
           </Flex>
         </Card>
 

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -28,7 +28,6 @@ export const EventCreateForm = () => {
       ...formData,
       eventStart: convertToISOString(formData.eventStart),
       eventEnd: convertToISOString(formData.eventEnd),
-      registrationStart: convertToISOString(formData.registrationStart),
       registrationEnd: convertToISOString(formData.registrationEnd),
     };
 
@@ -76,22 +75,13 @@ export const EventCreateForm = () => {
               />
             </Flex>
 
-            <Flex gap="16px">
-              <Input
-                id="registrationStart"
-                label="신청 시작 날짜/시간"
-                placeholder="2025.07.25 13:00"
-                value={formData.registrationStart}
-                onChange={handleChange('registrationStart')}
-              />
-              <Input
-                id="registrationEnd"
-                label="신청 종료 날짜/시간"
-                placeholder="2025.07.25 15:00"
-                value={formData.registrationEnd}
-                onChange={handleChange('registrationEnd')}
-              />
-            </Flex>
+            <Input
+              id="registrationEnd"
+              label="신청 종료 날짜/시간"
+              placeholder="2025.07.25 15:00"
+              value={formData.registrationEnd}
+              onChange={handleChange('registrationEnd')}
+            />
 
             <Input
               id="place"

--- a/client/src/features/Event/New/hooks/useEventForm.ts
+++ b/client/src/features/Event/New/hooks/useEventForm.ts
@@ -3,14 +3,13 @@ import { useState } from 'react';
 import type { CreateEventAPIRequest, QuestionRequest } from '@/features/Event/types/Event';
 
 export const useEventForm = () => {
-  const [formData, setFormData] = useState<CreateEventAPIRequest>({
+  const [formData, setFormData] = useState<Omit<CreateEventAPIRequest, 'organizerNickname'>>({
     title: '',
+    description: '',
+    place: '',
     eventStart: '',
     eventEnd: '',
     registrationEnd: '',
-    place: '',
-    description: '',
-    organizerNickname: '',
     maxCapacity: 0,
     questions: [],
   });

--- a/client/src/features/Event/New/hooks/useEventForm.ts
+++ b/client/src/features/Event/New/hooks/useEventForm.ts
@@ -7,7 +7,6 @@ export const useEventForm = () => {
     title: '',
     eventStart: '',
     eventEnd: '',
-    registrationStart: '',
     registrationEnd: '',
     place: '',
     description: '',

--- a/client/src/features/Event/Overview/components/EventCard.tsx
+++ b/client/src/features/Event/Overview/components/EventCard.tsx
@@ -14,7 +14,6 @@ export const EventCard = ({
   eventId,
   title,
   description,
-  registrationStart,
   registrationEnd,
   eventStart,
   eventEnd,
@@ -24,6 +23,7 @@ export const EventCard = ({
   maxCapacity,
 }: Event) => {
   const navigate = useNavigate();
+  const isRegistrationOpen = new Date(registrationEnd) > new Date();
 
   return (
     <CardWrapper onClick={() => navigate(`/event/${eventId}`)}>
@@ -32,8 +32,8 @@ export const EventCard = ({
           <Text type="Title" color="#ffffff" weight="semibold">
             {title}
           </Text>
-          <Badge isRegistrationOpen={new Date(registrationStart) < new Date()}>
-            {new Date(registrationStart) > new Date() ? '모집전' : '모집중'}
+          <Badge isRegistrationOpen={isRegistrationOpen}>
+            {isRegistrationOpen ? '모집중' : '모집마감'}
           </Badge>
         </Flex>
         <Text type="caption" color="#99A1AF">

--- a/client/src/features/Event/types/Event.ts
+++ b/client/src/features/Event/types/Event.ts
@@ -34,7 +34,6 @@ export type CreateEventAPIRequest = {
   maxCapacity: number;
   eventStart: string;
   eventEnd: string;
-  registrationStart: string;
   registrationEnd: string;
   organizerNickname: string;
   questions: QuestionRequest[];

--- a/client/webpack.config.cjs
+++ b/client/webpack.config.cjs
@@ -3,70 +3,74 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { DefinePlugin } = require('webpack');
 const Dotenv = require('dotenv-webpack');
 
-module.exports = {
-  mode: 'development',
-  entry: './src/main.tsx',
-  output: {
-    filename: 'bundle.js',
-    path: path.resolve(__dirname, 'dist'),
-    publicPath: '/',
-    clean: true,
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: './index.html',
-      filename: 'index.html',
-      inject: true,
-    }),
-    new DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('development'),
-      VERSION: JSON.stringify('1.0.0'),
-      __DEV__: JSON.stringify(true),
-    }),
-    new Dotenv({
-      path: path.resolve(__dirname, '.env'),
-      safe: true,
-    }),
-  ],
-  module: {
-    rules: [
-      {
-        test: /\.(ts|tsx)$/,
-        use: ['babel-loader'],
-        exclude: /node_modules/,
-      },
-      {
-        test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
-      },
-      {
-        test: /\.svg$/,
-        issuer: /\.[jt]sx?$/,
-        use: ['@svgr/webpack'],
-      },
-      {
-        test: /\.(png|jpg|jpeg|gif|webp)$/i,
-        type: 'asset',
-      },
-    ],
-  },
+module.exports = (env, argv) => {
+  const mode = argv.mode || 'development';
+  const isDev = mode === 'development';
 
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src/'),
+  return {
+    mode,
+    entry: './src/main.tsx',
+    output: {
+      filename: 'bundle.js',
+      path: path.resolve(__dirname, 'dist'),
+      publicPath: '/',
+      clean: true,
     },
-    extensions: ['.ts', '.tsx', '.js'],
-  },
-  devServer: {
-    static: {
-      directory: path.join(__dirname, 'dist'),
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: './index.html',
+        filename: 'index.html',
+        inject: true,
+      }),
+      new DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify(mode),
+        VERSION: JSON.stringify('1.0.0'),
+        __DEV__: JSON.stringify(isDev),
+      }),
+      new Dotenv({
+        path: path.resolve(__dirname, `.env.${mode}`),
+        safe: true,
+      }),
+    ],
+    module: {
+      rules: [
+        {
+          test: /\.(ts|tsx)$/,
+          use: ['babel-loader'],
+          exclude: /node_modules/,
+        },
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader'],
+        },
+        {
+          test: /\.svg$/,
+          issuer: /\.[jt]sx?$/,
+          use: ['@svgr/webpack'],
+        },
+        {
+          test: /\.(png|jpg|jpeg|gif|webp)$/i,
+          type: 'asset',
+        },
+      ],
     },
-    port: 5173,
-    open: true,
-    hot: true,
-    historyApiFallback: true,
-    client: {
-      overlay: true,
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src/'),
+      },
+      extensions: ['.ts', '.tsx', '.js'],
     },
-  },
+    devServer: {
+      static: {
+        directory: path.join(__dirname, 'dist'),
+      },
+      port: 5173,
+      open: true,
+      hot: true,
+      historyApiFallback: true,
+      client: {
+        overlay: true,
+      },
+    },
+  };
 };


### PR DESCRIPTION
## 관련 이슈

close #233 

## ✨ 작업 내용

이벤트 생성 폼의 입력 필드를 간소화하였습니다.

1. 이벤트 신청 시작 시간 필드 제거
- 신청 시작 시간은 별도로 받지 않고, 이벤트가 등록된 시점을 기준으로 신청 가능하다고 간주합니다.
- 따라서, 이벤트가 생성된 이후부터 신청 마감 시점까지 신청할 수 있습니다.

2. 이벤트 주최자 입력 필드 제거
- 주최자 이름은 사용자가 조직에 가입할 때 설정한 닉네임으로 자동 설정됩니다.
- 현재 닉네임 설정 기능이 구현되지 않았기 때문에, 일단 '임시닉네임'이라는 고정 값이 API 요청 시 전달되도록 설정하였습니다.

## 🙏 기타 참고 사항

<img width="713" height="804" alt="image" src="https://github.com/user-attachments/assets/852ba0ce-e6c3-4117-bbf2-91a93e20787a" />

