### PR TITLE
[BE] 주최자 이벤트 수정 기능 구현 

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -11,6 +11,7 @@ import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventNotification;
 import com.ahmadda.domain.EventOperationPeriod;
 import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
 import com.ahmadda.domain.Organization;
@@ -111,7 +112,7 @@ public class EventService {
                 eventUpdateRequest.maxCapacity()
         );
 
-        // notifyEventUpdated(event);
+        notifyEventUpdated(event);
 
         return event;
     }
@@ -156,6 +157,17 @@ public class EventService {
         List<OrganizationMember> recipients =
                 event.getNonGuestOrganizationMembers(organization.getOrganizationMembers());
         String content = "새로운 이벤트가 등록되었습니다.";
+        Email email = Email.of(event, content);
+
+        eventNotification.sendEmails(recipients, email);
+    }
+
+    private void notifyEventUpdated(final Event event) {
+        List<OrganizationMember> recipients = event.getGuests()
+                .stream()
+                .map(Guest::getOrganizationMember)
+                .toList();
+        String content = "이벤트 정보가 수정되었습니다.";
         Email email = Email.of(event, content);
 
         eventNotification.sendEmails(recipients, email);

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -41,12 +41,12 @@ public class EventService {
     @Transactional
     public Event createEvent(
             final Long organizationId,
-            final Long memberId,
+            final LoginMember loginMember,
             final EventCreateRequest eventCreateRequest,
             final LocalDateTime currentDateTime
     ) {
         Organization organization = getOrganization(organizationId);
-        OrganizationMember organizer = validateOrganizationAccess(organizationId, memberId);
+        OrganizationMember organizer = validateOrganizationAccess(organizationId, loginMember.memberId());
 
         EventOperationPeriod eventOperationPeriod = createEventOperationPeriod(eventCreateRequest, currentDateTime);
         Event event = Event.create(

--- a/server/src/main/java/com/ahmadda/application/dto/EventUpdateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.ahmadda.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record EventUpdateRequest(
+        @NotBlank
+        String title,
+        String description,
+        String place,
+        @NotNull
+        LocalDateTime registrationEnd,
+        @NotNull
+        LocalDateTime eventStart,
+        @NotNull
+        LocalDateTime eventEnd,
+        @NotBlank
+        String organizerNickname,
+        int maxCapacity
+) {
+
+}

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -156,6 +156,10 @@ public class Event extends BaseEntity {
             final String organizerNickname,
             final int maxCapacity
     ) {
+        validateTitle(title);
+        validateOrganizerNickname(organizerNickname);
+        validateMaxCapacity(maxCapacity);
+
         this.title = title;
         this.description = description;
         this.place = place;

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -148,6 +148,22 @@ public class Event extends BaseEntity {
         );
     }
 
+    public void update(
+            final String title,
+            final String description,
+            final String place,
+            final EventOperationPeriod eventOperationPeriod,
+            final String organizerNickname,
+            final int maxCapacity
+    ) {
+        this.title = title;
+        this.description = description;
+        this.place = place;
+        this.eventOperationPeriod = eventOperationPeriod;
+        this.organizerNickname = organizerNickname;
+        this.maxCapacity = maxCapacity;
+    }
+
     public boolean hasGuest(final OrganizationMember organizationMember) {
         if (organizationMember.equals(organizer)) {
             return true;

--- a/server/src/main/java/com/ahmadda/domain/EventOperationPeriod.java
+++ b/server/src/main/java/com/ahmadda/domain/EventOperationPeriod.java
@@ -55,6 +55,15 @@ public class EventOperationPeriod {
         return new EventOperationPeriod(registrationPeriod, eventPeriod, currentDateTime);
     }
 
+    public EventOperationPeriod update(
+            final Period registrationPeriod,
+            final Period eventPeriod,
+            final LocalDateTime currentDateTime
+    ) {
+        return new EventOperationPeriod(registrationPeriod, eventPeriod, currentDateTime);
+    }
+
+
     public boolean isNotStarted(final LocalDateTime currentDateTime) {
         return eventPeriod.isNotStarted(currentDateTime);
     }

--- a/server/src/main/java/com/ahmadda/domain/Period.java
+++ b/server/src/main/java/com/ahmadda/domain/Period.java
@@ -33,6 +33,10 @@ public class Period {
         return new Period(start, end);
     }
 
+    public Period update(final LocalDateTime start, final LocalDateTime end) {
+        return new Period(start, end);
+    }
+    
     public boolean isAfter(final Period other) {
         return this.start.isAfter(other.end);
     }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -5,11 +5,13 @@ import com.ahmadda.application.EventService;
 import com.ahmadda.application.OrganizationMemberEventService;
 import com.ahmadda.application.OrganizationService;
 import com.ahmadda.application.dto.EventCreateRequest;
+import com.ahmadda.application.dto.EventUpdateRequest;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.domain.Event;
 import com.ahmadda.presentation.dto.EventCreateResponse;
 import com.ahmadda.presentation.dto.EventDetailResponse;
 import com.ahmadda.presentation.dto.EventResponse;
+import com.ahmadda.presentation.dto.EventUpdateResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -24,6 +26,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -286,6 +289,96 @@ public class OrganizationEventController {
 
         return ResponseEntity.created(URI.create("/api/organizations/" + organizationId + "/events/" + event.getId()))
                 .body(new EventCreateResponse(event.getId()));
+    }
+
+    @Operation(summary = "이벤트 수정", description = "이벤트 ID에 해당하는 이벤트 정보를 수정합니다. 주최자만 수정할 수 있습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = EventUpdateResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/organizations/events/{eventId}"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Forbidden",
+                                              "status": 403,
+                                              "detail": "이벤트의 주최자만 수정할 수 있습니다.",
+                                              "instance": "/api/organizations/events/{eventId}"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "이벤트 없음",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않은 이벤트 정보입니다.",
+                                                      "instance": "/api/organizations/events/{eventId}"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "회원 없음",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 회원입니다.",
+                                                      "instance": "/api/organizations/events/{eventId}"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    @PatchMapping("/events/{eventId}")
+    public ResponseEntity<EventUpdateResponse> updateEvent(
+            @PathVariable final Long eventId,
+            @RequestBody @Valid final EventUpdateRequest eventUpdateRequest,
+            @AuthMember final LoginMember loginMember
+    ) {
+        Event updated = eventService.updateEvent(
+                eventId,
+                loginMember,
+                eventUpdateRequest,
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.ok(new EventUpdateResponse(updated.getId()));
     }
 
     @Operation(summary = "이벤트 상세 조회", description = "이벤트 ID에 해당하는 이벤트를 상세 조회합니다.")

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -279,7 +279,7 @@ public class OrganizationEventController {
     ) {
         Event event = eventService.createEvent(
                 organizationId,
-                loginMember.memberId(),
+                loginMember,
                 eventCreateRequest,
                 LocalDateTime.now()
         );

--- a/server/src/main/java/com/ahmadda/presentation/dto/EventUpdateResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/EventUpdateResponse.java
@@ -1,0 +1,5 @@
+package com.ahmadda.presentation.dto;
+
+public record EventUpdateResponse(Long eventId) {
+
+}

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -123,8 +123,6 @@ class EventServiceTest {
     @Test
     void 이벤트_생성시_조직_id에_해당하는_조직이_없다면_예외가_발생한다() {
         //given
-        var organizationMember = createOrganizationMember(createOrganization(), createMember());
-
         var now = LocalDateTime.now();
         var eventCreateRequest = new EventCreateRequest(
                 "UI/UX 이벤트",
@@ -319,34 +317,38 @@ class EventServiceTest {
         var loginMember = new LoginMember(member.getId());
 
         // when
-        var updated = sut.updateEvent(event.getId(), loginMember, updateRequest, now);
+        sut.updateEvent(event.getId(), loginMember, updateRequest, now);
 
         // then
-        assertSoftly(softly -> {
-            softly.assertThat(updated.getTitle())
-                    .isEqualTo("수정된 제목");
-            softly.assertThat(updated.getDescription())
-                    .isEqualTo("수정된 설명");
-            softly.assertThat(updated.getPlace())
-                    .isEqualTo("수정된 장소");
-            softly.assertThat(updated.getOrganizerNickname())
-                    .isEqualTo("수정된 닉네임");
-            softly.assertThat(updated.getMaxCapacity())
-                    .isEqualTo(200);
+        assertThat(eventRepository.findById(event.getId()))
+                .isPresent()
+                .hasValueSatisfying(savedEvent -> {
+                    assertSoftly(softly -> {
+                        softly.assertThat(savedEvent.getTitle())
+                                .isEqualTo("수정된 제목");
+                        softly.assertThat(savedEvent.getDescription())
+                                .isEqualTo("수정된 설명");
+                        softly.assertThat(savedEvent.getPlace())
+                                .isEqualTo("수정된 장소");
+                        softly.assertThat(savedEvent.getOrganizerNickname())
+                                .isEqualTo("수정된 닉네임");
+                        softly.assertThat(savedEvent.getMaxCapacity())
+                                .isEqualTo(200);
 
-            softly.assertThat(updated.getEventOperationPeriod()
-                            .getRegistrationPeriod()
-                            .end())
-                    .isEqualTo(now.plusDays(5));
-            softly.assertThat(updated.getEventOperationPeriod()
-                            .getEventPeriod()
-                            .start())
-                    .isEqualTo(now.plusDays(6));
-            softly.assertThat(updated.getEventOperationPeriod()
-                            .getEventPeriod()
-                            .end())
-                    .isEqualTo(now.plusDays(7));
-        });
+                        softly.assertThat(savedEvent.getEventOperationPeriod()
+                                        .getRegistrationPeriod()
+                                        .end())
+                                .isEqualTo(now.plusDays(5));
+                        softly.assertThat(savedEvent.getEventOperationPeriod()
+                                        .getEventPeriod()
+                                        .start())
+                                .isEqualTo(now.plusDays(6));
+                        softly.assertThat(savedEvent.getEventOperationPeriod()
+                                        .getEventPeriod()
+                                        .end())
+                                .isEqualTo(now.plusDays(7));
+                    });
+                });
     }
 
     @Test

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -85,8 +85,10 @@ class EventServiceTest {
                 List.of(new QuestionCreateRequest("1번 질문", true), new QuestionCreateRequest("2번 질문", false))
         );
 
+        var loginMember = new LoginMember(member.getId());
+
         //when
-        var event = sut.createEvent(organization.getId(), member.getId(), eventCreateRequest, now);
+        var event = sut.createEvent(organization.getId(), loginMember, eventCreateRequest, now);
 
         //then
         assertThat(eventRepository.findById(event.getId()))
@@ -135,8 +137,10 @@ class EventServiceTest {
                 List.of(new QuestionCreateRequest("1번 질문", true), new QuestionCreateRequest("2번 질문", false))
         );
 
+        var loginMember = new LoginMember(1L);
+
         //when //then
-        assertThatThrownBy(() -> sut.createEvent(999L, organizationMember.getId(), eventCreateRequest, now))
+        assertThatThrownBy(() -> sut.createEvent(999L, loginMember, eventCreateRequest, now))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않은 조직 정보입니다.");
     }
@@ -158,8 +162,10 @@ class EventServiceTest {
                 new ArrayList<>()
         );
 
+        var loginMember = new LoginMember(999L);
+
         //when //then
-        assertThatThrownBy(() -> sut.createEvent(organization.getId(), 999L, eventCreateRequest, now))
+        assertThatThrownBy(() -> sut.createEvent(organization.getId(), loginMember, eventCreateRequest, now))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 회원입니다.");
     }
@@ -184,8 +190,10 @@ class EventServiceTest {
                 new ArrayList<>()
         );
 
+        var loginMember = new LoginMember(member.getId());
+
         //when //then
-        assertThatThrownBy(() -> sut.createEvent(organization1.getId(), member.getId(), eventCreateRequest, now))
+        assertThatThrownBy(() -> sut.createEvent(organization1.getId(), loginMember, eventCreateRequest, now))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("조직에 소속되지 않은 멤버입니다.");
     }
@@ -248,8 +256,10 @@ class EventServiceTest {
                 )
         );
 
+        var loginMember = new LoginMember(organizerMember.getId());
+
         // when
-        var savedEvent = sut.createEvent(organization.getId(), organizer.getId(), request, now);
+        var savedEvent = sut.createEvent(organization.getId(), loginMember, request, now);
 
         // then
         var email = Email.of(savedEvent, "새로운 이벤트가 등록되었습니다.");

--- a/server/src/test/java/com/ahmadda/domain/EventOperationPeriodTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventOperationPeriodTest.java
@@ -9,8 +9,41 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class EventOperationPeriodTest {
+
+    @Test
+    void 이벤트_운영_기간을_수정할_수_있다() {
+        // given
+        var currentTime = LocalDateTime.of(2025, 7, 16, 8, 0);
+        var registrationPeriod = Period.create(
+                currentTime.plusDays(1),
+                currentTime.plusDays(5)
+        );
+        var eventPeriod = Period.create(
+                currentTime.plusDays(6),
+                currentTime.plusDays(7)
+        );
+        var sut = EventOperationPeriod.create(registrationPeriod, eventPeriod, currentTime);
+
+        // when
+        var updated = sut.update(
+                Period.create(currentTime.plusDays(2), currentTime.plusDays(4)),
+                Period.create(currentTime.plusDays(8), currentTime.plusDays(9)),
+                currentTime
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(updated.getRegistrationPeriod())
+                    .isEqualTo(Period.create(currentTime.plusDays(2), currentTime.plusDays(4)));
+            softly.assertThat(updated.getEventPeriod())
+                    .isEqualTo(Period.create(currentTime.plusDays(8), currentTime.plusDays(9)));
+            softly.assertThat(updated)
+                    .isNotEqualTo(sut);
+        });
+    }
 
     @Test
     void 정상적인_이벤트_운영_기간을_생성한다() {

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -25,6 +25,54 @@ class EventTest {
     }
 
     @Test
+    void 이벤트_정보를_수정할_수_있다() {
+        // given
+        var now = LocalDateTime.now();
+        var registrationPeriod = Period.create(now.plusDays(1), now.plusDays(2));
+        var eventPeriod = Period.create(now.plusDays(3), now.plusDays(4));
+        var sut = Event.create(
+                "이전 제목",
+                "이전 설명",
+                "이전 장소",
+                baseOrganizer,
+                baseOrganization,
+                EventOperationPeriod.create(registrationPeriod, eventPeriod, now),
+                "이전 닉네임",
+                10
+        );
+
+        var updatedRegistrationPeriod = Period.create(now.plusDays(2), now.plusDays(3));
+        var updatedEventPeriod = Period.create(now.plusDays(4), now.plusDays(5));
+        var updatedOperationPeriod = EventOperationPeriod.create(updatedRegistrationPeriod, updatedEventPeriod, now);
+
+        // when
+        sut.update(
+                "수정된 제목",
+                "수정된 설명",
+                "수정된 장소",
+                updatedOperationPeriod,
+                "수정된 닉네임",
+                20
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(sut.getTitle())
+                    .isEqualTo("수정된 제목");
+            softly.assertThat(sut.getDescription())
+                    .isEqualTo("수정된 설명");
+            softly.assertThat(sut.getPlace())
+                    .isEqualTo("수정된 장소");
+            softly.assertThat(sut.getEventOperationPeriod())
+                    .isEqualTo(updatedOperationPeriod);
+            softly.assertThat(sut.getOrganizerNickname())
+                    .isEqualTo("수정된 닉네임");
+            softly.assertThat(sut.getMaxCapacity())
+                    .isEqualTo(20);
+        });
+    }
+
+    @Test
     void 게스트가_이벤트에_참여했는지_알_수_있다() {
         // given
         var now = LocalDateTime.now();

--- a/server/src/test/java/com/ahmadda/domain/PeriodTest.java
+++ b/server/src/test/java/com/ahmadda/domain/PeriodTest.java
@@ -1,6 +1,7 @@
 package com.ahmadda.domain;
 
 import com.ahmadda.domain.exception.BusinessRuleViolatedException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -11,8 +12,34 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class PeriodTest {
+
+    @Test
+    void 기간을_수정할_수_있다() {
+        // given
+        var sut = Period.create(
+                LocalDateTime.of(2025, 7, 1, 10, 0),
+                LocalDateTime.of(2025, 7, 1, 12, 0)
+        );
+
+        // when
+        var updated = sut.update(
+                LocalDateTime.of(2025, 7, 2, 8, 0),
+                LocalDateTime.of(2025, 7, 2, 20, 0)
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(updated.start())
+                    .isEqualTo(LocalDateTime.of(2025, 7, 2, 8, 0));
+            softly.assertThat(updated.end())
+                    .isEqualTo(LocalDateTime.of(2025, 7, 2, 20, 0));
+            softly.assertThat(updated)
+                    .isNotEqualTo(sut);
+        });
+    }
 
     @ParameterizedTest
     @CsvSource({"2025-07-18T04:21, 2025-07-18T04:21", "2025-07-18T04:21, 2025-07-18T04:20"})


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #298 

## ✨ 작업 내용

- 이벤트 주최자 인가 검증 로직 추가
- 주최자가 이벤트 제목, 설명, 일정 등 주요 정보 수정 가능하도록 기능 구현
- 이벤트 수정시 게스트에게 알람을 발송하도록 구현

## 🙏 기타 참고 사항

최근 준의 이벤트를 계기로, 피드백을 통해 "이벤트 제목, 설명, 일정 등 주요 정보를 주최자가 직접 수정할 수 있어야 한다"는 요구가 많았습니다. 이번 기능은 이런 니즈를 반영해 빠르게 개발하게 되었습니다!! 너무 힘드네요 ㅠㅠ

그리고 [검증부(assert/expect)는 하드코딩한다](https://jojoldu.tistory.com/615)라는 주제도 함께 이야기해볼 수 있어 의미 있었다고 생각합니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 기존 이벤트의 정보를 수정할 수 있는 기능이 추가되었습니다.
  * 이벤트 수정 시 모든 참가자에게 변경 알림 이메일이 발송됩니다.

* **버그 수정**
  * 없음

* **문서화**
  * 이벤트 수정 API 엔드포인트가 추가되어 관련 응답 및 오류 코드가 문서화되었습니다.

* **테스트**
  * 이벤트 정보, 기간, 운영 기간 수정 기능에 대한 단위 테스트와 통합 테스트가 추가되었습니다.
  * 이벤트 생성 및 수정 시 인증 객체 사용에 대한 테스트가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->