### PR TITLE
[FE] Badge 컴포넌트, 스토리북 

### DIFF
--- a/client/src/shared/components/Badge/Badge.stories.tsx
+++ b/client/src/shared/components/Badge/Badge.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { Flex } from '../Flex';
+
 import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {
@@ -10,16 +12,16 @@ const meta: Meta<typeof Badge> = {
     docs: {
       description: {
         component:
-          'A badge component for displaying status information with different visual styles based on the type. Supports three types: recruiting, scheduled, and closed.',
+          'A badge component for displaying status information with different visual styles based on the variant. Supports three variants: blue, gray, and red.',
       },
     },
   },
   tags: ['autodocs'],
   argTypes: {
-    type: {
+    variant: {
       control: { type: 'select' },
-      options: ['모집중', '예정', '마감'],
-      description: 'The type of badge to display',
+      options: ['blue', 'gray', 'red'],
+      description: 'The variant of badge to display',
     },
   },
 };
@@ -29,16 +31,17 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    type: '모집중',
+    variant: 'blue',
+    children: '모집중',
   },
 };
 
-export const AllTypes: Story = {
+export const AllVariants: Story = {
   render: () => (
-    <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
-      <Badge type="모집중" />
-      <Badge type="예정" />
-      <Badge type="마감" />
-    </div>
+    <Flex gap="16px" alignItems="center">
+      <Badge variant="blue">모집중</Badge>
+      <Badge variant="gray">예정</Badge>
+      <Badge variant="red">신청마감</Badge>
+    </Flex>
   ),
 };

--- a/client/src/shared/components/Badge/Badge.stories.tsx
+++ b/client/src/shared/components/Badge/Badge.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Badge } from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Components/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A badge component for displaying status information with different visual styles based on the type. Supports three types: recruiting, scheduled, and closed.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: { type: 'select' },
+      options: ['모집중', '예정', '마감'],
+      description: 'The type of badge to display',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    type: '모집중',
+  },
+};
+
+export const AllTypes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
+      <Badge type="모집중" />
+      <Badge type="예정" />
+      <Badge type="마감" />
+    </div>
+  ),
+};

--- a/client/src/shared/components/Badge/Badge.styled.ts
+++ b/client/src/shared/components/Badge/Badge.styled.ts
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+
+import { theme } from '@/shared/styles/theme';
+
+import { BadgeType } from './Badge';
+
+export const StyledBadge = styled.div<{ type: BadgeType }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1.5;
+
+  ${({ type }) => {
+    switch (type) {
+      case '모집중':
+        return `
+          background-color: ${theme.colors.primary50};
+          color: ${theme.colors.primary600};
+        `;
+      case '예정':
+        return `
+          background-color: ${theme.colors.gray100};
+          color: ${theme.colors.gray500};
+        `;
+      case '마감':
+        return `
+          background-color: ${theme.colors.red50};
+          color: ${theme.colors.red600};
+        `;
+      default:
+        return `
+          background-color: ${theme.colors.gray100};
+          color: ${theme.colors.gray500};
+        `;
+    }
+  }}
+`;

--- a/client/src/shared/components/Badge/Badge.styled.ts
+++ b/client/src/shared/components/Badge/Badge.styled.ts
@@ -2,40 +2,32 @@ import styled from '@emotion/styled';
 
 import { theme } from '@/shared/styles/theme';
 
-import { BadgeType } from './Badge';
+export type BadgeVariant = {
+  backgroundColor: string;
+  textColor: string;
+};
 
-export const StyledBadge = styled.div<{ type: BadgeType }>`
+export const BADGE_VARIANTS: Record<string, BadgeVariant> = {
+  blue: {
+    backgroundColor: `${theme.colors.primary50}`,
+    textColor: `${theme.colors.primary600}`,
+  },
+  gray: {
+    backgroundColor: `${theme.colors.gray100}`,
+    textColor: `${theme.colors.gray500}`,
+  },
+  red: {
+    backgroundColor: `${theme.colors.red50}`,
+    textColor: `${theme.colors.red600}`,
+  },
+};
+
+export const StyledBadge = styled.div<BadgeVariant>`
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 2px 8px;
   border-radius: 4px;
-  font-weight: 600;
-  font-size: 13px;
-  line-height: 1.5;
-
-  ${({ type }) => {
-    switch (type) {
-      case '모집중':
-        return `
-          background-color: ${theme.colors.primary50};
-          color: ${theme.colors.primary600};
-        `;
-      case '예정':
-        return `
-          background-color: ${theme.colors.gray100};
-          color: ${theme.colors.gray500};
-        `;
-      case '마감':
-        return `
-          background-color: ${theme.colors.red50};
-          color: ${theme.colors.red600};
-        `;
-      default:
-        return `
-          background-color: ${theme.colors.gray100};
-          color: ${theme.colors.gray500};
-        `;
-    }
-  }}
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  color: ${({ textColor }) => textColor};
 `;

