### PR TITLE
[BE] 이벤트 생성 시 모든 조직원들에게 이벤트 알림을 보내도록 기능 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/EventNotification.java
+++ b/server/src/main/java/com/ahmadda/domain/EventNotification.java
@@ -3,6 +3,7 @@ package com.ahmadda.domain;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Component
@@ -13,6 +14,7 @@ public class EventNotification {
 
     public void sendEmails(final Event event, final List<OrganizationMember> recipients, final String content) {
         String subject = generateSubject(event);
+        String text = generateText(event, content);
 
         recipients.forEach(recipient ->
                 notificationMailer.sendEmail(
@@ -20,7 +22,7 @@ public class EventNotification {
                                 .getEmail(),
                         subject,
                         // TODO. 템플릿을 이용하여 content 생성하는 로직으로 변경 필요
-                        content
+                        text
                 )
         );
     }
@@ -32,6 +34,42 @@ public class EventNotification {
                 event.getOrganizer()
                         .getNickname(),
                 event.getTitle()
+        );
+    }
+
+    private String generateText(final Event event, final String content) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm");
+
+        return """
+                안녕하세요. %s 입니다.
+                
+                %s
+                
+                ────────────────────────────────
+                [이벤트 정보]
+                • 제목: %s
+                • 주최자: %s
+                • 장소: %s
+                • 모집기간: %s ~ %s
+                • 진행기간: %s ~ %s
+                ────────────────────────────────
+                
+                감사합니다.
+                """.formatted(
+                event.getOrganization()
+                        .getName(),
+                content,
+                event.getTitle(),
+                event.getOrganizerNickname(),
+                event.getPlace(),
+                event.getRegistrationStart()
+                        .format(formatter),
+                event.getRegistrationEnd()
+                        .format(formatter),
+                event.getEventStart()
+                        .format(formatter),
+                event.getEventEnd()
+                        .format(formatter)
         );
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/EventNotification.java
+++ b/server/src/main/java/com/ahmadda/domain/EventNotification.java
@@ -1,0 +1,37 @@
+package com.ahmadda.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class EventNotification {
+
+    private final NotificationMailer notificationMailer;
+
+    public void sendEmails(final Event event, final List<OrganizationMember> recipients, final String content) {
+        String subject = generateSubject(event);
+
+        recipients.forEach(recipient ->
+                notificationMailer.sendEmail(
+                        recipient.getMember()
+                                .getEmail(),
+                        subject,
+                        // TODO. 템플릿을 이용하여 content 생성하는 로직으로 변경 필요
+                        content
+                )
+        );
+    }
+
+    private String generateSubject(final Event event) {
+        return "[%s] %s님의 이벤트 안내: %s".formatted(
+                event.getOrganization()
+                        .getName(),
+                event.getOrganizer()
+                        .getNickname(),
+                event.getTitle()
+        );
+    }
+}

--- a/server/src/main/java/com/ahmadda/domain/EventNotification.java
+++ b/server/src/main/java/com/ahmadda/domain/EventNotification.java
@@ -21,7 +21,6 @@ public class EventNotification {
                         recipient.getMember()
                                 .getEmail(),
                         subject,
-                        // TODO. 템플릿을 이용하여 content 생성하는 로직으로 변경 필요
                         text
                 )
         );
@@ -37,6 +36,7 @@ public class EventNotification {
         );
     }
 
+    // TODO. 템플릿을 이용하여 content 생성하는 로직으로 변경 필요
     private String generateText(final Event event, final String content) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm");
 

--- a/server/src/main/java/com/ahmadda/domain/NotificationMailer.java
+++ b/server/src/main/java/com/ahmadda/domain/NotificationMailer.java
@@ -2,5 +2,5 @@ package com.ahmadda.domain;
 
 public interface NotificationMailer {
 
-    void sendNotification(final String recipientEmail, final String subject, final String content);
+    void sendEmail(final String recipientEmail, final String subject, final String content);
 }

