### PR TITLE
[FE] 시간 분 단위까지 보여지도록 수정

### DIFF
--- a/client/src/features/Event/Overview/utils/formatDateTime.ts
+++ b/client/src/features/Event/Overview/utils/formatDateTime.ts
@@ -2,12 +2,16 @@ export const formatDateTime = (eventStart: string, eventEnd: string): string => 
   const startDate = new Date(eventStart);
   const endDate = new Date(eventEnd);
 
+  const pad = (n: number) => n.toString().padStart(2, '0');
+
   const month = startDate.getMonth() + 1;
   const day = startDate.getDate();
   const weekday = startDate.toLocaleDateString('ko-KR', { weekday: 'short' });
 
-  const startHour = startDate.getHours();
-  const endHour = endDate.getHours();
+  const startHour = pad(startDate.getHours());
+  const startMinute = pad(startDate.getMinutes());
+  const endHour = pad(endDate.getHours());
+  const endMinute = pad(endDate.getMinutes());
 
-  return `${month}.${day} (${weekday}) ${startHour}시 ~ ${endHour}시`;
+  return `${month}.${day} (${weekday}) ${startHour}:${startMinute} ~ ${endHour}:${endMinute}`;
 };


### PR DESCRIPTION
## 관련 이슈

close #295 

## ✨ 작업 내용

- 이벤트 카드에서 시간 단위까지만 보여지고 있었어서, 분 단위까지 보여지도록 `formatDateTime` 유틸 함수 로직을 수정하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 시간 표시 형식이 "14시"에서 "14:05"와 같이 시와 분이 콜론으로 구분되고, 두 자리로 표시되도록 개선되었습니다. 시작 및 종료 시간이 모두 시:분 형식으로 일관되게 보여집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->