### PR TITLE
[BE] 등록 마감 임박 이벤트의 비게스트에게 알람 기능 구현 by 머피

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
@@ -1,0 +1,75 @@
+package com.ahmadda.application;
+
+import com.ahmadda.domain.EmailNotifier;
+import com.ahmadda.domain.Event;
+import com.ahmadda.domain.EventEmailPayload;
+import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.PushNotificationPayload;
+import com.ahmadda.domain.PushNotifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class EventNotificationScheduler {
+
+    private static final int REMINDER_MINUTES_BEFORE = 5;
+
+    private final EventRepository eventRepository;
+    private final EmailNotifier emailNotifier;
+    private final PushNotifier pushNotifier;
+
+    // TODO. 추후 5분이라는 시간을 보장하도록 구현
+    @Scheduled(fixedRate = 300_000)
+    public void sendRegistrationEndReminders() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime targetTime = now.plusMinutes(REMINDER_MINUTES_BEFORE);
+        // TODO. 추후 중복 알람을 방지하도록 구현
+        List<Event> upcomingEvents =
+                eventRepository.findAllByEventOperationPeriodRegistrationPeriodEndBetween(now, targetTime);
+
+        upcomingEvents.forEach(upcomingEvent -> {
+            List<OrganizationMember> recipients = upcomingEvent.getNonGuestOrganizationMembers(
+                    upcomingEvent.getOrganization()
+                            .getOrganizationMembers()
+            );
+            String content = "이벤트 신청 마감이 임박했습니다.";
+
+            sendNotificationToRecipients(recipients, upcomingEvent, content);
+        });
+    }
+
+    private void sendNotificationToRecipients(
+            final List<OrganizationMember> recipients,
+            final Event event,
+            final String content
+    ) {
+        sendEmailsToRecipients(recipients, event, content);
+        sendPushNotificationsToRecipients(recipients, event, content);
+    }
+
+    private void sendEmailsToRecipients(
+            final List<OrganizationMember> recipients,
+            final Event event,
+            final String content
+    ) {
+        EventEmailPayload eventEmailPayload = EventEmailPayload.of(event, content);
+
+        emailNotifier.sendEmails(recipients, eventEmailPayload);
+    }
+
+    private void sendPushNotificationsToRecipients(
+            final List<OrganizationMember> recipients,
+            final Event event,
+            final String content
+    ) {
+        PushNotificationPayload pushNotificationPayload = PushNotificationPayload.of(event, content);
+
+        pushNotifier.sendPushs(recipients, pushNotificationPayload);
+    }
+}

