### PR TITLE
[FE] release 브랜치에서도 ci workflow가 실행되도록 설정

### DIFF
--- a/.github/workflows/fe-ci-closed-prs.yml
+++ b/.github/workflows/fe-ci-closed-prs.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - fe/dev
+      - release*
 
 defaults:
   run:


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #228

## ✨ 작업 내용

- pull_request 대상 브랜치에 release* 추가하여 release 브랜치 pr에서도 CI가 실행되도록 수정했습니다. 
