### PR TITLE
[FE] FCM token 전송 로직 추가

### DIFF
--- a/client/src/shared/notification/useInitializeFCM.ts
+++ b/client/src/shared/notification/useInitializeFCM.ts
@@ -1,20 +1,26 @@
 import { useEffect } from 'react';
 
+import { fetcher } from '@/api/fetcher';
+
 import { requestFCMPermission, setupForegroundMessage } from './firebase';
+
+export const registerFCMToken = async (registrationToken: string) => {
+  return await fetcher.post(`fcm-registration-tokens`, { registrationToken });
+};
 
 export const useInitializeFCM = () => {
   useEffect(() => {
     const initializeFCM = async () => {
-      try {
-        if ('serviceWorker' in navigator) {
-          await navigator.serviceWorker.register('/firebase-messaging-sw.js');
-        }
+      if (!('serviceWorker' in navigator)) return;
 
+      try {
+        await navigator.serviceWorker.register('/firebase-messaging-sw.js');
         const token = await requestFCMPermission();
-        if (token) {
-          // TODO : 서버에 토큰 전송 로직 추가
-          setupForegroundMessage();
-        }
+
+        if (!token) return;
+
+        await registerFCMToken(token);
+        setupForegroundMessage();
       } catch (error) {
         // TODO : FCM 초기화 실패 시 처리 로직 추가
         console.error('FCM 초기화 실패:', error);


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #369

## ✨ 작업 내용

- 첫 진입 시 FCM 토큰을 서버로 전송하는 로직을 추가했습니다.
-`registerFCMToken` 함수는 tanstack-query와 직접적인 연관이 없고, `useInitializeFCM` 훅 내부에서만 사용되므로 응집도를 고려해 해당 훅 상단에 정의했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * FCM 등록 토큰을 서버에 전송하여 푸시 알림 등록 기능이 추가되었습니다.

* **버그 수정**
  * 서비스 워커 지원이 없는 경우 초기화가 즉시 중단되어 예외 상황 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->