### PR TITLE
 [BE] FCM Registraion Token 등록 API를 멱등하게 변경

### DIFF
--- a/server/src/main/java/com/ahmadda/application/FcmRegistrationTokenService.java
+++ b/server/src/main/java/com/ahmadda/application/FcmRegistrationTokenService.java
@@ -25,15 +25,21 @@ public class FcmRegistrationTokenService {
             final FcmRegistrationTokenRequest request,
             final LoginMember loginMember
     ) {
-        Member member = memberRepository.findById(loginMember.memberId())
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));
+        return fcmRegistrationTokenRepository.findByRegistrationTokenAndMemberId(
+                        request.registrationToken(),
+                        loginMember.memberId()
+                )
+                .orElseGet(() -> {
+                    Member member = memberRepository.findById(loginMember.memberId())
+                            .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));
 
-        FcmRegistrationToken fcmRegistrationToken = FcmRegistrationToken.create(
-                member.getId(),
-                request.registrationToken(),
-                LocalDateTime.now()
-        );
+                    FcmRegistrationToken registrationToken = FcmRegistrationToken.create(
+                            member.getId(),
+                            request.registrationToken(),
+                            LocalDateTime.now()
+                    );
 
-        return fcmRegistrationTokenRepository.save(fcmRegistrationToken);
+                    return fcmRegistrationTokenRepository.save(registrationToken);
+                });
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/push/FcmRegistrationToken.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/FcmRegistrationToken.java
@@ -26,7 +26,7 @@ public class FcmRegistrationToken {
     private Long memberId;
 
     // TODO. 추후 기기당 토큰의 중복을 허용할지 여부를 결정해야 함
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String registrationToken;
 
     @Column(nullable = false)

--- a/server/src/main/java/com/ahmadda/infra/notification/push/FcmRegistrationTokenRepository.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/FcmRegistrationTokenRepository.java
@@ -3,8 +3,14 @@ package com.ahmadda.infra.notification.push;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FcmRegistrationTokenRepository extends JpaRepository<FcmRegistrationToken, Long> {
+
+    Optional<FcmRegistrationToken> findByRegistrationTokenAndMemberId(
+            final String registrationToken,
+            final Long memberId
+    );
 
     List<FcmRegistrationToken> findAllByMemberIdIn(final List<Long> memberIds);
 

--- a/server/src/test/java/com/ahmadda/application/FcmRegistrationTokenServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/FcmRegistrationTokenServiceTest.java
@@ -52,6 +52,27 @@ class FcmRegistrationTokenServiceTest {
     }
 
     @Test
+    void 중복된_토큰을_등록하면_기존_토큰을_반환하고_새로_저장하지_않는다() {
+        // given
+        var member = memberRepository.save(Member.create("홍길동", "test@example.com"));
+        var loginMember = new LoginMember(member.getId());
+        var request = new FcmRegistrationTokenRequest("중복된토큰");
+
+        var firstSaved = sut.registerFcmRegistrationToken(request, loginMember);
+
+        // when
+        var secondSaved = sut.registerFcmRegistrationToken(request, loginMember);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(secondSaved.getId())
+                    .isEqualTo(firstSaved.getId());
+            softly.assertThat(fcmRegistrationTokenRepository.count())
+                    .isEqualTo(1);
+        });
+    }
+
+    @Test
     void 회원이_존재하지_않으면_예외가_발생한다() {
         // given
         var nonExistentMemberId = 999L;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #이슈번호

## ✨ 작업 내용

- FCM 등록 토큰 저장 시, 중복 여부 확인
- 중복된 경우 저장 생략하여 멱등성 보장

## 🙏 기타 참고 사항

- 클라이언트는 해당 FCM 토큰이 이미 등록된 것인지 여부를 알 필요가 없다고 판단하여, 멱등성을 보장하는 방식으로 변경했습니다~~!
- 이에 따라 성공 응답은 201 Created 대신 204 No Content를 사용했어요~~
