### PR TITLE
[BE] 게스트 답변 조회 API 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -92,7 +92,7 @@ public class EventGuestService {
         return event.hasGuest(organizationMember);
     }
 
-    public List<Answer> getAnswers(final Long eventId, Long guestId, final LoginMember organizerLoginMember) {
+    public List<Answer> getAnswers(final Long eventId, final Long guestId, final LoginMember organizerLoginMember) {
         Event event = getEvent(eventId);
         Organization organization = event.getOrganization();
         OrganizationMember organizer = getOrganizationMember(organization.getId(), organizerLoginMember.memberId());

--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -5,6 +5,7 @@ import com.ahmadda.application.dto.EventParticipateRequest;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.Answer;
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventRepository;
 import com.ahmadda.domain.Guest;
@@ -91,6 +92,15 @@ public class EventGuestService {
         return event.hasGuest(organizationMember);
     }
 
+    public List<Answer> getAnswers(final Long eventId, Long guestId, final LoginMember organizerLoginMember) {
+        Event event = getEvent(eventId);
+        Organization organization = event.getOrganization();
+        OrganizationMember organizer = getOrganizationMember(organization.getId(), organizerLoginMember.memberId());
+        Guest guest = getGuest(guestId);
+
+        return guest.viewAnswersAs(organizer);
+    }
+
     private void validateOrganizationAccess(final LoginMember loginMember, final Organization organization) {
         if (!organizationMemberRepository.existsByOrganizationIdAndMemberId(
                 organization.getId(),
@@ -120,5 +130,10 @@ public class EventGuestService {
     private Question getQuestion(final Long questionId) {
         return questionRepository.findById(questionId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 질문입니다."));
+    }
+
+    private Guest getGuest(Long guestId) {
+        return guestRepository.findById(guestId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 게스트입니다."));
     }
 }

--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -132,7 +132,7 @@ public class EventGuestService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 질문입니다."));
     }
 
-    private Guest getGuest(Long guestId) {
+    private Guest getGuest(final Long guestId) {
         return guestRepository.findById(guestId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 게스트입니다."));
     }

--- a/server/src/main/java/com/ahmadda/application/dto/GuestAnswerResponse.java
+++ b/server/src/main/java/com/ahmadda/application/dto/GuestAnswerResponse.java
@@ -1,0 +1,25 @@
+package com.ahmadda.application.dto;
+
+import com.ahmadda.domain.Answer;
+import com.ahmadda.domain.Question;
+
+public record GuestAnswerResponse(
+        Long questionId,
+        String questionText,
+        Long answerId,
+        String answerText,
+        int orderIndex
+) {
+
+    public static GuestAnswerResponse from(final Answer answer) {
+        Question question = answer.getQuestion();
+
+        return new GuestAnswerResponse(
+                question.getId(),
+                question.getQuestionText(),
+                answer.getId(),
+                answer.getAnswerText(),
+                question.getOrderIndex()
+        );
+    }
+}

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -214,6 +214,10 @@ public class Event extends BaseEntity {
                 .equals(member);
     }
 
+    public boolean isOrganizer(final OrganizationMember organizer) {
+        return this.organizer.equals(organizer);
+    }
+
     public void cancelParticipation(
             final OrganizationMember organizationMember,
             final LocalDateTime cancelParticipateTime

--- a/server/src/main/java/com/ahmadda/domain/Guest.java
+++ b/server/src/main/java/com/ahmadda/domain/Guest.java
@@ -110,7 +110,7 @@ public class Guest extends BaseEntity {
         }
     }
 
-    public List<Answer> viewAnswersAs(OrganizationMember organizationMember) {
+    public List<Answer> viewAnswersAs(final OrganizationMember organizationMember) {
         if (!canViewAnswers(organizationMember)) {
             throw new UnauthorizedOperationException("답변을 볼 권한이 없습니다.");
         }
@@ -118,7 +118,7 @@ public class Guest extends BaseEntity {
         return answers;
     }
 
-    private boolean canViewAnswers(OrganizationMember organizationMember) {
+    private boolean canViewAnswers(final OrganizationMember organizationMember) {
         return event.isOrganizer(organizationMember) || this.organizationMember.equals(organizationMember);
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/Guest.java
+++ b/server/src/main/java/com/ahmadda/domain/Guest.java
@@ -2,6 +2,7 @@ package com.ahmadda.domain;
 
 
 import com.ahmadda.domain.exception.BusinessRuleViolatedException;
+import com.ahmadda.domain.exception.UnauthorizedOperationException;
 import com.ahmadda.domain.util.Assert;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -42,7 +43,7 @@ public class Guest extends BaseEntity {
     private OrganizationMember organizationMember;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "guest", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Answer> answers = new ArrayList<>();
+    private final List<Answer> answers = new ArrayList<>();
 
     private Guest(final Event event, final OrganizationMember organizationMember, final LocalDateTime currentDateTime) {
         validateEvent(event);
@@ -51,7 +52,7 @@ public class Guest extends BaseEntity {
 
         this.event = event;
         this.organizationMember = organizationMember;
-        
+
         event.participate(this, currentDateTime);
     }
 
@@ -107,5 +108,17 @@ public class Guest extends BaseEntity {
         if (!organizationMember.isBelongTo(event.getOrganization())) {
             throw new BusinessRuleViolatedException("같은 조직의 이벤트에만 게스트로 참여가능합니다.");
         }
+    }
+
+    public List<Answer> viewAnswersAs(OrganizationMember organizationMember) {
+        if (!canViewAnswers(organizationMember)) {
+            throw new UnauthorizedOperationException("답변을 볼 권한이 없습니다.");
+        }
+
+        return answers;
+    }
+
+    private boolean canViewAnswers(OrganizationMember organizationMember) {
+        return event.isOrganizer(organizationMember) || this.organizationMember.equals(organizationMember);
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -3,7 +3,9 @@ package com.ahmadda.presentation;
 import com.ahmadda.application.EventGuestService;
 import com.ahmadda.application.EventService;
 import com.ahmadda.application.dto.EventParticipateRequest;
+import com.ahmadda.application.dto.GuestAnswerResponse;
 import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.domain.Answer;
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.OrganizationMember;
@@ -507,5 +509,20 @@ public class EventGuestController {
 
         return ResponseEntity.noContent()
                 .build();
+    }
+
+    @GetMapping("/{eventId}/guests/{guestId}/answers")
+    public ResponseEntity<List<GuestAnswerResponse>> getAnswers(
+            @PathVariable final Long eventId,
+            @PathVariable final Long guestId,
+            @AuthMember final LoginMember loginMember
+    ) {
+        List<Answer> answers = eventGuestService.getAnswers(eventId, guestId, loginMember);
+
+        List<GuestAnswerResponse> guestAnswerResponses = answers.stream()
+                .map(GuestAnswerResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(guestAnswerResponses);
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -15,6 +15,7 @@ import com.ahmadda.presentation.dto.GuestStatusResponse;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -511,6 +512,90 @@ public class EventGuestController {
                 .build();
     }
 
+    @Operation(summary = "게스트 답변 조회", description = "게스트의 답변을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = GuestAnswerResponse.class))
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/events/{eventId}/guests/{guestId}/answers"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "이벤트 없음",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 이벤트입니다.",
+                                                      "instance": "/api/events/{eventId}/guests/{guestId}/answers"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "조직원 없음",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 조직원입니다.",
+                                                      "instance": "/api/events/{eventId}/guests/{guestId}/answers"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "게스트 없음",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 게스트입니다.",
+                                                      "instance": "/api/events/{eventId}/guests/{guestId}/answers"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "답변을 볼 권한이 없습니다.",
+                                              "instance": "/api/events/{eventId}/guests/{guestId}/answers"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/{eventId}/guests/{guestId}/answers")
     public ResponseEntity<List<GuestAnswerResponse>> getAnswers(
             @PathVariable final Long eventId,

--- a/server/src/test/java/com/ahmadda/domain/GuestTest.java
+++ b/server/src/test/java/com/ahmadda/domain/GuestTest.java
@@ -36,9 +36,10 @@ class GuestTest {
         member = Member.create("참가자 회원", "guest@example.com", "testPicture");
         participant = OrganizationMember.create("참가자", member, organization);
         otherParticipant =
-                OrganizationMember.create("다른 참가자",
-                                          Member.create("다른 회원", "other@example.com", "testPicture"),
-                                          organization
+                OrganizationMember.create(
+                        "다른 참가자",
+                        Member.create("다른 회원", "other@example.com", "testPicture"),
+                        organization
                 );
     }
 
@@ -73,7 +74,7 @@ class GuestTest {
 
         //then
         assertThat(event.getGuests()
-                           .contains(guest)).isTrue();
+                .contains(guest)).isTrue();
     }
 
     @Test
@@ -282,7 +283,7 @@ class GuestTest {
         var now = LocalDateTime.now();
         var question = Question.create("질문", true, 0);
         var event = createEvent("이벤트", participant, now, question);
-        var otherMember = Member.create("다른 회원", "email@email.com");
+        var otherMember = Member.create("다른 회원", "email@email.com", "profileUrl");
         var othrerOrganizationMember =
                 OrganizationMember.create("다른 게스트", otherMember, participant.getOrganization());
         var guest = Guest.create(event, otherParticipant, now);


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #297 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

게스트 답변 조회 API를 구현했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 주최자가 특정 이벤트의 게스트가 제출한 답변 목록을 조회할 수 있는 API 엔드포인트가 추가되었습니다.
  * 게스트의 답변 정보를 제공하는 응답 구조가 추가되었습니다.

* **버그 수정**
  * 게스트 답변 조회 시 권한 및 존재하지 않는 이벤트, 주최자, 게스트에 대한 예외 처리가 강화되었습니다.

* **테스트**
  * 주최자 및 게스트의 답변 조회, 권한 예외, 존재하지 않는 리소스에 대한 다양한 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->