### PR TITLE
[BE] 이벤트 주최자 여부 API 기능 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -175,10 +175,6 @@ public class Event extends BaseEntity {
     }
 
     public boolean hasGuest(final OrganizationMember organizationMember) {
-        if (organizationMember.equals(organizer)) {
-            return true;
-        }
-
         return guests.stream()
                 .anyMatch(guest -> guest.isSameOrganizationMember(organizationMember));
     }

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -264,9 +264,12 @@ public class Event extends BaseEntity {
         Assert.notNull(organization, "조직은 null이 되면 안됩니다.");
     }
 
-    private void validateBelongToOrganization(final OrganizationMember organizer, final Organization organization) {
-        if (!organizer.isBelongTo(organization)) {
-            throw new UnauthorizedOperationException("자신이 속한 조직에서만 이벤트를 생성할 수 있습니다.");
+    private void validateBelongToOrganization(
+            final OrganizationMember organizationMember,
+            final Organization organization
+    ) {
+        if (!organizationMember.isBelongTo(organization)) {
+            throw new UnauthorizedOperationException("자신이 속한 조직이 아닙니다.");
         }
     }
 

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -150,17 +150,18 @@ public class OrganizationEventController {
             @ApiResponse(
                     responseCode = "403",
                     content = @Content(
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "type": "about:blank",
-                                              "title": "Forbidden",
-                                              "status": 403,
-                                              "detail": "조직에 소속되지 않은 회원입니다.",
-                                              "instance": "/api/organizations/{organizationId}/events"
-                                            }
-                                            """
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Forbidden",
+                                                      "status": 403,
+                                                      "detail": "자신이 속한 조직이 아닙니다.",
+                                                      "instance": "/api/organizations/{organizationId}/events"
+                                                    }
+                                                    """
+                                    )}
                     )
             ),
             @ApiResponse(
@@ -180,17 +181,17 @@ public class OrganizationEventController {
                                                     """
                                     ),
                                     @ExampleObject(
-                                            name = "회원 없음",
+                                            name = "조직원 없음",
                                             value = """
                                                     {
                                                       "type": "about:blank",
                                                       "title": "Not Found",
                                                       "status": 404,
-                                                      "detail": "존재하지 않는 회원입니다.",
+                                                      "detail": "존재하지 않은 조직원 정보입니다.",
                                                       "instance": "/api/organizations/{organizationId}/events"
                                                     }
                                                     """
-                                    )
+                                    ),
                             }
                     )
             ),
@@ -242,18 +243,6 @@ public class OrganizationEventController {
                                                       "title": "Unprocessable Entity",
                                                       "status": 422,
                                                       "detail": "신청 기간은 이벤트 기간보다 앞서야 합니다.",
-                                                      "instance": "/api/organizations/{organizationId}/events"
-                                                    }
-                                                    """
-                                    ),
-                                    @ExampleObject(
-                                            name = "다른 조직에서 생성 시도",
-                                            value = """
-                                                    {
-                                                      "type": "about:blank",
-                                                      "title": "Unprocessable Entity",
-                                                      "status": 422,
-                                                      "detail": "자신이 속한 조직에서만 이벤트를 생성할 수 있습니다.",
                                                       "instance": "/api/organizations/{organizationId}/events"
                                                     }
                                                     """
@@ -315,32 +304,17 @@ public class OrganizationEventController {
             @ApiResponse(
                     responseCode = "403",
                     content = @Content(
-                            examples = {
-                                    @ExampleObject(
-                                            name = "조직에 소속된 회원이 아님",
-                                            value = """
-                                                    {
-                                                      "type": "about:blank",
-                                                      "title": "Forbidden",
-                                                      "status": 403,
-                                                      "detail": "조직에 소속되지 않은 회원입니다.",
-                                                      "instance": "/api/organizations/events/{eventId}/registration/close"
-                                                    }
-                                                    """
-                                    ),
-                                    @ExampleObject(
-                                            name = "이벤트 주최자가 아님",
-                                            value = """
-                                                    {
-                                                      "type": "about:blank",
-                                                      "title": "Forbidden",
-                                                      "status": 403,
-                                                      "detail": "이벤트의 주최자만 마감할 수 있습니다.",
-                                                      "instance": "/api/organizations/events/{eventId}/registration/close"
-                                                    }
-                                                    """
-                                    )
-                            }
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Forbidden",
+                                              "status": 403,
+                                              "detail": "이벤트의 주최자만 마감할 수 있습니다.",
+                                              "instance": "/api/organizations/events/{eventId}/registration/close"
+                                            }
+                                            """
+                            )
                     )
             ),
             @ApiResponse(
@@ -516,6 +490,22 @@ public class OrganizationEventController {
                     content = @Content(
                             schema = @Schema(
                                     implementation = EventDetailResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Forbidden",
+                                              "status": 403,
+                                              "detail": "조직에 소속되지 않은 회원입니다.",
+                                              "instance": "/api/organizations/events/{eventId}/registration/close"
+                                            }
+                                            """
                             )
                     )
             ),

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -648,6 +648,60 @@ public class OrganizationEventController {
         return ResponseEntity.ok(eventResponses);
     }
 
+    @Operation(summary = "내가 주최한 이벤트 여부 조회", description = "내가 주최한 이벤트인지 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = OrganizerStatusResponse.class))
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/organizations/events/{eventId}/organizer-status"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않은 이벤트 정보입니다.",
+                                                      "instance": "/api/organizations/events/{eventId}/organizer-status"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 회원입니다.",
+                                                      "instance": "/api/organizations/events/{eventId}/organizer-status"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
     @GetMapping("/events/{eventId}/organizer-status")
     public ResponseEntity<OrganizerStatusResponse> isOrganizer(
             @PathVariable final Long eventId,

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -12,6 +12,7 @@ import com.ahmadda.presentation.dto.EventCreateResponse;
 import com.ahmadda.presentation.dto.EventDetailResponse;
 import com.ahmadda.presentation.dto.EventResponse;
 import com.ahmadda.presentation.dto.EventUpdateResponse;
+import com.ahmadda.presentation.dto.OrganizerStatusResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -645,5 +646,15 @@ public class OrganizationEventController {
                 .toList();
 
         return ResponseEntity.ok(eventResponses);
+    }
+
+    @GetMapping("/events/{eventId}/organizer-status")
+    public ResponseEntity<OrganizerStatusResponse> isOrganizer(
+            @PathVariable final Long eventId,
+            @AuthMember final LoginMember loginMember
+    ) {
+        boolean isOrganizer = eventService.isOrganizer(eventId, loginMember);
+
+        return ResponseEntity.ok(new OrganizerStatusResponse(isOrganizer));
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizerStatusResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizerStatusResponse.java
@@ -1,0 +1,7 @@
+package com.ahmadda.presentation.dto;
+
+public record OrganizerStatusResponse(
+        boolean isOrganizer
+) {
+
+}

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -261,12 +261,12 @@ class EventGuestServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.participantEvent(
-                                           event.getId(),
-                                           new LoginMember(member2.getId()),
-                                           event.getRegistrationStart(),
-                                           request
-                                   )
+                sut.participantEvent(
+                        event.getId(),
+                        new LoginMember(member2.getId()),
+                        event.getRegistrationStart(),
+                        request
+                )
         )
                 .isInstanceOf(BusinessRuleViolatedException.class)
                 .hasMessageContaining("필수 질문에 대한 답변이 누락되었습니다");
@@ -290,12 +290,12 @@ class EventGuestServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.participantEvent(
-                                           event.getId(),
-                                           new LoginMember(member2.getId()),
-                                           event.getRegistrationStart(),
-                                           request
-                                   )
+                sut.participantEvent(
+                        event.getId(),
+                        new LoginMember(member2.getId()),
+                        event.getRegistrationStart(),
+                        request
+                )
         )
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("존재하지 않는 질문입니다.");
@@ -319,8 +319,8 @@ class EventGuestServiceTest {
         createAndSaveGuest(event, organizationMember2);
 
         //when
-        var actual1 = sut.isGuest(event.getId(), member2.getId());
-        var actual2 = sut.isGuest(event.getId(), member3.getId());
+        var actual1 = sut.isGuest(event.getId(), createLoginMember(organizationMember2));
+        var actual2 = sut.isGuest(event.getId(), createLoginMember(organizationMember3));
 
         //then
         assertThat(actual1).isEqualTo(true);

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -317,12 +317,10 @@ class EventGuestServiceTest {
         //when
         var actual1 = sut.isGuest(event.getId(), member2.getId());
         var actual2 = sut.isGuest(event.getId(), member3.getId());
-        var actual3 = sut.isGuest(event.getId(), member1.getId());
 
         //then
         assertThat(actual1).isEqualTo(true);
         assertThat(actual2).isEqualTo(false);
-        assertThat(actual3).isEqualTo(true);
     }
 
     @Test

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -579,8 +579,12 @@ class EventServiceTest {
         boolean actual2 = sut.isOrganizer(event.getId(), nonOrganizerLoginMember);
 
         //then
-        assertThat(actual1).isTrue();
-        assertThat(actual2).isFalse();
+        assertSoftly(softly -> {
+            softly.assertThat(actual1)
+                    .isTrue();
+            softly.assertThat(actual2)
+                    .isFalse();
+        });
     }
 
     @Test

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -4,7 +4,6 @@ import com.ahmadda.application.dto.EventCreateRequest;
 import com.ahmadda.application.dto.EventUpdateRequest;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.QuestionCreateRequest;
-import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventEmailPayload;
@@ -166,7 +165,7 @@ class EventServiceTest {
         //when //then
         assertThatThrownBy(() -> sut.createEvent(organization.getId(), loginMember, eventCreateRequest, now))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 회원입니다.");
+                .hasMessage("존재하지 않은 조직원 정보입니다.");
     }
 
     @Test
@@ -193,8 +192,8 @@ class EventServiceTest {
 
         //when //then
         assertThatThrownBy(() -> sut.createEvent(organization1.getId(), loginMember, eventCreateRequest, now))
-                .isInstanceOf(AccessDeniedException.class)
-                .hasMessage("조직에 소속되지 않은 회원입니다.");
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않은 조직원 정보입니다.");
     }
 
     @Test
@@ -224,7 +223,7 @@ class EventServiceTest {
         //when //then
         assertThatThrownBy(() -> createEvent(organizationMember, organization)).isInstanceOf(
                         UnauthorizedOperationException.class)
-                .hasMessage("자신이 속한 조직에서만 이벤트를 생성할 수 있습니다.");
+                .hasMessage("자신이 속한 조직이 아닙니다.");
     }
 
     @Test
@@ -255,7 +254,7 @@ class EventServiceTest {
                 now
         ))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 회원입니다.");
+                .hasMessage("존재하지 않은 조직원 정보입니다.");
     }
 
     @Test
@@ -279,8 +278,8 @@ class EventServiceTest {
                 notBelongingOrgMember.getId(),
                 now
         ))
