### PR TITLE
[BE] 조직원을 선택해서 알람을 보내는 기능 구현 

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventNotificationService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationService.java
@@ -54,7 +54,7 @@ public class EventNotificationService {
 
         List<OrganizationMember> recipients = resolveRecipients(event, request.organizationMemberIds());
         String subject = generateSubject(event);
-        
+
         sendNotificationToRecipients(recipients, subject, request.content());
     }
 
@@ -96,7 +96,7 @@ public class EventNotificationService {
             final Map<Long, OrganizationMember> organizationMembersById,
             final List<Long> requestedIds
     ) {
-        final boolean allExist = requestedIds.stream()
+        boolean allExist = requestedIds.stream()
                 .allMatch(organizationMembersById::containsKey);
 
         if (!allExist) {

--- a/server/src/main/java/com/ahmadda/application/EventNotificationService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationService.java
@@ -53,7 +53,7 @@ public class EventNotificationService {
         Event event = getEvent(eventId);
         validateOrganizer(event, loginMember.memberId());
 
-        List<OrganizationMember> recipients = resolveRecipients(event, request.organizationMemberIds());
+        List<OrganizationMember> recipients = getEventRecipientsFromIds(event, request.organizationMemberIds());
         String subject = generateSubject(event);
 
         sendNotificationToRecipients(recipients, subject, request.content());
@@ -73,7 +73,7 @@ public class EventNotificationService {
         }
     }
 
-    private List<OrganizationMember> resolveRecipients(
+    private List<OrganizationMember> getEventRecipientsFromIds(
             final Event event,
             final List<Long> organizationMemberIds
     ) {

--- a/server/src/main/java/com/ahmadda/application/EventNotificationService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationService.java
@@ -10,6 +10,7 @@ import com.ahmadda.domain.EventRepository;
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
 import com.ahmadda.domain.NotificationMailer;
+import com.ahmadda.domain.Organization;
 import com.ahmadda.domain.OrganizationMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -76,7 +77,7 @@ public class EventNotificationService {
             final Event event,
             final List<Long> organizationMemberIds
     ) {
-        Map<Long, OrganizationMember> organizationMembersById = getOrganizationMembersById(event);
+        Map<Long, OrganizationMember> organizationMembersById = getOrganizationMembersById(event.getOrganization());
         validateOrganizationMemberIdsExist(organizationMembersById, organizationMemberIds);
 
         return organizationMemberIds.stream()
@@ -85,8 +86,8 @@ public class EventNotificationService {
                 .toList();
     }
 
-    private Map<Long, OrganizationMember> getOrganizationMembersById(final Event event) {
-        return event.getOrganization()
+    private Map<Long, OrganizationMember> getOrganizationMembersById(final Organization organization) {
+        return organization
                 .getOrganizationMembers()
                 .stream()
                 .collect(Collectors.toMap(OrganizationMember::getId, Function.identity()));

--- a/server/src/main/java/com/ahmadda/application/dto/NonGuestsNotificationRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/NonGuestsNotificationRequest.java
@@ -2,7 +2,7 @@ package com.ahmadda.application.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record NotificationRequest(
+public record NonGuestsNotificationRequest(
         @NotBlank
         String content
 ) {

--- a/server/src/main/java/com/ahmadda/application/dto/SelectedOrganizationMembersNotificationRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/SelectedOrganizationMembersNotificationRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
 public record SelectedOrganizationMembersNotificationRequest(
+        // TODO. 추후 요청 Body 크기 자체를 제한하도록 변경
         @NotEmpty
         List<Long> organizationMemberIds,
 

--- a/server/src/main/java/com/ahmadda/application/dto/SelectedOrganizationMembersNotificationRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/SelectedOrganizationMembersNotificationRequest.java
@@ -1,0 +1,16 @@
+package com.ahmadda.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record SelectedOrganizationMembersNotificationRequest(
+        @NotEmpty
+        List<Long> organizationMemberIds,
+
+        @NotBlank
+        String content
+) {
+
+}

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -1,16 +1,5 @@
 package com.ahmadda.presentation;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.ahmadda.application.EventGuestService;
 import com.ahmadda.application.EventService;
 import com.ahmadda.application.dto.EventParticipateRequest;
@@ -23,7 +12,6 @@ import com.ahmadda.presentation.dto.GuestResponse;
 import com.ahmadda.presentation.dto.GuestStatusResponse;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -33,6 +21,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Tag(name = "Event Guest", description = "이벤트 게스트 관련 API")
 @RestController
@@ -201,7 +199,6 @@ public class EventGuestController {
             @ApiResponse(
                     responseCode = "401",
                     content = @Content(
-                            mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
                                             {
@@ -362,7 +359,7 @@ public class EventGuestController {
                 LocalDateTime.now(),
                 eventParticipateRequest
         );
-        
+
         Event event = eventService.getEvent(eventId);
         return ResponseEntity.ok(EventDetailResponse.from(event));
     }
@@ -380,7 +377,6 @@ public class EventGuestController {
             @ApiResponse(
                     responseCode = "401",
                     content = @Content(
-                            mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
                                             {

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
@@ -91,11 +91,82 @@ public class EventNotificationController {
         return ResponseEntity.ok()
                 .build();
     }
-    @PostMapping("/{eventId}/notify-members")
-    public ResponseEntity<Void> notifySelectedMembers(
-            @PathVariable final Long eventId,
-            @RequestBody @Valid final SelectedOrganizationMembersNotificationRequest request,
-            @AuthMember final LoginMember loginMember
+
+    @Operation(
+            summary = "선택된 조직원에게 알림 발송",
+            description = "주최자가 선택한 조직원들에게 이메일 알림을 발송합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/events/{eventId}/notify-organization-members"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Forbidden",
+                                              "status": 403,
+                                              "detail": "이벤트 주최자가 아닙니다.",
+                                              "instance": "/api/events/{eventId}/notify-organization-members"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "이벤트 없음",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 이벤트입니다.",
+                                                      "instance": "/api/events/{eventId}/notify-organization-members"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "조직원 없음",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 조직원입니다.",
+                                                      "instance": "/api/events/{eventId}/notify-organization-members"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+    })
+    @PostMapping("/{eventId}/notify-organization-members")
+    public ResponseEntity<Void> notifyOrganizationMembers(
+            @PathVariable Long eventId,
+            @RequestBody @Valid SelectedOrganizationMembersNotificationRequest request,
+            @AuthMember LoginMember loginMember
     ) {
         eventNotificationService.notifySelectedOrganizationMembers(eventId, request, loginMember);
 

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
@@ -1,17 +1,10 @@
 package com.ahmadda.presentation;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.ahmadda.application.EventNotificationService;
 import com.ahmadda.application.dto.LoginMember;
-import com.ahmadda.application.dto.NotificationRequest;
+import com.ahmadda.application.dto.NonGuestsNotificationRequest;
+import com.ahmadda.application.dto.SelectedOrganizationMembersNotificationRequest;
 import com.ahmadda.presentation.resolver.AuthMember;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -20,6 +13,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Event Notification", description = "이벤트 알림 관련 API")
 @RestController
@@ -84,10 +83,21 @@ public class EventNotificationController {
     @PostMapping("/{eventId}/notify-non-guests")
     public ResponseEntity<Void> notifyNonGuests(
             @PathVariable final Long eventId,
-            @RequestBody @Valid final NotificationRequest request,
+            @RequestBody @Valid final NonGuestsNotificationRequest request,
             @AuthMember final LoginMember loginMember
     ) {
         eventNotificationService.notifyNonGuestOrganizationMembers(eventId, request, loginMember);
+
+        return ResponseEntity.ok()
+                .build();
+    }
+    @PostMapping("/{eventId}/notify-members")
+    public ResponseEntity<Void> notifySelectedMembers(
+            @PathVariable final Long eventId,
+            @RequestBody @Valid final SelectedOrganizationMembersNotificationRequest request,
+            @AuthMember final LoginMember loginMember
+    ) {
+        eventNotificationService.notifySelectedOrganizationMembers(eventId, request, loginMember);
 
         return ResponseEntity.ok()
                 .build();

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
@@ -164,9 +164,9 @@ public class EventNotificationController {
     })
     @PostMapping("/{eventId}/notify-organization-members")
     public ResponseEntity<Void> notifyOrganizationMembers(
-            @PathVariable Long eventId,
-            @RequestBody @Valid SelectedOrganizationMembersNotificationRequest request,
-            @AuthMember LoginMember loginMember
+            @PathVariable final Long eventId,
+            @RequestBody @Valid final SelectedOrganizationMembersNotificationRequest request,
+            @AuthMember final LoginMember loginMember
     ) {
         eventNotificationService.notifySelectedOrganizationMembers(eventId, request, loginMember);
 

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -131,7 +131,6 @@ public class OrganizationEventController {
             @ApiResponse(
                     responseCode = "401",
                     content = @Content(
-                            mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
                                             {
@@ -148,7 +147,6 @@ public class OrganizationEventController {
             @ApiResponse(
                     responseCode = "403",
                     content = @Content(
-                            mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
                                             {
@@ -165,7 +163,6 @@ public class OrganizationEventController {
             @ApiResponse(
                     responseCode = "404",
                     content = @Content(
-                            mediaType = "application/json",
                             examples = {
                                     @ExampleObject(
                                             name = "조직 없음",
@@ -197,7 +194,6 @@ public class OrganizationEventController {
             @ApiResponse(
                     responseCode = "422",
                     content = @Content(
-                            mediaType = "application/json",
                             examples = {
                                     @ExampleObject(
                                             name = "이벤트 종료 시간이 시작 시간보다 과거",

--- a/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
@@ -230,7 +230,7 @@ class EventNotificationServiceTest {
     }
 
     @Test
-    void 존재하지_않는_이벤트로_선택_조직원_전송시_예외가_발생한다() {
+    void 존재하지_않는_이벤트로_알람_전송시_예외가_발생한다() {
         // given
         var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
         var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);

--- a/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
@@ -1,7 +1,8 @@
 package com.ahmadda.application;
 
 import com.ahmadda.application.dto.LoginMember;
-import com.ahmadda.application.dto.NotificationRequest;
+import com.ahmadda.application.dto.NonGuestsNotificationRequest;
+import com.ahmadda.application.dto.SelectedOrganizationMembersNotificationRequest;
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Event;
@@ -168,8 +169,159 @@ class EventNotificationServiceTest {
                 .hasMessage("이벤트 주최자가 아닙니다.");
     }
 
-    private NotificationRequest createNotificationRequest() {
-        return new NotificationRequest("이메일 내용입니다.");
+    @Test
+    void 선택된_조직원에게_이메일을_전송한다(CapturedOutput output) {
+        // given
+        var organizationName = "조직명";
+        var organizerNickname = "주최자";
+        var eventTitle = "이벤트제목";
+
+        var organization = organizationRepository.save(Organization.create(organizationName, "설명", "img.png"));
+        var organizer = createAndSaveOrganizationMember(organizerNickname, "host@email.com", organization);
+
+        var now = LocalDateTime.now();
+        var event = eventRepository.save(Event.create(
+                eventTitle,
+                "설명",
+                "장소",
+                organizer,
+                organization,
+                EventOperationPeriod.create(
+                        Period.create(now.minusDays(2), now.minusDays(1)),
+                        Period.create(now.plusDays(1), now.plusDays(2)),
+                        now.minusDays(3)
+                ),
+                organizerNickname,
+                100
+        ));
+
+        var om1 = createAndSaveOrganizationMember("선택1", "sel1@email.com", organization);
+        var om2 = createAndSaveOrganizationMember("선택2", "sel2@email.com", organization);
+        var om3 = createAndSaveOrganizationMember("비선택", "nsel@email.com", organization);
+
+        var request = createSelectedMembersRequest(
+                java.util.List.of(om1.getId(), om3.getId())
+        );
+
+        // when
+        sut.notifySelectedOrganizationMembers(event.getId(), request, createLoginMember(organizer));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(output)
+                    .contains("To: " + om1.getMember()
+                            .getEmail());
+            softly.assertThat(output)
+                    .contains("To: " + om3.getMember()
+                            .getEmail());
+            softly.assertThat(output)
+                    .doesNotContain("To: " + om2.getMember()
+                            .getEmail());
+            softly.assertThat(output)
+                    .contains("Subject: " + String.format(
+                            "[%s] %s님의 이벤트 안내: %s",
+                            organizationName,
+                            organizerNickname,
+                            eventTitle
+                    ));
+            softly.assertThat(output)
+                    .contains("Content: " + request.content());
+        });
+    }
+
+    @Test
+    void 존재하지_않는_이벤트로_선택_조직원_전송시_예외가_발생한다() {
+        // given
+        var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
+        var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);
+        var om = createAndSaveOrganizationMember("대상자", "target@email.com", organization);
+        var request = createSelectedMembersRequest(java.util.List.of(om.getId()));
+
+        // when // then
+        assertThatThrownBy(() ->
+                sut.notifySelectedOrganizationMembers(999L, request, createLoginMember(organizer))
+        )
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 이벤트입니다.");
+    }
+
+    @Test
+    void 주최자가_아닌_회원이_전송하면_예외가_발생한다() {
+        // given
+        var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
+        var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);
+        var other = createAndSaveOrganizationMember("다른사람", "other@email.com", organization);
+
+        var now = LocalDateTime.now();
+        var event = eventRepository.save(Event.create(
+                "이벤트",
+                "설명",
+                "장소",
+                organizer,
+                organization,
+                EventOperationPeriod.create(
+                        Period.create(now.minusDays(1), now.plusDays(1)),
+                        Period.create(now.plusDays(2), now.plusDays(3)),
+                        now.minusDays(2)
+                ),
+                organizer.getNickname(),
+                100
+        ));
+
+        var om = createAndSaveOrganizationMember("대상자", "target@email.com", organization);
+        var request = createSelectedMembersRequest(java.util.List.of(om.getId()));
+
+        // when // then
+        assertThatThrownBy(() ->
+                sut.notifySelectedOrganizationMembers(event.getId(), request, createLoginMember(other))
+        )
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("이벤트 주최자가 아닙니다.");
+    }
+
+    @Test
+    void 요청에_존재하지_않는_조직원_ID가_포함되면_예외가_발생한다() {
+        // given
+        var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
+        var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);
+
+        var now = LocalDateTime.now();
+        var event = eventRepository.save(Event.create(
+                "이벤트",
+                "설명",
+                "장소",
+                organizer,
+                organization,
+                EventOperationPeriod.create(
+                        Period.create(now.minusDays(1), now.plusDays(1)),
+                        Period.create(now.plusDays(2), now.plusDays(3)),
+                        now.minusDays(2)
+                ),
+                organizer.getNickname(),
+                100
+        ));
+
+        var validOm = createAndSaveOrganizationMember("유효", "valid@email.com", organization);
+
+        var otherOrg = organizationRepository.save(Organization.create("다른조직", "설명", "img2.png"));
+        var otherOm = createAndSaveOrganizationMember("다른조직원", "otherorg@email.com", otherOrg);
+
+        var request = createSelectedMembersRequest(java.util.List.of(validOm.getId(), otherOm.getId()));
+
+        // when // then
+        assertThatThrownBy(() ->
+                sut.notifySelectedOrganizationMembers(event.getId(), request, createLoginMember(organizer))
+        )
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 조직원입니다.");
+    }
+
+    private NonGuestsNotificationRequest createNotificationRequest() {
+        return new NonGuestsNotificationRequest("이메일 내용입니다.");
+    }
+
+    private SelectedOrganizationMembersNotificationRequest createSelectedMembersRequest(java.util.List<Long> organizationMemberIds) {
+        return new SelectedOrganizationMembersNotificationRequest(organizationMemberIds, "이메일 내용입니다.");
     }
 
     private OrganizationMember createAndSaveOrganizationMember(


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #251

## ✨ 작업 내용

- 선택된 조직원에게 알람 발송 API 구현
- Swagger 명세 추가

## 🙏 기타 참고 사항

UT 과정에서 많은 분들이 해당 기능의 필요성을 강하게 어필하셨죠.  
사용자에게 가장 필요한 기능이라 판단하여 빠르게 개발했습니다~~~ 😎


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 주최자가 선택한 조직원에게만 알림 이메일을 전송할 수 있는 기능이 추가되었습니다.
  * 선택 조직원 알림 전송을 위한 새로운 API 엔드포인트가 제공됩니다.

* **버그 수정**
  * 기존 비게스트 조직원 알림 전송 요청 타입이 더 명확한 이름으로 변경되었습니다.

* **테스트**
  * 선택된 조직원 알림 전송 기능에 대한 다양한 성공 및 실패 케이스 테스트가 추가되었습니다.

* **문서**
  * API 문서의 일부 미디어 타입 명시가 제거되어 문서가 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->