### PR TITLE
[FE] Toast 컴포넌트, 스토리북

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from 'react-router-dom';
 
+import { ToastProvider } from './shared/components/Toast/ToastContext';
 import { usePageTrack } from './shared/hooks/usePageTrack';
 import { useInitializeFCM } from './shared/notification/useInitializeFCM';
 
@@ -7,5 +8,9 @@ export const App = () => {
   usePageTrack();
   useInitializeFCM();
 
-  return <Outlet />;
+  return (
+    <ToastProvider>
+      <Outlet />
+    </ToastProvider>
+  );
 };

--- a/client/src/shared/components/Toast/Toast.stories.tsx
+++ b/client/src/shared/components/Toast/Toast.stories.tsx
@@ -10,7 +10,8 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: 'Toast system using context. Call `useToast().openToast()` to trigger.',
+        component:
+          'Toast system using context. Call `useToast().success()` or `useToast().error()` to trigger.',
       },
     },
     layout: 'fullscreen',
@@ -21,21 +22,13 @@ export default meta;
 type Story = StoryObj;
 
 const ToastStoryExample = () => {
-  const toast = useToast();
+  const { success, error } = useToast();
 
   return (
-    <div style={{ padding: '2rem' }}>
-      <Button
-        onClick={() =>
-          toast.openToast({
-            message: '스토리북에서도 잘 작동해요!',
-            variant: 'success',
-            duration: 2000,
-          })
-        }
-      >
-        Show Toast
-      </Button>
+    <div style={{ padding: '2rem', display: 'flex', gap: '0.75rem' }}>
+      <Button onClick={() => success('성공 토스트!')}>Success</Button>
+      <Button onClick={() => error('에러 토스트!')}>Error</Button>
+      <Button onClick={() => success('5초 동안 표시!', { duration: 5000 })}>Success (5s)</Button>
     </div>
   );
 };

--- a/client/src/shared/components/Toast/Toast.stories.tsx
+++ b/client/src/shared/components/Toast/Toast.stories.tsx
@@ -1,58 +1,49 @@
-import { useState } from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
-import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '@/shared/components/Button';
 
-import { Toast } from './Toast';
+import { ToastProvider, useToast } from './ToastContext';
 
 const meta = {
   title: 'components/Toast',
-  component: Toast,
   tags: ['autodocs'],
   parameters: {
     docs: {
       description: {
-        component:
-          'Toast component to notify users of success or error events. Automatically disappears after a given duration.',
+        component: 'Toast system using context. Call `useToast().openToast()` to trigger.',
       },
     },
     layout: 'fullscreen',
   },
-} satisfies Meta<typeof Toast>;
+} satisfies Meta;
 
 export default meta;
-type Story = StoryObj<typeof Toast>;
+type Story = StoryObj;
 