--- a/server/src/main/java/com/ahmadda/infra/mail/MockNotificationMailer.java
+++ b/server/src/main/java/com/ahmadda/infra/mail/MockNotificationMailer.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MockNotificationMailer implements NotificationMailer {
 
     @Override
-    public void sendNotification(
+    public void sendEmail(
             final String recipientEmail,
             final String subject,
             final String content

--- a/server/src/main/java/com/ahmadda/infra/mail/SmtpNotificationMailer.java
+++ b/server/src/main/java/com/ahmadda/infra/mail/SmtpNotificationMailer.java
@@ -18,7 +18,7 @@ public class SmtpNotificationMailer implements NotificationMailer {
 
     @Async
     @Override
-    public void sendNotification(final String recipientEmail, final String subject, final String content) {
+    public void sendEmail(final String recipientEmail, final String subject, final String content) {
         MimeMessage mimeMessage = createMimeMessage(recipientEmail, subject, content);
 
         javaMailSender.send(mimeMessage);

--- a/server/src/main/java/com/ahmadda/infra/mail/SmtpNotificationMailer.java
+++ b/server/src/main/java/com/ahmadda/infra/mail/SmtpNotificationMailer.java
@@ -18,13 +18,13 @@ public class SmtpNotificationMailer implements NotificationMailer {
 
     @Async
     @Override
-    public void sendEmail(final String recipientEmail, final String subject, final String content) {
-        MimeMessage mimeMessage = createMimeMessage(recipientEmail, subject, content);
+    public void sendEmail(final String recipientEmail, final String subject, final String text) {
+        MimeMessage mimeMessage = createMimeMessage(recipientEmail, subject, text);
 
         javaMailSender.send(mimeMessage);
     }
 
-    private MimeMessage createMimeMessage(final String recipientEmail, final String subject, final String content) {
+    private MimeMessage createMimeMessage(final String recipientEmail, final String subject, final String text) {
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         MimeMessageHelper helper;
         try {
@@ -32,7 +32,7 @@ public class SmtpNotificationMailer implements NotificationMailer {
 
             helper.setTo(recipientEmail);
             helper.setSubject(subject);
-            helper.setText(content, true);
+            helper.setText(text, true);
         } catch (MessagingException e) {
             log.error("mailError : {} ", e.getMessage(), e);
             throw new MailSendFailedException("이메일 발송에 실패했습니다.", e);

--- a/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
@@ -56,8 +56,7 @@ class EventNotificationServiceTest {
 
     @MockitoBean
     private EventNotification eventNotification;
-
-
+    
     @Test
     void 비게스트_조직원에게_이메일을_전송한다() {
         // given

--- a/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
@@ -6,6 +6,7 @@ import com.ahmadda.application.dto.SelectedOrganizationMembersNotificationReques
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Event;
+import com.ahmadda.domain.EventNotification;
 import com.ahmadda.domain.EventOperationPeriod;
 import com.ahmadda.domain.EventRepository;
 import com.ahmadda.domain.Guest;
@@ -18,25 +19,20 @@ import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.domain.Period;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.system.CapturedOutput;
-import org.springframework.boot.test.system.OutputCaptureExtension;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
-@ExtendWith(OutputCaptureExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@TestPropertySource(
-        properties = {
-                "mail.mock=true"
-        })
 @Transactional
 class EventNotificationServiceTest {
 
@@ -58,8 +54,12 @@ class EventNotificationServiceTest {
     @Autowired
     private GuestRepository guestRepository;
 
+    @MockitoBean
+    private EventNotification eventNotification;
+
+
     @Test
-    void 비게스트_조직원에게_이메일을_전송한다(CapturedOutput output) {
+    void 비게스트_조직원에게_이메일을_전송한다() {
         // given
         var organizationName = "조직명";
         var organizerNickname = "주최자";
@@ -100,23 +100,18 @@ class EventNotificationServiceTest {
         sut.notifyNonGuestOrganizationMembers(event.getId(), notificationRequest, createLoginMember(organizer));
 
         // then
-        assertSoftly(softly -> {
-            softly.assertThat(output)
-                    .contains("To: " + nonGuest1Email);
-            softly.assertThat(output)
-                    .contains("To: " + nonGuest2Email);
-            softly.assertThat(output)
-                    .doesNotContain("To: " + guestEmail);
-            softly.assertThat(output)
-                    .contains("Subject: " + String.format(
-                            "[%s] %s님의 이벤트 안내: %s",
-                            organizationName,
-                            organizerNickname,
-                            eventTitle
-                    ));
-            softly.assertThat(output)
-                    .contains("Content: " + notificationRequest.content());
-        });
+        verify(eventNotification).sendEmails(
+                eq(event),
+                argThat(recipients -> {
+                    var emails = recipients.stream()
+                            .map(om -> om.getMember()
+                                    .getEmail())
+                            .toList();
+
+                    return emails.equals(List.of(nonGuest1Email, nonGuest2Email));
+                }),
+                eq(notificationRequest.content())
+        );
     }
 
     @Test
@@ -170,7 +165,7 @@ class EventNotificationServiceTest {
     }
 
     @Test
-    void 선택된_조직원에게_이메일을_전송한다(CapturedOutput output) {
+    void 선택된_조직원에게_이메일을_전송한다() {
         // given
         var organizationName = "조직명";
         var organizerNickname = "주최자";
@@ -200,33 +195,25 @@ class EventNotificationServiceTest {
         var om3 = createAndSaveOrganizationMember("비선택", "nsel@email.com", organization);
 
         var request = createSelectedMembersRequest(
-                java.util.List.of(om1.getId(), om3.getId())
+                List.of(om1.getId(), om2.getId())
         );
 
         // when
         sut.notifySelectedOrganizationMembers(event.getId(), request, createLoginMember(organizer));
 
         // then
-        assertSoftly(softly -> {
-            softly.assertThat(output)
-                    .contains("To: " + om1.getMember()
-                            .getEmail());
-            softly.assertThat(output)
-                    .contains("To: " + om3.getMember()
-                            .getEmail());
-            softly.assertThat(output)
-                    .doesNotContain("To: " + om2.getMember()
-                            .getEmail());
-            softly.assertThat(output)
-                    .contains("Subject: " + String.format(
-                            "[%s] %s님의 이벤트 안내: %s",
-                            organizationName,
-                            organizerNickname,
-                            eventTitle
-                    ));
-            softly.assertThat(output)
-                    .contains("Content: " + request.content());
-        });
+        verify(eventNotification).sendEmails(
+                eq(event),
+                argThat(recipients -> {
+                    var ids = recipients.stream()
+                            .map(OrganizationMember::getId)
+                            .toList();
+
+                    return ids.containsAll(request.organizationMemberIds())
+                            && !ids.contains(om3.getId());
+                }),
+                eq(request.content())
+        );
     }
 
     @Test
@@ -320,7 +307,7 @@ class EventNotificationServiceTest {
         return new NonGuestsNotificationRequest("이메일 내용입니다.");
     }
 
-    private SelectedOrganizationMembersNotificationRequest createSelectedMembersRequest(java.util.List<Long> organizationMemberIds) {
+    private SelectedOrganizationMembersNotificationRequest createSelectedMembersRequest(List<Long> organizationMemberIds) {
         return new SelectedOrganizationMembersNotificationRequest(organizationMemberIds, "이메일 내용입니다.");
     }
 

--- a/server/src/test/java/com/ahmadda/domain/EventNotificationTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventNotificationTest.java
@@ -1,0 +1,82 @@
+package com.ahmadda.domain;
+
+import com.ahmadda.infra.mail.MockNotificationMailer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@ExtendWith(OutputCaptureExtension.class)
+class EventNotificationTest {
+
+    private final EventNotification sut = new EventNotification(new MockNotificationMailer());
+
+    @Test
+    void 수신자_목록에게_이메일을_전송한다(CapturedOutput output) {
+        // given
+        var organizationName = "조직명";
+        var organizerNickname = "주최자";
+        var eventTitle = "이벤트제목";
+        var content = "이메일 본문입니다.";
+
+        var organization = Organization.create(organizationName, "설명", "img.png");
+        var organizer = createOrganizationMember(organizerNickname, "host@email.com", organization);
+
+        var now = LocalDateTime.now();
+        var event = Event.create(
+                eventTitle,
+                "설명",
+                "장소",
+                organizer,
+                organization,
+                EventOperationPeriod.create(
+                        Period.create(now.minusDays(2), now.minusDays(1)),
+                        Period.create(now.plusDays(1), now.plusDays(2)),
+                        now.minusDays(3)
+                ),
+                organizerNickname,
+                100
+        );
+
+        var om1 = createOrganizationMember("수신자1", "r1@email.com", organization);
+        var om2 = createOrganizationMember("수신자2", "r2@email.com", organization);
+        var recipients = List.of(om1, om2);
+
+        // when
+        sut.sendEmails(event, recipients, content);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(output)
+                    .contains(om1.getMember()
+                            .getEmail());
+            softly.assertThat(output)
+                    .contains(om2.getMember()
+                            .getEmail());
+            softly.assertThat(output)
+                    .contains(String.format(
+                            "[%s] %s님의 이벤트 안내: %s",
+                            organizationName,
+                            organizerNickname,
+                            eventTitle
+                    ));
+            softly.assertThat(output)
+                    .contains(content);
+        });
+    }
+
+    private OrganizationMember createOrganizationMember(
+            String nickname,
+            String email,
+            Organization organization
+    ) {
+        var member = Member.create(nickname, email);
+
+        return OrganizationMember.create(nickname, member, organization);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #256

## ✨ 작업 내용

- 이메일 제목과 본문 생성 로직을 도메인(`EventNotification`)으로 이동
- 이벤트 생성 시 모든 조직원에게 이메일 알림 발송 로직 구현

## 🙏 기타 참고 사항

이번에 **이벤트 생성 시 모든 조직원에게 이메일 알림을 발송하는 로직**을 구현하면서, 이메일 제목과 본문을 어디서 만들어야 할지 고민을 많이 했습니다.  
그런 고민속에서 더 나아가 프론트엔드 분들과 협업하다 보니 "제목에는 어떤 정보가 들어가야 하는지", "본문에는 어떤 메시지가 포함돼야 하는지"가 명확한 규칙으로 자리잡아야 한다는 걸 느꼈습니다..!!
그래서 이메일 제목과 본문은 단순한 UI 요소가 아니라, **우리 서비스의 중요한 도메인 규칙**이라고 판단했습니다. 

이런 이유로 이메일 제목과 본문을 생성하는 로직을 애플리케이션 서비스에서 도메인(`EventNotification`)으로 이동해봤습니다! 
이제 애플리케이션 서비스는 비즈니스 플로우(언제 누구에게 이메일을 보낼지)만 책임지고,  
도메인은 **어떤 제목과 본문으로 보낼지**를 알아서 처리합니다.  
덕분에 코드의 역할이 훨씬 깔끔해졌고, 앞으로 변경에 더 쉽게 대응할 수 있을거라 생각합니다!!  

테스트는 아래와 같이 구분했습니다!!

- EventNotification: 단위 테스트로 이메일 제목/본문 생성과 발송 로직을 검증  
- EventService 등 응용 계층: @MockitoBean 으로 EventNotification 을 모킹하여 호출 여부만 검증  

EventNotification 를 단위 테스트한 이유는  
이메일 제목/본문은 도메인 규칙이므로 독립적으로 검증하는 것이 적절하다고 판단했기 때문입니다.  

그리고 EventService 등 응용 계층의 책임은  
비즈니스 플로우(권한 확인, 대상자 선정, 저장, 알림 호출)를 조립하는 것이므로, 콘텐츠 생성은 도메인에 위임하고 호출 여부만 검증하면 충분하다고 생각했습니다.  
이렇게 하면 EventNotification 변경 시 테스트가 깨지지 않아 테스트에서 제일 중요한 가치인 리팩터링에 내성적이라고 판단했습니다!! 

[테스트 대역 (목 과 스텁) - 5장 목과 테스트 취약성](https://jonghoonpark.com/2023/05/11/%ED%85%8C%EC%8A%A4%ED%8A%B8-%EB%8C%80%EC%97%AD-%EB%AA%A9-%EA%B3%BC-%EC%8A%A4%ED%85%81)를 참고하셔도 좋을 것 같아 공유드립니다!! 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 생성 시 조직원에게 이메일 알림이 발송됩니다.
  * 이벤트 알림 전송 기능이 별도의 컴포넌트로 분리되어 관리됩니다.

* **버그 수정**
  * 이메일 발송 관련 메서드 명칭이 명확하게 변경되어 혼동을 줄였습니다.

* **테스트**
  * 이벤트 및 알림 발송 기능에 대한 테스트가 추가 및 개선되었습니다.
  * 이메일 발송 동작을 검증하는 테스트가 도입되었습니다.

* **리팩터**
  * 알림 전송 로직이 개선되어 코드 구조가 단순화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->