-                .isInstanceOf(AccessDeniedException.class)
-                .hasMessage("조직에 소속되지 않은 회원입니다.");
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않은 조직원 정보입니다.");
     }
 
     @Test
@@ -561,6 +560,54 @@ class EventServiceTest {
                 }),
                 eq(email)
         );
+    }
+
+    @Test
+    void 로그인한_회원이_이벤트의_주최자인지_확인할_수_있다() {
+        //given
+        var organization = createOrganization();
+        var organizerMember = createMember("surf", "surf@ahmadda.com");
+        var nonOrganizerMember = createMember("tuda", "tuda@ahmadda.com");
+        var organizer = createOrganizationMember(organization, organizerMember);
+        var nonOrganizer = createOrganizationMember(organization, nonOrganizerMember);
+        var event = createEvent(organizer, organization);
+        var organizerLoginMember = createLoginMember(organizerMember);
+        var nonOrganizerLoginMember = createLoginMember(nonOrganizerMember);
+
+        //when
+        boolean actual1 = sut.isOrganizer(event.getId(), organizerLoginMember);
+        boolean actual2 = sut.isOrganizer(event.getId(), nonOrganizerLoginMember);
+
+        //then
+        assertThat(actual1).isTrue();
+        assertThat(actual2).isFalse();
+    }
+
+    @Test
+    void 이벤트의_주최자인지_확인할때_존재하지_않는_이벤트라면_예외가_발생한다() {
+        //given
+        var organization = createOrganization();
+        var member = createMember("surf", "surf@ahmadda.com");
+        var loginMember = createLoginMember(member);
+
+        //when //then
+        assertThatThrownBy(() -> sut.isOrganizer(999L, loginMember))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않은 이벤트 정보입니다.");
+    }
+
+    @Test
+    void 이벤트의_주최자인지_확인할때_존재하지_않는_회원이라면_예외가_발생한다() {
+        //given
+        var organization = createOrganization();
+        var organizerMember = createMember("surf", "surf@ahmadda.com");
+        var organizer = createOrganizationMember(organization, organizerMember);
+        var event = createEvent(organizer, organization);
+
+        //when //then
+        assertThatThrownBy(() -> sut.isOrganizer(event.getId(), new LoginMember(999L)))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 회원입니다.");
     }
 
     private Organization createOrganization() {

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -204,7 +204,7 @@ class EventTest {
         //when //then
         assertThatThrownBy(() -> createEvent(organizationMember, organization2))
                 .isInstanceOf(UnauthorizedOperationException.class)
-                .hasMessage("자신이 속한 조직에서만 이벤트를 생성할 수 있습니다.");
+                .hasMessage("자신이 속한 조직이 아닙니다.");
     }
 
     @ParameterizedTest

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -154,7 +154,6 @@ class EventTest {
         // when
         var actual1 = sut.hasGuest(guest);
         var actual2 = sut.hasGuest(notGuest);
-        var actual3 = sut.hasGuest(baseOrganizer);
 
         // then
         assertSoftly(softly -> {
@@ -162,8 +161,6 @@ class EventTest {
                     .isTrue();
             softly.assertThat(actual2)
                     .isFalse();
-            softly.assertThat(actual3)
-                    .isTrue();
         });
     }
 


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #320 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
- 이벤트의 주최자 여부를 알려주는 API를 구현했습니다. 
- 간단한 리팩터링을 진행했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 특정 이벤트의 주최자인지 확인할 수 있는 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 조직원이 아닌 경우 및 존재하지 않는 회원/이벤트에 대한 예외 메시지가 더 명확하게 개선되었습니다.

* **문서**
  * API 오류 응답 예시 및 메시지가 일관성 있게 수정되었습니다.

* **테스트**
  * 주최자 여부 확인 기능에 대한 테스트가 추가되었고, 기존 테스트의 예외 메시지 및 일부 검증 로직이 개선되었습니다.

* **리팩터**
  * 내부 유효성 검사 및 도메인 엔티티 조회 방식이 개선되어 예외 처리가 더 구체적으로 분리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->