### PR TITLE
[FE] 수용인원 수정

### DIFF
--- a/client/src/features/Event/My/components/EventCard.tsx
+++ b/client/src/features/Event/My/components/EventCard.tsx
@@ -43,7 +43,7 @@ export const EventCard = ({
     <EventCardWrapper onClick={handleClick}>
       <Flex dir="column" gap="3.5px">
         <Text as="h2" type="Heading" weight="semibold" color="white">
-          {title}
+          {title.length > 15 ? `${title.slice(0, 12)}...` : title}
         </Text>
         <Text type="Body" weight="regular" color="#99A1AF">
           {description}

--- a/client/src/features/Event/My/components/EventCard.tsx
+++ b/client/src/features/Event/My/components/EventCard.tsx
@@ -7,7 +7,6 @@ import { ProgressBar } from '@/shared/components/ProgressBar';
 import { Spacing } from '@/shared/components/Spacing';
 import { Text } from '@/shared/components/Text';
 
-import { UNLIMITED_CAPACITY } from '../../New/constants/validation';
 import { formatDateTime } from '../../Overview/utils/formatDateTime';
 import { formatTime } from '../../Overview/utils/formatTime';
 import { Event } from '../../types/Event';
@@ -84,27 +83,16 @@ export const EventCard = ({
             {organizerName}
           </Text>
         </Flex>
+
         <Flex width="100%" justifyContent="space-between" alignItems="center">
           <Text type="Label" color="#99A1AF">
             참여 현황
           </Text>
-          <Text type="Label" weight="regular" color="#99A1AF">
-            {`${currentGuestCount}/${maxCapacity}명`}
+          <Text type="Label" color="#99A1AF">
+            {`${currentGuestCount}/${maxCapacity} 명`}
           </Text>
         </Flex>
-        {maxCapacity !== UNLIMITED_CAPACITY && (
-          <>
-            <Flex width="100%" justifyContent="space-between" alignItems="center">
-              <Text type="Label" color="#99A1AF">
-                참여 현황
-              </Text>
-              <Text type="Label" color="#99A1AF">
-                {`${currentGuestCount}/${maxCapacity} 명`}
-              </Text>
-            </Flex>
-            <ProgressBar value={Number(currentGuestCount)} max={maxCapacity} color="black" />
-          </>
-        )}
+        <ProgressBar value={Number(currentGuestCount)} max={maxCapacity} color="black" />
       </Flex>
     </EventCardWrapper>
   );

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { css } from '@emotion/react';
 import { useQuery } from '@tanstack/react-query';
 import { HTTPError } from 'ky';
@@ -9,17 +7,14 @@ import { myQueryOptions } from '@/api/queries/my';
 import { Button } from '@/shared/components/Button';
 import { Card } from '@/shared/components/Card';
 import { Flex } from '@/shared/components/Flex';
-import { Icon } from '@/shared/components/Icon';
 import { Input } from '@/shared/components/Input';
 import { Text } from '@/shared/components/Text';
 
-import { UNLIMITED_CAPACITY } from '../constants/validation';
 import { useAddEvent } from '../hooks/useAddEvent';
 import { useEventForm } from '../hooks/useEventForm';
 import { useEventValidation } from '../hooks/useEventValidation';
 import { convertDatetimeLocalToKSTISOString } from '../utils/convertDatetimeLocalToKSTISOString';
 
-import { MaxCapacityModal } from './MaxCapacityModal';
 import { QuestionForm } from './QuestionForm';
 
 const ORGANIZATION_ID = 1; // 임시
@@ -31,10 +26,7 @@ export const EventCreateForm = () => {
   const { formData, handleChange, setQuestions } = useEventForm();
   const { errors, setQuestionErrors, validate, validateField, isFormValid } =
     useEventValidation(formData);
-  const [isCapacityModalOpen, setIsCapacityModalOpen] = useState(false);
   const { data: userProfile } = useQuery(myQueryOptions.profile());
-
-  const today = new Date();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -186,6 +178,7 @@ export const EventCreateForm = () => {
               error={!!errors.place}
               errorMessage={errors.place}
               isRequired={true}
+              max={12}
             />
 
             <Input
@@ -200,57 +193,18 @@ export const EventCreateForm = () => {
               error={!!errors.description}
               errorMessage={errors.description}
               isRequired={true}
+              max={80}
             />
 
-            <div
-              onClick={() => setIsCapacityModalOpen(true)}
-              // eslint-disable-next-line react/no-unknown-property
-              css={css`
-                width: 100%;
-                padding: 16px;
-                border-radius: 10px;
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                cursor: pointer;
-
-                &:hover {
-                  background-color: #f0f0f0;
-                }
-              `}
-            >
-              <Flex alignItems="center" gap="8px">
-                <Icon name="users" size={18} />
-                <Text type="Label" color="gray">
-                  수용 인원
-                </Text>
-              </Flex>
-
-              <Flex alignItems="center" gap="4px">
-                <Text type="Label">
-                  {formData.maxCapacity === UNLIMITED_CAPACITY
-                    ? '무제한'
-                    : `${formData.maxCapacity}명`}
-                </Text>
-                <Text type="Label" color="gray">
-                  ✏️
-                </Text>
-              </Flex>
-            </div>
-
-            <MaxCapacityModal
-              isOpen={isCapacityModalOpen}
-              initialValue={formData.maxCapacity === UNLIMITED_CAPACITY ? 10 : formData.maxCapacity}
-              onClose={() => setIsCapacityModalOpen(false)}
-              onSubmit={(value) => {
-                const syntheticEvent = {
-                  target: {
-                    value: value.toString(),
-                  },
-                };
-                handleChange('maxCapacity')(syntheticEvent as React.ChangeEvent<HTMLInputElement>);
-                validateField('maxCapacity', syntheticEvent.target.value);
-              }}
+            <Input
+              id="maxCapacity"
+              label="수용 인원"
+              placeholder="최대 참가 인원을 입력해 주세요"
+              type="number"
+              value={formData.maxCapacity}
+              min={1}
+              onChange={handleChange('maxCapacity')}
+              isRequired={true}
             />
           </Flex>
         </Card>

--- a/client/src/features/Event/New/hooks/useEventForm.ts
+++ b/client/src/features/Event/New/hooks/useEventForm.ts
@@ -2,8 +2,6 @@ import { useState } from 'react';
 
 import type { CreateEventAPIRequest, QuestionRequest } from '@/features/Event/types/Event';
 
-import { UNLIMITED_CAPACITY } from '../constants/validation';
-
 export const useEventForm = () => {
   const [formData, setFormData] = useState<Omit<CreateEventAPIRequest, 'organizerNickname'>>({
     title: '',
@@ -12,7 +10,7 @@ export const useEventForm = () => {
     eventStart: '',
     eventEnd: '',
     registrationEnd: '',
-    maxCapacity: UNLIMITED_CAPACITY,
+    maxCapacity: 0,
     questions: [],
   });
 

--- a/client/src/features/Event/Overview/components/EventCard.tsx
+++ b/client/src/features/Event/Overview/components/EventCard.tsx
@@ -6,7 +6,6 @@ import { Icon } from '@/shared/components/Icon';
 import { ProgressBar } from '@/shared/components/ProgressBar';
 import { Text } from '@/shared/components/Text';
 
-import { UNLIMITED_CAPACITY } from '../../New/constants/validation';
 import { Event } from '../../types/Event';
 import { formatDateTime } from '../utils/formatDateTime';
 import { formatTime } from '../utils/formatTime';
@@ -31,7 +30,7 @@ export const EventCard = ({
       <Flex dir="column" gap="8px">
         <Flex justifyContent="space-between" alignItems="center" gap="8px">
           <Text as="h2" type="Heading" color="#ffffff" weight="semibold">
-            {title}
+            {title.length > 15 ? `${title.slice(0, 12)}...` : title}
           </Text>
           <Badge isRegistrationOpen={isRegistrationOpen}>
             {isRegistrationOpen ? '모집중' : '모집마감'}
@@ -68,19 +67,16 @@ export const EventCard = ({
             {organizerName}
           </Text>
         </Flex>
-        {maxCapacity !== UNLIMITED_CAPACITY && (
-          <>
-            <Flex width="100%" justifyContent="space-between" alignItems="center">
-              <Text type="Label" color="#99A1AF">
-                참여 현황
-              </Text>
-              <Text type="Label" color="#99A1AF">
-                {`${currentGuestCount}/${maxCapacity} 명`}
-              </Text>
-            </Flex>
-            <ProgressBar value={Number(currentGuestCount)} max={maxCapacity} color="black" />
-          </>
-        )}
+
+        <Flex width="100%" justifyContent="space-between" alignItems="center">
+          <Text type="Label" color="#99A1AF">
+            참여 현황
+          </Text>
+          <Text type="Label" color="#99A1AF">
+            {`${currentGuestCount}/${maxCapacity} 명`}
+          </Text>
+        </Flex>
+        <ProgressBar value={Number(currentGuestCount)} max={maxCapacity} color="black" />
       </Flex>
     </CardWrapper>
   );


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #282 

## ✨ 작업 내용

- 수용인원 모달 제거
- 이벤트 생성 폼 내 글자수 제한
- 이벤트 타이틀 12글자 이상 시 ...적용




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 생성 시 최대 인원 입력 방식을 모달에서 숫자 입력 필드로 변경하였습니다.
  * 이벤트 제목이 15자를 초과할 경우 자동으로 말줄임표(...)로 표시됩니다.

* **버그 수정**
  * 참여 현황과 진행률 표시가 최대 인원 설정과 관계없이 항상 표시되도록 개선하였습니다.

* **스타일**
  * 참여 인원 수 표시에 공백 추가 및 텍스트 스타일 조정이 이루어졌습니다.

* **기타**
  * 장소와 설명 입력란에 최대 글자 수(각각 12자, 80자) 제한이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->