### PR TITLE
[BE] 게스트 참여 가능 여부 반환 API 주최자는 참여 불가하게 반환하도록 수정

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -150,6 +150,10 @@ public class Event extends BaseEntity {
     }
 
     public boolean hasGuest(final OrganizationMember organizationMember) {
+        if (organizationMember.equals(organizer)) {
+            return false;
+        }
+        
         return guests.stream()
                 .anyMatch(guest -> guest.isSameOrganizationMember(organizationMember));
     }

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -40,14 +40,17 @@ class EventTest {
         Guest.create(sut, guest, registrationPeriod.start());
 
         // when
-        var actual = sut.hasGuest(guest);
-        var unexpected = sut.hasGuest(notGuest);
+        var actual1 = sut.hasGuest(guest);
+        var actual2 = sut.hasGuest(notGuest);
+        var actual3 = sut.hasGuest(baseOrganizer);
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(actual)
+            softly.assertThat(actual1)
                     .isTrue();
-            softly.assertThat(unexpected)
+            softly.assertThat(actual2)
+                    .isFalse();
+            softly.assertThat(actual3)
                     .isFalse();
         });
     }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #261 

## ✨ 작업 내용

게스트 참여 가능 여부 반환 API 에서 주최자가 조회했을 경우 false를 반환하도록 수정해주었습니다.
