### PR TITLE
[FE] 비로그인 상태에 401 에러 해결 & 모든 401에러는 토큰지우고 리다이렉트

### DIFF
--- a/client/src/api/fetcher.ts
+++ b/client/src/api/fetcher.ts
@@ -1,10 +1,11 @@
 import { ACCESS_TOKEN_KEY } from '@/shared/constants';
 import { reportApiError } from '@/shared/utils/apiErrorHandler';
 import { getLocalStorage } from '@/shared/utils/localStorage';
+import { tokenErrorHandler } from '@/shared/utils/tokenErrorHandler';
 
 type HttpMethod = 'GET' | 'POST' | 'DELETE' | 'PATCH' | 'PUT';
 
-type HttpErrorResponse = {
+export type HttpErrorResponse = {
   type: string;
   title: string;
   status: number;
@@ -40,6 +41,7 @@ const request = async <T>(path: string, method: HttpMethod, body?: object): Prom
   if (!response.ok) {
     try {
       const responseText = await response.json();
+      tokenErrorHandler(responseText);
       throw new HttpError(response.status, responseText);
     } catch (parseError) {
       if (parseError instanceof HttpError) {

--- a/client/src/features/Home/component/Info.tsx
+++ b/client/src/features/Home/component/Info.tsx
@@ -20,7 +20,10 @@ export const Info = () => {
   const navigate = useNavigate();
 
   //E.TODO 추후 organizationId 받아오기
-  const { data: profileData } = useQuery(organizationQueryOptions.profile(1));
+  const { data: profileData } = useQuery({
+    ...organizationQueryOptions.profile(1),
+    enabled: isAuthenticated(),
+  });
 
   const handleButtonClick = () => {
     if (profileData?.nickname) {

--- a/client/src/shared/utils/tokenErrorHandler.ts
+++ b/client/src/shared/utils/tokenErrorHandler.ts
@@ -3,7 +3,7 @@ import { ACCESS_TOKEN_KEY } from '@/shared/constants';
 import { removeLocalStorage } from '@/shared/utils/localStorage';
 
 export const tokenErrorHandler = (responseText: HttpErrorResponse) => {
-  if (responseText.detail === '인증 토큰 정보가 존재하지 않거나 유효하지 않습니다.') {
+  if (responseText.detail === '만료기한이 지난 토큰입니다.') {
     removeLocalStorage(ACCESS_TOKEN_KEY);
     alert('로그인이 만료되었습니다. 다시 로그인해 주세요.');
     window.location.href = '/';

--- a/client/src/shared/utils/tokenErrorHandler.ts
+++ b/client/src/shared/utils/tokenErrorHandler.ts
@@ -3,10 +3,7 @@ import { ACCESS_TOKEN_KEY } from '@/shared/constants';
 import { removeLocalStorage } from '@/shared/utils/localStorage';
 
 export const tokenErrorHandler = (responseText: HttpErrorResponse) => {
-  if (
-    responseText.detail === '인증 토큰 정보가 존재하지 않거나 유효하지 않습니다.'
-    // '유효하지 않은 인증 정보입니다.'
-  ) {
+  if (responseText.detail === '인증 토큰 정보가 존재하지 않거나 유효하지 않습니다.') {
     removeLocalStorage(ACCESS_TOKEN_KEY);
     alert('로그인이 만료되었습니다. 다시 로그인해 주세요.');
     window.location.href = '/';

--- a/client/src/shared/utils/tokenErrorHandler.ts
+++ b/client/src/shared/utils/tokenErrorHandler.ts
@@ -1,0 +1,14 @@
+import type { HttpErrorResponse } from '@/api/fetcher';
+import { ACCESS_TOKEN_KEY } from '@/shared/constants';
+import { removeLocalStorage } from '@/shared/utils/localStorage';
+
+export const tokenErrorHandler = (responseText: HttpErrorResponse) => {
+  if (
+    responseText.detail === '인증 토큰 정보가 존재하지 않거나 유효하지 않습니다.'
+    // '유효하지 않은 인증 정보입니다.'
+  ) {
+    removeLocalStorage(ACCESS_TOKEN_KEY);
+    alert('로그인이 만료되었습니다. 다시 로그인해 주세요.');
+    window.location.href = '/';
+  }
+};


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #382 

## ✨ 작업 내용

- 상황 설명
홈 화면에서는 사용자의 조직 가입 여부를 판단하기 위해 profile API를 호출합니다. 
이때 사용자의 nickname 유무로 조직 가입 여부를 판단하고, 가입이 안 되어 있으면 모달을 띄우는 로직입니다.
그런데, 이 profile API는 로그인하지 않은 사용자에게는 401을 반환합니다. 

- 발생한 문제
모든 401 응답에 대해 클라이언트에서는 다음과 같이 처리해야합니다. (401은 토큰 기간 만료 이슈)
1. 로컬스토리지 초기화
2. "토큰이 만료되었으니 재로그인해라"라는 alert

이러한 이유들로 비로그인 상태에서 홈에 진입하면 다음과 같은 악순환이 벌어졌습니다:
1. 홈 진입
2. profile API 호출 → 401
3. alert 표시 + 로컬스토리지 초기화
4. 컴포넌트 리렌더 → 다시 profile API 호출
5. 또 401 → 또 alert…
무한 alert 루프가 발생한 것이죠.

- 고민했던 해결 방안들
1. 클라이언트에서 nickname === null로 판단하기 전에 API 호출 자체를 막을 수 없을까?
2. 혹은 서버에서 401을 상황별로 다르게 구분해 줄 수 있다면?
3. 극단적으로는 조직 가입 여부를 로컬스토리지에 저장할까…? 

#### 최종 해결 방법

1. 서버 응답 메시지 개선

서버에서 같은 401이라도 메시지를 상황에 맞게 구분해서 내려주도록 요청했습니다. (with 서프)

**기존**
“인증 토큰을 파싱하는데 실패하였습니다.” → 토큰 자체의 문제가 있을 경우 & 토큰이 만료된 경우
“인증 토큰 정보가 존재하지 않거나 유효하지 않습니다.” → 토큰이 없을 경우

**수정 후**
“만료기한이 지난 토큰입니다.” → 토큰이 만료된 경우

2. 리액트 쿼리 enabled 옵션

enabled 옵션을 활용해, 토큰이 있는 경우에만 profile API가 호출되도록 변경했습니다.
따라서 로그인이 된 상황에서만 profile 조회 API가 호출됩니다. 


### 만료된 토큰일 경우

https://github.com/user-attachments/assets/1d3737e2-e6b1-4758-8f31-da1173642678



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인증되지 않은 사용자의 경우 프로필 정보 요청이 실행되지 않도록 개선되었습니다.

* **신규 기능**
  * 로그인 세션 만료 시, 안내 메시지와 함께 자동 로그아웃 및 메인 페이지로 이동하는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->