--- a/client/src/shared/components/Badge/Badge.tsx
+++ b/client/src/shared/components/Badge/Badge.tsx
@@ -1,24 +1,22 @@
-import { StyledBadge } from './Badge.styled';
+import { ReactNode } from 'react';
 
-export type BadgeType = '모집중' | '예정' | '마감';
+import { Text } from '@/shared/components/Text';
+
+import { BADGE_VARIANTS, StyledBadge } from './Badge.styled';
 
 type BadgeProps = {
-  type: BadgeType;
+  variant: keyof typeof BADGE_VARIANTS;
+  children: ReactNode;
 };
 
-export const Badge = ({ type }: BadgeProps) => {
-  const getBadgeText = () => {
-    switch (type) {
-      case '모집중':
-        return '모집중';
-      case '예정':
-        return '예정';
-      case '마감':
-        return '신청마감';
-      default:
-        return '모집중';
-    }
-  };
+export const Badge = ({ variant = 'blue', children, ...props }: BadgeProps) => {
+  const style = BADGE_VARIANTS[variant];
 
-  return <StyledBadge type={type}>{getBadgeText()}</StyledBadge>;
+  return (
+    <StyledBadge backgroundColor={style.backgroundColor} textColor={style.textColor} {...props}>
+      <Text type="Label" weight="semibold" color={style.textColor}>
+        {children}
+      </Text>
+    </StyledBadge>
+  );
 };

--- a/client/src/shared/components/Badge/Badge.tsx
+++ b/client/src/shared/components/Badge/Badge.tsx
@@ -1,0 +1,24 @@
+import { StyledBadge } from './Badge.styled';
+
+export type BadgeType = '모집중' | '예정' | '마감';
+
+type BadgeProps = {
+  type: BadgeType;
+};
+
+export const Badge = ({ type }: BadgeProps) => {
+  const getBadgeText = () => {
+    switch (type) {
+      case '모집중':
+        return '모집중';
+      case '예정':
+        return '예정';
+      case '마감':
+        return '신청마감';
+      default:
+        return '모집중';
+    }
+  };
+
+  return <StyledBadge type={type}>{getBadgeText()}</StyledBadge>;
+};

--- a/client/src/shared/components/Badge/index.ts
+++ b/client/src/shared/components/Badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge } from './Badge';
+export type { BadgeType } from './Badge';

--- a/client/src/shared/components/Badge/index.ts
+++ b/client/src/shared/components/Badge/index.ts
@@ -1,2 +1,1 @@
 export { Badge } from './Badge';
-export type { BadgeType } from './Badge';


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #141 

## ✨ 작업 내용

- 공통 Badge 컴포넌트와 스토리북을 구현하였습니다. 

### 구조 고민
- '모집중', '예정', '신청마감' 만을 염두하였는데, 더 유연한 구조로 바꾸어야 할까요?
- 지금 생각에서는 사실 이 Badge가 더 확장성 있게 쓰일만한 곳이 떠오르지 않네요.
- 예를 들면 getBadgeText를 children으로 받는다던가 등등 더 유연한 구조가 좋을지 의견 부탁드립니다!





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 모집 상태를 나타내는 배지(Badge) 컴포넌트가 추가되었습니다. (모집중, 예정, 마감)
  * 다양한 배지 타입을 미리 볼 수 있는 스토리북 예제가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->