--- a/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
@@ -18,18 +18,19 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EventNotificationScheduler {
 
+    // TODO. 추후 5분이라는 시간을 보장하도록 구현
     private static final int REMINDER_MINUTES_BEFORE = 5;
 
     private final EventRepository eventRepository;
     private final EmailNotifier emailNotifier;
     private final PushNotifier pushNotifier;
 
-    // TODO. 추후 5분이라는 시간을 보장하도록 구현
-    @Scheduled(fixedRate = 300_000)
-    public void sendRegistrationEndReminders() {
+    // TODO. 추후 중복 알람을 방지하도록 구현
+    @Scheduled(fixedRate = 180_000)
+    public void notifyRegistrationClosingEvents() {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime targetTime = now.plusMinutes(REMINDER_MINUTES_BEFORE);
-        // TODO. 추후 중복 알람을 방지하도록 구현
+
         List<Event> upcomingEvents =
                 eventRepository.findAllByEventOperationPeriodRegistrationPeriodEndBetween(now, targetTime);
 

--- a/server/src/main/java/com/ahmadda/domain/EventRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/EventRepository.java
@@ -2,9 +2,15 @@ package com.ahmadda.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findAllByOrganizer(final OrganizationMember organizer);
+
+    List<Event> findAllByEventOperationPeriodRegistrationPeriodEndBetween(
+            final LocalDateTime from,
+            final LocalDateTime to
+    );
 }

--- a/server/src/main/java/com/ahmadda/infra/config/SchedulingConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/config/SchedulingConfig.java
@@ -1,0 +1,11 @@
+package com.ahmadda.infra.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+// TODO. 추후 ThreadPoolTaskScheduler 설정 추가 필요
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+}

--- a/server/src/test/java/com/ahmadda/application/EventNotificationSchedulerTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationSchedulerTest.java
@@ -1,0 +1,139 @@
+package com.ahmadda.application;
+
+import com.ahmadda.domain.EmailNotifier;
+import com.ahmadda.domain.Event;
+import com.ahmadda.domain.EventEmailPayload;
+import com.ahmadda.domain.EventOperationPeriod;
+import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
+import com.ahmadda.domain.Organization;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberRepository;
+import com.ahmadda.domain.OrganizationRepository;
+import com.ahmadda.domain.PushNotificationPayload;
+import com.ahmadda.domain.PushNotifier;
+import com.ahmadda.infra.notification.push.FcmRegistrationToken;
+import com.ahmadda.infra.notification.push.FcmRegistrationTokenRepository;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class EventNotificationSchedulerTest {
+
+    @Autowired
+    private EventNotificationScheduler sut;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private OrganizationMemberRepository organizationMemberRepository;
+
+    @Autowired
+    private FcmRegistrationTokenRepository fcmRegistrationTokenRepository;
+
+    @MockitoBean
+    private EmailNotifier emailNotifier;
+
+    @MockitoBean
+    private PushNotifier pushNotifier;
+
+    @ParameterizedTest
+    @MethodSource("registrationEndOffsets")
+    void 등록_마감_임박_이벤트에_대해_비게스트에게_알람을_전송한다(
+            int minutesUntilRegistrationEnds,
+            boolean expectToSend
+    ) {
+        // given
+        var organization = organizationRepository.save(Organization.create("조직", "설명", "img.png"));
+        var host = saveOrganizationMember("주최자", "host@email.com", organization);
+        var ng1 = saveOrganizationMember("비게스트1", "ng1@email.com", organization);
+        var ng2 = saveOrganizationMember("비게스트2", "ng2@email.com", organization);
+
+        var now = LocalDateTime.now();
+
+        var registrationEnd = now.plusMinutes(minutesUntilRegistrationEnds);
+
+        var event = eventRepository.save(Event.create(
+                "이벤트", "설명", "장소",
+                host, organization,
+                EventOperationPeriod.create(
+                        now.minusDays(2),
+                        registrationEnd,
+                        now.plusDays(1),
+                        now.plusDays(2),
+                        now.minusDays(3)
+                ),
+                100
+        ));
+
+        saveFcmRegistrationToken(ng1, "token-ng1");
+        saveFcmRegistrationToken(ng2, "token-ng2");
+
+        // when
+        sut.notifyRegistrationClosingEvents();
+
+        // then
+        var expectedEmail = EventEmailPayload.of(event, "이벤트 신청 마감이 임박했습니다.");
+        var expectedPush = PushNotificationPayload.of(event, "이벤트 신청 마감이 임박했습니다.");
+
+        if (expectToSend) {
+            verify(emailNotifier).sendEmails(List.of(ng1, ng2), expectedEmail);
+            verify(pushNotifier).sendPushs(List.of(ng1, ng2), expectedPush);
+        } else {
+            verify(emailNotifier, Mockito.never()).sendEmails(any(), any());
+            verify(pushNotifier, Mockito.never()).sendPushs(any(), any());
+        }
+    }
+
+    private static Stream<Arguments> registrationEndOffsets() {
+        return Stream.of(
+                Arguments.of(4, true),
+                Arguments.of(5, true),
+                Arguments.of(6, false),
+                Arguments.of(-1, false)
+        );
+    }
+
+    private OrganizationMember saveOrganizationMember(
+            String nickname,
+            String email,
+            Organization organization
+    ) {
+        var member = memberRepository.save(Member.create(nickname, email));
+
+        return organizationMemberRepository.save(OrganizationMember.create(nickname, member, organization));
+    }
+
+    private void saveFcmRegistrationToken(OrganizationMember organizationMember, String token) {
+        var fcmToken = FcmRegistrationToken.create(
+                organizationMember.getMember()
+                        .getId(),
+                token,
+                LocalDateTime.now()
+        );
+
+        fcmRegistrationTokenRepository.save(fcmToken);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

close #365

## ✨ 작업 내용

- 등록 마감 임박 이벤트에 대해 이메일 및 푸시 알림 전송 기능 구현

- 현재는 스케줄링을 3분 간격으로 구성하였고, 5분 전 마감 이벤트를 조회하는 방식입니다. 이로 인해 중복 발송은 간헐적으로만 발생하지만, 이는 추후 해결이 필요한 과제로 보입니다! ㅠㅠ
- 또한, 정확히 '5분 전'이라는 시간을 보장하기 어려운 점이 있어, 문구는 "이벤트 신청 마감이 임박했습니다"로 처리했습니다. 이 역시 이후 개선이 필요한 부분입니다.
- 머피 계정 정지로 인해 가이온 계정으로 PR을 작성했지만, 작성자는 머피입니다! 😅