### PR TITLE
[BE] 이벤트 생성 및 이벤트 수정시 주최자 이름 요청으로 안받게 변경

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -60,7 +60,6 @@ public class EventService {
                 organizer,
                 organization,
                 eventOperationPeriod,
-                eventCreateRequest.organizerNickname(),
                 eventCreateRequest.maxCapacity(),
                 createQuestions(eventCreateRequest.questions())
         );
@@ -116,7 +115,6 @@ public class EventService {
                 eventUpdateRequest.description(),
                 eventUpdateRequest.place(),
                 updatedOperationPeriod,
-                eventUpdateRequest.organizerNickname(),
                 eventUpdateRequest.maxCapacity()
         );
 

--- a/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
@@ -21,8 +21,6 @@ public record EventCreateRequest(
         LocalDateTime eventStart,
         @NotNull
         LocalDateTime eventEnd,
-        @NotBlank
-        String organizerNickname,
         int maxCapacity,
         @Valid
         List<QuestionCreateRequest> questions

--- a/server/src/main/java/com/ahmadda/application/dto/EventUpdateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventUpdateRequest.java
@@ -19,8 +19,6 @@ public record EventUpdateRequest(
         LocalDateTime eventStart,
         @NotNull
         LocalDateTime eventEnd,
-        @NotBlank
-        String organizerNickname,
         int maxCapacity
 ) {
 

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -70,9 +70,6 @@ public class Event extends BaseEntity {
     private EventOperationPeriod eventOperationPeriod;
 
     @Column(nullable = false)
-    private String organizerNickname;
-
-    @Column(nullable = false)
     private int maxCapacity;
 
     private Event(
@@ -82,7 +79,6 @@ public class Event extends BaseEntity {
             final OrganizationMember organizer,
             final Organization organization,
             final EventOperationPeriod eventOperationPeriod,
-            final String organizerNickname,
             final int maxCapacity,
             final List<Question> questions
     ) {
@@ -90,7 +86,6 @@ public class Event extends BaseEntity {
         validateOrganizer(organizer);
         validateOrganization(organization);
         validateBelongToOrganization(organizer, organization);
-        validateOrganizerNickname(organizerNickname);
         validateMaxCapacity(maxCapacity);
 
         this.title = title;
@@ -99,7 +94,6 @@ public class Event extends BaseEntity {
         this.organizer = organizer;
         this.organization = organization;
         this.eventOperationPeriod = eventOperationPeriod;
-        this.organizerNickname = organizerNickname;
         this.maxCapacity = maxCapacity;
 
         organization.addEvent(this);
@@ -113,7 +107,6 @@ public class Event extends BaseEntity {
             final OrganizationMember organizer,
             final Organization organization,
             final EventOperationPeriod eventOperationPeriod,
-            final String organizerNickname,
             final int maxCapacity,
             final Question... questions
     ) {
@@ -124,7 +117,6 @@ public class Event extends BaseEntity {
                 organizer,
                 organization,
                 eventOperationPeriod,
-                organizerNickname,
                 maxCapacity,
                 new ArrayList<>(List.of(questions))
         );
@@ -137,7 +129,6 @@ public class Event extends BaseEntity {
             final OrganizationMember organizer,
             final Organization organization,
             final EventOperationPeriod eventOperationPeriod,
-            final String organizerNickname,
             final int maxCapacity,
             final List<Question> questions
     ) {
@@ -148,7 +139,6 @@ public class Event extends BaseEntity {
                 organizer,
                 organization,
                 eventOperationPeriod,
-                organizerNickname,
                 maxCapacity,
                 questions
         );
@@ -160,19 +150,16 @@ public class Event extends BaseEntity {
             final String description,
             final String place,
             final EventOperationPeriod eventOperationPeriod,
-            final String organizerNickname,
             final int maxCapacity
     ) {
         validateUpdatableBy(organizer);
         validateTitle(title);
-        validateOrganizerNickname(organizerNickname);
         validateMaxCapacity(maxCapacity);
 
         this.title = title;
         this.description = description;
         this.place = place;
         this.eventOperationPeriod = eventOperationPeriod;
-        this.organizerNickname = organizerNickname;
         this.maxCapacity = maxCapacity;
     }
 
@@ -227,8 +214,10 @@ public class Event extends BaseEntity {
                 .equals(member);
     }
 
-    public void cancelParticipation(final OrganizationMember organizationMember,
-                                    final LocalDateTime cancelParticipateTime) {
+    public void cancelParticipation(
+            final OrganizationMember organizationMember,
+            final LocalDateTime cancelParticipateTime
+    ) {
         validateCancelParticipation(cancelParticipateTime);
         Guest guest = getGuestByOrganizationMember(organizationMember);
         guests.remove(guest);

--- a/server/src/main/java/com/ahmadda/domain/EventEmailPayload.java
+++ b/server/src/main/java/com/ahmadda/domain/EventEmailPayload.java
@@ -21,7 +21,8 @@ public record EventEmailPayload(
                 event.getOrganization()
                         .getName(),
                 event.getTitle(),
-                event.getOrganizerNickname(),
+                event.getOrganizer()
+                        .getNickname(),
                 event.getPlace(),
                 event.getRegistrationStart(),
                 event.getRegistrationEnd(),

--- a/server/src/main/java/com/ahmadda/presentation/dto/EventDetailResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/EventDetailResponse.java
@@ -44,7 +44,8 @@ public record EventDetailResponse(
                 event.getTitle(),
                 event.getDescription(),
                 event.getPlace(),
-                event.getOrganizerNickname(),
+                event.getOrganizer()
+                        .getNickname(),
                 event.getEventStart(),
                 event.getEventEnd(),
                 event.getRegistrationStart(),

--- a/server/src/main/java/com/ahmadda/presentation/dto/EventResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/EventResponse.java
@@ -31,7 +31,8 @@ public record EventResponse(
                 event.getPlace(),
                 event.getRegistrationStart(),
                 event.getRegistrationEnd(),
-                event.getOrganizerNickname()
+                event.getOrganizer()
+                        .getNickname()
         );
     }
 }

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -374,7 +374,6 @@ class EventGuestServiceTest {
                         now.plusDays(1), now.plusDays(2),
                         now.minusDays(6)
                 ),
-                organizer.getNickname(),
                 100,
                 questions
         );
@@ -405,7 +404,6 @@ class EventGuestServiceTest {
                         eventEnd,
                         creationTime
                 ),
-                organizer.getNickname(),
                 100,
                 questions
         );

--- a/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
@@ -80,7 +80,7 @@ class EventNotificationServiceTest {
                         now.plusDays(1), now.plusDays(2),
                         now.minusDays(3)
                 ),
-                organizer.getNickname(), 100
+                100
         ));
 
         var request = createNotificationRequest();
@@ -141,7 +141,6 @@ class EventNotificationServiceTest {
                         now.plusDays(2), now.plusDays(3),
                         now.minusDays(2)
                 ),
-                organizer.getNickname(),
                 100
         ));
 
@@ -174,7 +173,6 @@ class EventNotificationServiceTest {
                         now.plusDays(1), now.plusDays(2),
                         now.minusDays(3)
                 ),
-                organizer.getNickname(),
                 100
         ));
 
@@ -232,7 +230,6 @@ class EventNotificationServiceTest {
                         now.plusDays(2), now.plusDays(3),
                         now.minusDays(2)
                 ),
-                organizer.getNickname(),
                 100
         ));
 
@@ -265,7 +262,6 @@ class EventNotificationServiceTest {
                         now.plusDays(2), now.plusDays(3),
                         now.minusDays(2)
                 ),
-                organizer.getNickname(),
                 100
         ));
 

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -86,7 +86,6 @@ class EventServiceTest {
                 "선릉",
                 now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
-                "이벤트 근로",
                 100,
                 List.of(new QuestionCreateRequest("1번 질문", true), new QuestionCreateRequest("2번 질문", false))
         );
