### PR TITLE
[BE] 이벤트 게스트 조회, 비게스트 조회 주최자 유효성 제거

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -35,7 +35,7 @@ public class EventGuestService {
     public List<Guest> getGuests(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
         Organization organization = event.getOrganization();
-        validateAccessToOrganization(loginMember, organization);
+        validateOrganizationAccess(loginMember, organization);
 
         return event.getGuests();
     }
@@ -43,7 +43,7 @@ public class EventGuestService {
     public List<OrganizationMember> getNonGuestOrganizationMembers(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
         Organization organization = event.getOrganization();
-        validateAccessToOrganization(loginMember, organization);
+        validateOrganizationAccess(loginMember, organization);
 
         List<OrganizationMember> allMembers = organization.getOrganizationMembers();
 
@@ -77,7 +77,7 @@ public class EventGuestService {
         return event.hasGuest(organizationMember);
     }
 
-    private void validateAccessToOrganization(final LoginMember loginMember, final Organization organization) {
+    private void validateOrganizationAccess(final LoginMember loginMember, final Organization organization) {
         if (!organizationMemberRepository.existsByOrganizationIdAndMemberId(
                 organization.getId(),
                 loginMember.memberId()

--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -9,8 +9,6 @@ import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventRepository;
 import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.GuestRepository;
-import com.ahmadda.domain.Member;
-import com.ahmadda.domain.MemberRepository;
 import com.ahmadda.domain.Organization;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
@@ -33,20 +31,20 @@ public class EventGuestService {
     private final EventRepository eventRepository;
     private final QuestionRepository questionRepository;
     private final OrganizationMemberRepository organizationMemberRepository;
-    private final MemberRepository memberRepository;
 
     public List<Guest> getGuests(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
-        validateOrganizer(event, loginMember.memberId());
+        Organization organization = event.getOrganization();
+        validateAccessToOrganization(loginMember, organization);
 
         return event.getGuests();
     }
 
     public List<OrganizationMember> getNonGuestOrganizationMembers(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
-        validateOrganizer(event, loginMember.memberId());
-
         Organization organization = event.getOrganization();
+        validateAccessToOrganization(loginMember, organization);
+
         List<OrganizationMember> allMembers = organization.getOrganizationMembers();
 
         return event.getNonGuestOrganizationMembers(allMembers);
@@ -79,18 +77,18 @@ public class EventGuestService {
         return event.hasGuest(organizationMember);
     }
 
+    private void validateAccessToOrganization(final LoginMember loginMember, final Organization organization) {
+        if (!organizationMemberRepository.existsByOrganizationIdAndMemberId(
+                organization.getId(),
+                loginMember.memberId()
+        )) {
+            throw new AccessDeniedException("조직의 조직원만 접근할 수 있습니다.");
+        }
+    }
+
     private Event getEvent(final Long eventId) {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 이벤트입니다."));
-    }
-
-    private void validateOrganizer(final Event event, final Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));
-
-        if (!event.isOrganizer(member)) {
-            throw new AccessDeniedException("이벤트 주최자가 아닙니다.");
-        }
     }
 
     private OrganizationMember getOrganizationMember(final Long organizationId, final Long memberId) {

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -39,7 +39,7 @@ public class EventService {
             final LocalDateTime currentDateTime
     ) {
         Organization organization = getOrganization(organizationId);
-        OrganizationMember organizer = validateAccessToOrganization(organizationId, memberId);
+        OrganizationMember organizer = validateOrganizationAccess(organizationId, memberId);
 
         EventOperationPeriod eventOperationPeriod = createEventOperationPeriod(eventCreateRequest, currentDateTime);
         Event event = Event.create(
@@ -81,7 +81,7 @@ public class EventService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않은 조직 정보입니다."));
     }
 
-    private OrganizationMember validateAccessToOrganization(final Long organizationId, final Long memberId) {
+    private OrganizationMember validateOrganizationAccess(final Long organizationId, final Long memberId) {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));
 

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -1,16 +1,5 @@
 package com.ahmadda.presentation;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.ahmadda.application.EventGuestService;
 import com.ahmadda.application.EventService;
 import com.ahmadda.application.dto.EventParticipateRequest;
@@ -23,7 +12,6 @@ import com.ahmadda.presentation.dto.GuestResponse;
 import com.ahmadda.presentation.dto.GuestStatusResponse;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -33,6 +21,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Tag(name = "Event Guest", description = "이벤트 게스트 관련 API")
 @RestController
@@ -94,7 +92,7 @@ public class EventGuestController {
                                               "type": "about:blank",
                                               "title": "Forbidden",
                                               "status": 403,
-                                              "detail": "이벤트 주최자가 아닙니다.",
+                                              "detail": "조직의 조직원만 접근할 수 있습니다.",
                                               "instance": "/api/events/{eventId}/guests"
                                             }
                                             """
@@ -167,7 +165,7 @@ public class EventGuestController {
                                               "type": "about:blank",
                                               "title": "Forbidden",
                                               "status": 403,
-                                              "detail": "이벤트 주최자가 아닙니다.",
+                                              "detail": "조직의 조직원만 접근할 수 있습니다.",
                                               "instance": "/api/events/{eventId}/non-guests"
                                             }
                                             """
@@ -362,7 +360,7 @@ public class EventGuestController {
                 LocalDateTime.now(),
                 eventParticipateRequest
         );
-        
+
         Event event = eventService.getEvent(eventId);
         return ResponseEntity.ok(EventDetailResponse.from(event));
     }

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -41,7 +41,7 @@ public class EventGuestController {
     private final EventGuestService eventGuestService;
     private final EventService eventService;
 
-    @Operation(summary = "이벤트 게스트 목록 조회", description = "해당 이벤트에 참여한 게스트 목록을 조회합니다. 주최자만 조회할 수 있습니다.")
+    @Operation(summary = "이벤트 게스트 목록 조회", description = "해당 이벤트에 참여한 게스트 목록을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
@@ -114,7 +114,7 @@ public class EventGuestController {
         return ResponseEntity.ok(responses);
     }
 
-    @Operation(summary = "이벤트 미참여 조직원 목록 조회", description = "해당 이벤트에 아직 참여하지 않은 조직원 목록을 조회합니다. 주최자만 조회할 수 있습니다.")
+    @Operation(summary = "이벤트 미참여 조직원 목록 조회", description = "해당 이벤트에 아직 참여하지 않은 조직원 목록을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -98,19 +98,20 @@ class EventGuestServiceTest {
     }
 
     @Test
-    void 주최자가_아닌_회원이_게스트_조회시_예외가_발생한다() {
+    void 이벤트가_생성된_조직의_조직원이_아닐때_게스트_조회시_예외가_발생한다() {
         // given
-        var organization = createAndSaveOrganization();
+        var organization1 = createAndSaveOrganization();
+        var organization2 = createAndSaveOrganization();
         var organizer =
-                createAndSaveOrganizationMember("주최자", createAndSaveMember("홍길동", "host@email.com"), organization);
+                createAndSaveOrganizationMember("주최자", createAndSaveMember("홍길동", "host@email.com"), organization1);
         var otherMember =
-                createAndSaveOrganizationMember("다른사람", createAndSaveMember("user", "user@email.com"), organization);
-        var event = createAndSaveEvent(organizer, organization);
+                createAndSaveOrganizationMember("다른사람", createAndSaveMember("user", "user@email.com"), organization2);
+        var event = createAndSaveEvent(organizer, organization1);
 
         // when // then
         assertThatThrownBy(() -> sut.getGuests(event.getId(), createLoginMember(otherMember)))
                 .isInstanceOf(AccessDeniedException.class)
-                .hasMessage("이벤트 주최자가 아닙니다.");
+                .hasMessage("조직의 조직원만 접근할 수 있습니다.");
     }
 
     @Test
@@ -152,19 +153,20 @@ class EventGuestServiceTest {
     }
 
     @Test
-    void 주최자가_아닌_회원이_비게스트_조회시_예외가_발생한다() {
+    void 이벤트가_생성된_조직의_조직원이_아닐때_비게스트_조회시_예외가_발생한다() {
         // given
-        var organization = createAndSaveOrganization();
+        var organization1 = createAndSaveOrganization();
+        var organization2 = createAndSaveOrganization();
         var organizer =
-                createAndSaveOrganizationMember("주최자", createAndSaveMember("홍길동", "host@email.com"), organization);
+                createAndSaveOrganizationMember("주최자", createAndSaveMember("홍길동", "host@email.com"), organization1);
         var otherMember =
-                createAndSaveOrganizationMember("다른사람", createAndSaveMember("user", "user@email.com"), organization);
-        var event = createAndSaveEvent(organizer, organization);
+                createAndSaveOrganizationMember("다른사람", createAndSaveMember("user", "user@email.com"), organization2);
+        var event = createAndSaveEvent(organizer, organization1);
 
         // when // then
         assertThatThrownBy(() -> sut.getNonGuestOrganizationMembers(event.getId(), createLoginMember(otherMember)))
                 .isInstanceOf(AccessDeniedException.class)
-                .hasMessage("이벤트 주최자가 아닙니다.");
+                .hasMessage("조직의 조직원만 접근할 수 있습니다.");
     }
 
     @Test
@@ -256,11 +258,12 @@ class EventGuestServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.participantEvent(event.getId(),
-                                                        member2.getId(),
-                                                        event.getRegistrationStart(),
-                                                        request
-                                   )
+                sut.participantEvent(
+                        event.getId(),
+                        member2.getId(),
+                        event.getRegistrationStart(),
+                        request
+                )
         )
                 .isInstanceOf(BusinessRuleViolatedException.class)
                 .hasMessageContaining("필수 질문에 대한 답변이 누락되었습니다");
@@ -284,11 +287,12 @@ class EventGuestServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.participantEvent(event.getId(),
-                                                        member2.getId(),
-                                                        event.getRegistrationStart(),
-                                                        request
-                                   )
+                sut.participantEvent(
+                        event.getId(),
+                        member2.getId(),
+                        event.getRegistrationStart(),
+                        request
+                )
         )
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("존재하지 않는 질문입니다.");


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #249 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
이벤트 게스트 조회, 비게스트 조회시 주최자 유효성 검증을 제거했습니다. 
조직의 조직원이 아닌 경우 유효성 검증을 추가해주었습니다.
스웨거 명세서 또한 변경해주었습니다.

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
이벤트 상세 조회시에도 이벤트에 참여한 조직원과 참여하지 않은 조직원을 조회하기 위해 주최자 검증을 제거해주었습니다.
