### PR TITLE
[BE] 초대코드를 통한 조직 조회 API 구현 

### DIFF
--- a/server/src/main/java/com/ahmadda/application/OrganizationInviteCodeService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationInviteCodeService.java
@@ -1,6 +1,7 @@
 package com.ahmadda.application;
 
 import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.application.exception.BusinessFlowViolatedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.InviteCode;
 import com.ahmadda.domain.InviteCodeRepository;
@@ -36,6 +37,17 @@ public class OrganizationInviteCodeService {
         OrganizationMember inviter = getOrganizationMember(organizationId, loginMember);
 
         return findOrCreateInviteCode(inviter, organization, now);
+    }
+
+    public Organization getOrganizationByCode(final String code) {
+        InviteCode inviteCode = inviteCodeRepository.findByCode(code)
+                .orElseThrow(() -> new BusinessFlowViolatedException("유효하지 않은 초대코드입니다."));
+
+        if (inviteCode.isExpired(LocalDateTime.now())) {
+            throw new BusinessFlowViolatedException("만료된 초대코드입니다.");
+        }
+        
+        return inviteCode.getOrganization();
     }
 
     private Organization getOrganization(final Long organizationId) {

--- a/server/src/main/java/com/ahmadda/domain/InviteCode.java
+++ b/server/src/main/java/com/ahmadda/domain/InviteCode.java
@@ -72,6 +72,10 @@ public class InviteCode extends BaseEntity {
         return new InviteCode(code, expiresAt, organization, inviter);
     }
 
+    public boolean isExpired(LocalDateTime currentDateTime) {
+        return currentDateTime.isAfter(expiresAt);
+    }
+
     private static void validateBelongToOrganization(
             final Organization organization,
             final OrganizationMember organizationMember

--- a/server/src/main/java/com/ahmadda/domain/InviteCodeRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/InviteCodeRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 
 public interface InviteCodeRepository extends JpaRepository<InviteCode, Long> {
 
-    Optional<InviteCode> findFirstByInviterAndExpiresAtAfter(OrganizationMember inviter, LocalDateTime now);
+    Optional<InviteCode> findFirstByInviterAndExpiresAtAfter(final OrganizationMember inviter, final LocalDateTime now);
+
+    Optional<InviteCode> findByCode(final String code);
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -679,6 +679,7 @@ public class OrganizationEventController {
                     content = @Content(
                             examples = {
                                     @ExampleObject(
+                                            name = "이벤트 없음",
                                             value = """
                                                     {
                                                       "type": "about:blank",
@@ -690,6 +691,7 @@ public class OrganizationEventController {
                                                     """
                                     ),
                                     @ExampleObject(
+                                            name = "회원 없음",
                                             value = """
                                                     {
                                                       "type": "about:blank",

--- a/server/src/test/java/com/ahmadda/application/OrganizationInviteCodeServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationInviteCodeServiceTest.java
@@ -181,7 +181,7 @@ class OrganizationInviteCodeServiceTest {
     }
 
     @Test
-    void 만료된_초대코드를_통해_조직을_조회할_수_있다() {
+    void 만료된_초대코드를_통해_조직을_조회한다면_예외가_발생한다() {
         //given
         var organization = createAndSaveOrganization("우테코");
         var member = createAndSaveMember("surf", "surf@ahmadda.com");

--- a/server/src/test/java/com/ahmadda/domain/InviteCodeTest.java
+++ b/server/src/test/java/com/ahmadda/domain/InviteCodeTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class InviteCodeTest {
 
@@ -37,6 +38,28 @@ class InviteCodeTest {
 
         //then
         assertThat(inviteCode.getExpiresAt()).isEqualTo(currentDateTime.plusDays(7));
+    }
+
+    @Test
+    void 초대코드가_만료됐는지_확인할_수_있다() {
+        //given
+        var organization = createOrganization("우테코");
+        var member = createMember();
+        var inviter = createOrganizationMember(member, organization);
+        var expiredInviteCode = InviteCode.create("code", organization, inviter, LocalDateTime.of(2000, 1, 1, 0, 0));
+        var nonExpiredInviteCode = InviteCode.create("code", organization, inviter, LocalDateTime.now());
+
+        //when
+        var actual1 = expiredInviteCode.isExpired(LocalDateTime.now());
+        var actual2 = nonExpiredInviteCode.isExpired(LocalDateTime.now());
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(actual1)
+                    .isEqualTo(true);
+            softly.assertThat(actual2)
+                    .isEqualTo(false);
+        });
     }
 
     private OrganizationMember createOrganizationMember(Member member, Organization organization) {


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #356 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
초대코드를 통해 조직을 조회하는 API를 구현헀습니다. 

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
프론트엔드에서는 초대코드를 포함한 URL로 사용자가 접속하면, 해당 조직의 설명을 화면에 표시하고 사용자에게 닉네임을 입력받을 예정입니다. 이때 조직 정보를 조회하려면 초대코드를 통해 조직을 조회할 수 있어야 하기 때문에, 해당 API를 구현했습니다.