@@ -136,7 +135,6 @@ class EventServiceTest {
                 "선릉",
                 now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
-                "이벤트 근로",
                 100,
                 List.of(new QuestionCreateRequest("1번 질문", true), new QuestionCreateRequest("2번 질문", false))
         );
@@ -161,7 +159,6 @@ class EventServiceTest {
                 "선릉",
                 now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
-                "이밴트 근로",
                 100,
                 new ArrayList<>()
         );
@@ -189,7 +186,6 @@ class EventServiceTest {
                 "선릉",
                 now.plusDays(4),
                 now.plusDays(5), now.plusDays(6),
-                "이밴트 근로",
                 100,
                 new ArrayList<>()
         );
@@ -330,7 +326,6 @@ class EventServiceTest {
                 now.plusDays(4),
                 now.plusDays(5),
                 now.plusDays(6),
-                "이벤트 근로",
                 100,
                 List.of(
                         new QuestionCreateRequest("1번 질문", true),
@@ -370,7 +365,6 @@ class EventServiceTest {
                         now.plusDays(3), now.plusDays(4),
                         now
                 ),
-                "원래 닉네임",
                 50
         );
         eventRepository.save(event);
@@ -382,7 +376,6 @@ class EventServiceTest {
                 now.plusDays(5),
                 now.plusDays(6),
                 now.plusDays(7),
-                "수정된 닉네임",
                 200
         );
 
@@ -402,8 +395,6 @@ class EventServiceTest {
                                 .isEqualTo("수정된 설명");
                         softly.assertThat(savedEvent.getPlace())
                                 .isEqualTo("수정된 장소");
-                        softly.assertThat(savedEvent.getOrganizerNickname())
-                                .isEqualTo("수정된 닉네임");
                         softly.assertThat(savedEvent.getMaxCapacity())
                                 .isEqualTo(200);
 
@@ -437,7 +428,6 @@ class EventServiceTest {
                 now.plusDays(5),
                 now.plusDays(6),
                 now.plusDays(7),
-                "수정된 닉네임",
                 200
         );
 
@@ -466,7 +456,6 @@ class EventServiceTest {
                         now.plusDays(3), now.plusDays(4),
                         now
                 ),
-                "원래 닉네임",
                 50
         );
         eventRepository.save(event);
@@ -478,7 +467,6 @@ class EventServiceTest {
                 now.plusDays(5),
                 now.plusDays(6),
                 now.plusDays(7),
-                "수정된 닉네임",
                 200
         );
         var loginMember = new LoginMember(9999L);
@@ -516,7 +504,6 @@ class EventServiceTest {
                         now.plusDays(3), now.plusDays(4),
                         now
                 ),
-                "원래 닉네임",
                 50
         );
         eventRepository.save(event);
