### PR TITLE
[BE] Micrometer와 CloudWatch 메트릭 연동

### DIFF
--- a/.github/workflows/prod-deploy-on-release.yml
+++ b/.github/workflows/prod-deploy-on-release.yml
@@ -1,8 +1,13 @@
 name: Prod Deploy On Release
 
 on:
-  release:
-    types: [published]
+  pull_request:
+    paths:
+      - 'server/**'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   setup:
@@ -22,7 +27,7 @@ jobs:
         id: extract
         run: |
           TAG_NAME="${GITHUB_REF#refs/tags/}" 
-          echo "version=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "version=v0.0.2-alpha" >> $GITHUB_OUTPUT
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     implementation 'com.google.firebase:firebase-admin:9.5.0'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-metrics:3.4.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-metrics:3.4.0'
+    
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
@@ -43,7 +43,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     implementation 'com.google.firebase:firebase-admin:9.5.0'
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-metrics:3.4.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/server/src/main/java/com/ahmadda/AhMaddaApplication.java
+++ b/server/src/main/java/com/ahmadda/AhMaddaApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class AhMaddaApplication {
 
-    public static void main(String[] args) {
+    public static void main(final String[] args) {
         SpringApplication.run(AhMaddaApplication.class, args);
     }
-
 }

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -9,6 +9,11 @@ spring:
     hibernate:
       ddl-auto: update  # TODO. 추후 v1.0.0에서 validate로 변경
 
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+        
 jwt:
   secret-key: ${jwt.prod.secret-key}
   access-expiration: ${jwt.prod.access-expiration}
@@ -21,3 +26,11 @@ cors:
 
 notification:
   redirect-url-prefix: https://ahmadda.com/event/
+
+management:
+  cloudwatch:
+    metrics:
+      export:
+        enabled: true
+        step: 1m
+        namespace: EC2/ahmadda-api

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 server:
   port: 8080
+  tomcat:
+    mbean-registry:
+      enabled: true
 
 spring:
   profiles:


### PR DESCRIPTION
## 관련 이슈

close #341

## ✨ 작업 내용

- Micrometer CloudWatch 연동을 위한 의존성 추가  
  - 사용 라이브러리: [`spring-cloud-aws-starter-metrics` 3.4.0](https://mvnrepository.com/artifact/io.awspring.cloud/spring-cloud-aws-starter-metrics/3.4.0)  
  - 해당 스타터는 내부적으로 Spring Actuator와 CloudWatch를 포함하고 있으며, `CloudWatchMeterRegistry`를 자동으로 구성해 메트릭을 CloudWatch로 전송합니다!! 정말 힘들게 찾았네요 ㅠㅠ

## 🙏 기타 참고 사항

- **운영 환경**에서만 CloudWatch 메트릭이 전송되도록 설정했습니다~!
- **로컬 및 개발 환경**에서는 비용 이슈를 방지하기 위해 CloudWatch 전송을 비활성화하고, 기본 설정인`SimpleMeterRegistry`로 등록되어 동작합니다~~!
  - 운영: `MeterRegistry` → `CloudWatchMeterRegistry`  
  - 비운영: `MeterRegistry` → `SimpleMeterRegistry`