-const ToastExample = ({
-  message,
-  duration,
-  variant,
-}: {
-  message: string;
-  duration?: number;
-  variant?: 'success' | 'error';
-}) => {
-  const [show, setShow] = useState(true);
+const ToastStoryExample = () => {
+  const toast = useToast();
 
   return (
-    <div style={{ minHeight: '300px', position: 'relative' }}>
-      <button onClick={() => setShow(true)}>Show Toast</button>
-      {show && (
-        <Toast
-          message={message}
-          duration={duration}
-          variant={variant}
-          onClose={() => setShow(false)}
-        />
-      )}
+    <div style={{ padding: '2rem' }}>
+      <Button
+        onClick={() =>
+          toast.openToast({
+            message: '스토리북에서도 잘 작동해요!',
+            variant: 'success',
+            duration: 2000,
+          })
+        }
+      >
+        Show Toast
+      </Button>
     </div>
   );
 };
 
 export const Basic: Story = {
-  args: {
-    message: '이벤트 생성에 실패했어요.',
-    duration: 3000,
-    variant: 'error',
-  },
-  render: (args) => <ToastExample {...args} />,
+  render: () => (
+    <ToastProvider>
+      <ToastStoryExample />
+    </ToastProvider>
+  ),
 };

--- a/client/src/shared/components/Toast/Toast.stories.tsx
+++ b/client/src/shared/components/Toast/Toast.stories.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Toast } from './Toast';
+
+const meta = {
+  title: 'components/Toast',
+  component: Toast,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Toast component to notify users of success or error events. Automatically disappears after a given duration.',
+      },
+    },
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof Toast>;
+
+const ToastExample = ({
+  message,
+  duration,
+  variant,
+}: {
+  message: string;
+  duration?: number;
+  variant?: 'success' | 'error';
+}) => {
+  const [show, setShow] = useState(true);
+
+  return (
+    <div style={{ minHeight: '300px', position: 'relative' }}>
+      <button onClick={() => setShow(true)}>Show Toast</button>
+      {show && (
+        <Toast
+          message={message}
+          duration={duration}
+          variant={variant}
+          onClose={() => setShow(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export const Basic: Story = {
+  args: {
+    message: '이벤트 생성에 실패했어요.',
+    duration: 3000,
+    variant: 'error',
+  },
+  render: (args) => <ToastExample {...args} />,
+};

--- a/client/src/shared/components/Toast/Toast.styled.ts
+++ b/client/src/shared/components/Toast/Toast.styled.ts
@@ -4,7 +4,8 @@ import styled from '@emotion/styled';
 export const StyledToastLayout = styled.div`
   position: fixed;
   top: 25px;
-  right: 30px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 1000;
 `;
 

--- a/client/src/shared/components/Toast/Toast.styled.ts
+++ b/client/src/shared/components/Toast/Toast.styled.ts
@@ -1,0 +1,70 @@
+import { keyframes, css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const StyledToastLayout = styled.div`
+  position: fixed;
+  top: 25px;
+  right: 30px;
+  z-index: 1000;
+`;
+
+export const StyledToastContainer = styled.div`
+  position: relative;
+  border-radius: 12px;
+  background: #fff;
+  padding: 20px 35px 20px 20px;
+  margin: 0;
+  box-shadow: 0 6px 20px -5px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  transform: translateX(0%);
+  transition: all 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.35);
+  min-width: 280px;
+`;
+
+export const StyledToastCloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  padding: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  opacity: 0.7;
+
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+const progressKeyframes = keyframes`
+  0% {
+    right: 0%;
+  }
+  100% {
+    right: 100%;
+  }
+`;
+
+export const StyledToastProgressBar = styled.div<{
+  color: string;
+  duration: number;
+}>`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 5px;
+  width: 100%;
+
+  &::before {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: 100%;
+    width: 100%;
+    background-color: ${({ color }) => color};
+    animation: ${({ duration }) => css`
+      ${progressKeyframes} ${duration}ms linear forwards
+    `};
+  }
+`;

--- a/client/src/shared/components/Toast/Toast.tsx
+++ b/client/src/shared/components/Toast/Toast.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { createPortal } from 'react-dom';
+
 import { Flex } from '@/shared/components/Flex';
 import { Icon } from '@/shared/components/Icon';
 import { Text } from '@/shared/components/Text';
@@ -56,7 +58,7 @@ export const Toast = ({ message, duration = 3000, onClose, variant = 'success' }
 
   const variantColor = variant === 'success' ? '#3D84FF' : '#F52C1F';
 
-  return (
+  const toastContent = (
     <StyledToastLayout>
       <StyledToastContainer>
         <Flex dir="column" alignItems="flex-start">
@@ -73,4 +75,6 @@ export const Toast = ({ message, duration = 3000, onClose, variant = 'success' }
       </StyledToastContainer>
     </StyledToastLayout>
   );
+
+  return createPortal(toastContent, document.body);
 };

--- a/client/src/shared/components/Toast/Toast.tsx
+++ b/client/src/shared/components/Toast/Toast.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+
+import { Flex } from '@/shared/components/Flex';
+import { Icon } from '@/shared/components/Icon';
+import { Text } from '@/shared/components/Text';
+
+import {
+  StyledToastLayout,
+  StyledToastContainer,
+  StyledToastCloseButton,
+  StyledToastProgressBar,
+} from './Toast.styled';
+
+export type ToastVariant = 'success' | 'error';
+
+export type ToastProps = {
+  /**
+   * Message text to display inside the toast.
+   * @type {string}
+   * @example "Operation failed."
+   */
+  message: string;
+
+  /**
+   * Duration (in milliseconds) before the toast automatically disappears.
+   * @default 3000
+   * @type {number}
+   */
+  duration?: number;
+
+  /**
+   * Callback when the toast is closed (either by user or timeout).
+   * @type {() => void}
+   */
+  onClose?: () => void;
+
+  /**
+   * Visual style of the toast (e.g. success or error).
+   * @default 'success'
+   */
+  variant?: ToastVariant;
+};
+
+export const Toast = ({ message, duration = 3000, onClose, variant = 'success' }: ToastProps) => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsVisible(false);
+      onClose?.();
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [duration, onClose]);
+
+  if (!isVisible) return null;
+
+  const variantColor = variant === 'success' ? '#3D84FF' : '#F52C1F';
+
+  return (
+    <StyledToastLayout>
+      <StyledToastContainer>
+        <Flex dir="column" alignItems="flex-start">
+          <Text type="Body" color="#666">
+            {message}
+          </Text>
+        </Flex>
+
+        <StyledToastCloseButton onClick={() => setIsVisible(false)} aria-label="close">
+          <Icon name="close" size={16} />
+        </StyledToastCloseButton>
+
+        <StyledToastProgressBar color={variantColor} duration={duration} />
+      </StyledToastContainer>
+    </StyledToastLayout>
+  );
+};

--- a/client/src/shared/components/Toast/Toast.tsx
+++ b/client/src/shared/components/Toast/Toast.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 import { createPortal } from 'react-dom';
 
 import { Flex } from '@/shared/components/Flex';
@@ -44,18 +42,6 @@ export type ToastProps = {
 };
 
 export const Toast = ({ message, duration = 3000, onClose, variant = 'success' }: ToastProps) => {
-  const [isVisible, setIsVisible] = useState(true);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsVisible(false);
-      onClose?.();
-    }, duration);
-    return () => clearTimeout(timer);
-  }, [duration, onClose]);
-
-  if (!isVisible) return null;
-
   const variantColor = variant === 'success' ? '#3D84FF' : '#F52C1F';
 
   const toastContent = (
@@ -67,7 +53,7 @@ export const Toast = ({ message, duration = 3000, onClose, variant = 'success' }
           </Text>
         </Flex>
 
-        <StyledToastCloseButton onClick={() => setIsVisible(false)} aria-label="close">
+        <StyledToastCloseButton onClick={onClose} aria-label="close">
           <Icon name="close" size={16} />
         </StyledToastCloseButton>
 

--- a/client/src/shared/components/Toast/Toast.tsx
+++ b/client/src/shared/components/Toast/Toast.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { Flex } from '@/shared/components/Flex';
 import { Icon } from '@/shared/components/Icon';
 import { Text } from '@/shared/components/Text';
+import { theme } from '@/shared/styles/theme';
 
 import {
   StyledToastLayout,
@@ -42,7 +43,7 @@ export type ToastProps = {
 };
 
 export const Toast = ({ message, duration = 3000, onClose, variant = 'success' }: ToastProps) => {
-  const variantColor = variant === 'success' ? '#3D84FF' : '#F52C1F';
+  const variantColor = variant === 'success' ? theme.colors.primary600 : theme.colors.red600;
 
   const toastContent = (
     <StyledToastLayout>

--- a/client/src/shared/components/Toast/ToastContext.tsx
+++ b/client/src/shared/components/Toast/ToastContext.tsx
@@ -6,6 +6,13 @@ type ToastContextType = {
   openToast: (options: { message: string; variant?: ToastVariant; duration?: number }) => void;
 };
 
+type ToastState = {
+  message: string;
+  variant: ToastVariant;
+  duration: number;
+  isVisible: boolean;
+};
+
 const ToastContext = createContext<ToastContextType | null>(null);
 
 export const useToast = () => {
@@ -15,12 +22,7 @@ export const useToast = () => {
 };
 
 export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
-  const [toastState, setToastState] = useState<{
-    message: string;
-    variant: ToastVariant;
-    duration: number;
-    isVisible: boolean;
-  }>({
+  const [toastState, setToastState] = useState<ToastState>({
     message: '',
     variant: 'success',
     duration: 3000,

--- a/client/src/shared/components/Toast/ToastContext.tsx
+++ b/client/src/shared/components/Toast/ToastContext.tsx
@@ -3,7 +3,8 @@ import { createContext, useContext, useState, useRef } from 'react';
 import { Toast, ToastVariant } from './Toast';
 
 type ToastContextType = {
-  openToast: (options: { message: string; variant?: ToastVariant; duration?: number }) => void;
+  success: (message: string, options?: { duration?: number }) => void;
+  error: (message: string, options?: { duration?: number }) => void;
 };
 
 type ToastState = {
@@ -57,8 +58,15 @@ export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
     }, duration);
   };
 
+  const success = (message: string, options?: { duration?: number }) => {
+    openToast({ message, variant: 'success', duration: options?.duration });
+  };
+  const error = (message: string, options?: { duration?: number }) => {
+    openToast({ message, variant: 'error', duration: options?.duration });
+  };
+
   return (
-    <ToastContext.Provider value={{ openToast }}>
+    <ToastContext.Provider value={{ success, error }}>
       {children}
       {toastState.isVisible && (
         <Toast

--- a/client/src/shared/components/Toast/ToastContext.tsx
+++ b/client/src/shared/components/Toast/ToastContext.tsx
@@ -1,0 +1,71 @@
+import { createContext, useContext, useState, useRef } from 'react';
+
+import { Toast, ToastVariant } from './Toast';
+
+type ToastContextType = {
+  openToast: (options: { message: string; variant?: ToastVariant; duration?: number }) => void;
+};
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) throw new Error('useToast must be used within a ToastProvider');
+  return context;
+};
+
+export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
+  const [toastState, setToastState] = useState<{
+    message: string;
+    variant: ToastVariant;
+    duration: number;
+    isVisible: boolean;
+  }>({
+    message: '',
+    variant: 'success',
+    duration: 3000,
+    isVisible: false,
+  });
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const closeToast = () => {
+    setToastState((prev) => ({ ...prev, isVisible: false }));
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const openToast = ({
+    message,
+    variant = 'success',
+    duration = 3000,
+  }: {
+    message: string;
+    variant?: ToastVariant;
+    duration?: number;
+  }) => {
+    closeToast();
+
+    setToastState({ message, variant, duration, isVisible: true });
+
+    timerRef.current = setTimeout(() => {
+      closeToast();
+    }, duration);
+  };
+
+  return (
+    <ToastContext.Provider value={{ openToast }}>
+      {children}
+      {toastState.isVisible && (
+        <Toast
+          message={toastState.message}
+          variant={toastState.variant}
+          duration={toastState.duration}
+          onClose={closeToast}
+        />
+      )}
+    </ToastContext.Provider>
+  );
+};

--- a/client/src/shared/components/Toast/index.ts
+++ b/client/src/shared/components/Toast/index.ts
@@ -1,0 +1,1 @@
+export { Toast } from './Toast';


### PR DESCRIPTION
## 관련 이슈

close #384 

## ✨ 작업 내용

- Toast 컴포넌트를 구현하였습니다.
- variant는 'success'와 'error' 두 가지를 지원하며, 타입에 따라 색상이 다르게 표시됩니다.
- 향후 텍스트 왼쪽에 아이콘도 추가되면 좋을 것 같습니다.

## 🙏 기타 참고 사항

https://github.com/user-attachments/assets/62c815bb-1195-415b-85a6-9fa5d5611fb1




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 자동으로 사라지는 토스트 알림이 추가되었습니다(성공/오류, 표시 시간, 닫기 버튼, 진행 바 지원).
  * 전역 토스트 관리용 ToastProvider와 useToast 훅이 도입되어 앱 전역에서 토스트를 호출할 수 있습니다.
* **문서**
  * Storybook에 토스트 사용 예제 및 설명이 추가되었습니다 (데모 버튼 포함).
* **스타일**
  * 토스트 레이아웃, 색상, 그림자, 진행 바 애니메이션 등 시각적 스타일이 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->