@@ -533,7 +520,6 @@ class EventServiceTest {
                 now.plusDays(5),
                 now.plusDays(6),
                 now.plusDays(7),
-                "수정된 닉네임",
                 200
         );
 
@@ -640,7 +626,6 @@ class EventServiceTest {
                         now.plusDays(3), now.plusDays(4),
                         now
                 ),
-                "이벤트 근로",
                 10
         );
 

--- a/server/src/test/java/com/ahmadda/application/OrganizationMemberEventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationMemberEventServiceTest.java
@@ -266,7 +266,6 @@ class OrganizationMemberEventServiceTest {
                         LocalDateTime.now()
                                 .minusDays(20)
                 ),
-                organizer.getNickname(),
                 maxCapacity
         );
         return eventRepository.save(event);

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -234,7 +234,6 @@ class OrganizationServiceTest {
                         end.plusHours(1), end.plusHours(2),
                         start.minusDays(1)
                 ),
-                organizer.getNickname(),
                 100
         );
     }

--- a/server/src/test/java/com/ahmadda/domain/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventTest.java
@@ -45,7 +45,6 @@ class EventTest {
                         eventPeriod.end(),
                         now
                 ),
-                "이전 닉네임",
                 10
         );
 
@@ -61,12 +60,12 @@ class EventTest {
 
         // when
         sut.update(
-                sut.getOrganizer().getMember(),
+                sut.getOrganizer()
+                        .getMember(),
                 "수정된 제목",
                 "수정된 설명",
                 "수정된 장소",
                 updatedOperationPeriod,
-                "수정된 닉네임",
                 20
         );
 
@@ -80,8 +79,6 @@ class EventTest {
                     .isEqualTo("수정된 장소");
             softly.assertThat(sut.getEventOperationPeriod())
                     .isEqualTo(updatedOperationPeriod);
-            softly.assertThat(sut.getOrganizerNickname())
-                    .isEqualTo("수정된 닉네임");
             softly.assertThat(sut.getMaxCapacity())
                     .isEqualTo(20);
         });
