### PR TITLE
[BE] 이벤트 생성시 장소, 설명 null 가능하게 변경 및 이벤트 신청 마감 기간과 이벤트 시작 시간이 같아도 …

### DIFF
--- a/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
@@ -10,9 +10,7 @@ import java.util.List;
 public record EventCreateRequest(
         @NotBlank
         String title,
-        @NotBlank
         String description,
-        @NotBlank
         String place,
         @NotNull
         LocalDateTime registrationEnd,

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
@@ -40,9 +41,9 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
+    @Lob
     private String description;
 
-    @Column(nullable = false)
     private String place;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -80,8 +81,6 @@ public class Event extends BaseEntity {
             final List<Question> questions
     ) {
         validateTitle(title);
-        validateDescription(description);
-        validatePlace(place);
         validateOrganizer(organizer);
         validateOrganization(organization);
         validateBelongToOrganization(organizer, organization);
@@ -153,7 +152,7 @@ public class Event extends BaseEntity {
         if (organizationMember.equals(organizer)) {
             return false;
         }
-        
+
         return guests.stream()
                 .anyMatch(guest -> guest.isSameOrganizationMember(organizationMember));
     }
@@ -212,14 +211,6 @@ public class Event extends BaseEntity {
 
     private void validateTitle(final String title) {
         Assert.notBlank(title, "제목은 공백이면 안됩니다.");
-    }
-
-    private void validateDescription(final String description) {
-        Assert.notBlank(description, "설명은 공백이면 안됩니다.");
-    }
-
-    private void validatePlace(final String place) {
-        Assert.notBlank(place, "장소는 공백이면 안됩니다.");
     }
 
     private void validateOrganizer(final OrganizationMember organizer) {

--- a/server/src/main/java/com/ahmadda/domain/Period.java
+++ b/server/src/main/java/com/ahmadda/domain/Period.java
@@ -42,7 +42,7 @@ public class Period {
     }
 
     public boolean isOverlappedWith(final Period other) {
-        return !this.isAfter(other) && !this.isBefore(other);
+        return this.start.isBefore(other.end) && other.start.isBefore(this.end);
     }
 
     public boolean isNotStarted(final LocalDateTime currentDateTime) {

--- a/server/src/test/java/com/ahmadda/domain/EventOperationPeriodTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventOperationPeriodTest.java
@@ -89,7 +89,7 @@ class EventOperationPeriodTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"2025-07-16T08:30", "2025-07-16T08:31"})
+    @CsvSource({"2025-07-16T08:31", "2025-07-16T08:32"})
     void 이벤트_신청_마감_시간이_이벤트_시작_시간보다_미래라면_예외가_발생한다(LocalDateTime registrationEnd) {
         //given
         var eventRegistrationPeriod = Period.create(

--- a/server/src/test/java/com/ahmadda/domain/PeriodTest.java
+++ b/server/src/test/java/com/ahmadda/domain/PeriodTest.java
@@ -79,7 +79,7 @@ class PeriodTest {
                                 LocalDateTime.of(2025, 7, 19, 0, 0),
                                 LocalDateTime.of(2025, 7, 20, 0, 0)
                         ),
-                        true
+                        false
                 ),
                 Arguments.of(
                         Period.create(


### PR DESCRIPTION


<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #274 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- 이벤트 장소, 이벤트 설명이 공백 가능하도록 변경해주었습니다.
- 이벤트 신청 마감 시간과 이벤트 시작 시간이 같아도 되도록 변경해주었습니다.
- 이벤트 설명을 좀 더 길게 작성할 수 있도록 데이터베이스 타입을 변경해주었습니다.

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

프론트에서 이벤트 시작 시간을 입력하면 동일한 값이 자동으로 신청 종료 시간에도 입력되도록 변경예정이라
신청 종료 시간과 이벤트 시작 시간이 같아도 허용해 달라는 요청이 있어 해당 로직을 수정했습니다.