@@ -106,7 +103,6 @@ class EventTest {
                         eventPeriod.end(),
                         now
                 ),
-                "이전 닉네임",
                 10
         );
 
@@ -129,7 +125,6 @@ class EventTest {
                 "수정된 설명",
                 "수정된 장소",
                 updatedOperationPeriod,
-                "수정된 닉네임",
                 20
         ))
                 .isInstanceOf(UnauthorizedOperationException.class)
@@ -398,9 +393,13 @@ class EventTest {
 
         //when // then
         assertSoftly(softly -> {
-            softly.assertThat(sut.getGuests().size()).isEqualTo(1L);
+            softly.assertThat(sut.getGuests()
+                            .size())
+                    .isEqualTo(1L);
             sut.cancelParticipation(organizationMember2, LocalDateTime.now());
-            softly.assertThat(sut.getGuests().size()).isEqualTo(0L);
+            softly.assertThat(sut.getGuests()
+                            .size())
+                    .isEqualTo(0L);
         });
     }
 
@@ -525,7 +524,6 @@ class EventTest {
                                 .plusDays(4),
                         LocalDateTime.now()
                 ),
-                "이벤트 근로",
                 maxCapacity,
                 questions
         );
@@ -543,7 +541,6 @@ class EventTest {
                         now.plusDays(3), now.plusDays(4),
                         now
                 ),
-                "이벤트 근로",
                 10
         );
     }
@@ -574,7 +571,6 @@ class EventTest {
                 createOrganizationMember(createMember(), organization),
                 organization,
                 eventOperationPeriod,
-                "이벤트 근로",
                 100
         );
     }
@@ -605,7 +601,6 @@ class EventTest {
                         now.plusDays(3), now.plusDays(4),
                         now
                 ),
-                "이벤트 근로",
                 10
         );
     }

--- a/server/src/test/java/com/ahmadda/domain/GuestTest.java
+++ b/server/src/test/java/com/ahmadda/domain/GuestTest.java
@@ -30,7 +30,6 @@ class GuestTest {
                         now.plusDays(10), now.plusDays(11),
                         now
                 ),
-                organizer.getNickname(),
                 50
         );
         member = Member.create("참가자 회원", "guest@example.com");
@@ -90,7 +89,6 @@ class GuestTest {
                         now.plusDays(10), now.plusDays(11),
                         now
                 ),
-                organizationMember1.getNickname(),
                 50
         );
 
@@ -114,7 +112,6 @@ class GuestTest {
                         now.plusDays(10), now.plusDays(11),
                         now
                 ),
-                organizationMember.getNickname(),
                 50
         );
 
@@ -140,7 +137,6 @@ class GuestTest {
                         now.plusDays(10), now.plusDays(11),
                         now
                 ),
-                organizationMember1.getNickname(),
                 1
         );
         Guest.create(event, organizationMember2, event.getRegistrationStart());
@@ -245,7 +241,6 @@ class GuestTest {
                         now.plusDays(2), now.plusDays(3),
                         now
                 ),
-                organizer.getNickname(),
                 10,
                 questions
         );

--- a/server/src/test/java/com/ahmadda/domain/OrganizationMemberTest.java
+++ b/server/src/test/java/com/ahmadda/domain/OrganizationMemberTest.java
@@ -52,7 +52,6 @@ class OrganizationMemberTest {
                         now.plusDays(10), now.plusDays(11),
                         now
                 ),
-                "이벤트 근로",
                 50
         );
     }

--- a/server/src/test/java/com/ahmadda/domain/OrganizationTest.java
+++ b/server/src/test/java/com/ahmadda/domain/OrganizationTest.java
@@ -49,7 +49,6 @@ class OrganizationTest {
                         start, end,
                         start.minusDays(6)
                 ),
-                organizer.getNickname(),
                 50
         );
     }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #354 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

이벤트 생성 API와 이벤트 수정 API에서 주최자의 이름을 요청 받는 로직을 삭제했습니다. 
