### PR TITLE
[FE] GA 이벤트 트래킹 코드 추가

### DIFF
--- a/client/src/features/Event/Manage/components/AlarmSection.tsx
+++ b/client/src/features/Event/Manage/components/AlarmSection.tsx
@@ -8,6 +8,7 @@ import { Icon } from '@/shared/components/Icon';
 import { Input } from '@/shared/components/Input';
 import { Spacing } from '@/shared/components/Spacing';
 import { Text } from '@/shared/components/Text';
+import { trackSendAlarm } from '@/shared/lib/gaEvents';
 
 import { useNotificationForm } from '../hooks/useNotificationForm';
 
@@ -22,6 +23,8 @@ export const AlarmSection = ({ organizationMemberIds, selectedGuestCount }: Alar
   const { mutate: postAlarm, isPending } = useAddAlarm({ eventId: Number(eventIdParam) });
 
   const handleSendAlarm = () => {
+    trackSendAlarm(selectedGuestCount);
+
     postAlarm(
       { organizationMemberIds, content },
       {

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -8,6 +8,7 @@ import { Card } from '@/shared/components/Card';
 import { Flex } from '@/shared/components/Flex';
 import { Input } from '@/shared/components/Input';
 import { Text } from '@/shared/components/Text';
+import { trackCreateEvent } from '@/shared/lib/gaEvents';
 
 import { useAddEvent } from '../hooks/useAddEvent';
 import { useEventForm } from '../hooks/useEventForm';
@@ -30,6 +31,8 @@ export const EventCreateForm = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!validate()) return;
+
+    trackCreateEvent(formData.title);
 
     const payload = {
       ...formData,

--- a/client/src/features/Event/Overview/components/EventCard.tsx
+++ b/client/src/features/Event/Overview/components/EventCard.tsx
@@ -5,6 +5,7 @@ import { Flex } from '@/shared/components/Flex';
 import { Icon } from '@/shared/components/Icon';
 import { ProgressBar } from '@/shared/components/ProgressBar';
 import { Text } from '@/shared/components/Text';
+import { trackClickEventCard } from '@/shared/lib/gaEvents';
 
 import { Event } from '../../types/Event';
 import { formatDateTime } from '../utils/formatDateTime';
@@ -25,8 +26,13 @@ export const EventCard = ({
   const navigate = useNavigate();
   const isRegistrationOpen = new Date(registrationEnd) > new Date();
 
+  const handleClickCard = () => {
+    trackClickEventCard(title);
+    navigate(`/event/${eventId}`);
+  };
+
   return (
-    <CardWrapper onClick={() => navigate(`/event/${eventId}`)}>
+    <CardWrapper onClick={handleClickCard}>
       <Flex dir="column" gap="8px">
         <Flex justifyContent="space-between" alignItems="center" gap="8px">
           <Text as="h2" type="Heading" color="#ffffff" weight="semibold">

--- a/client/src/shared/lib/gaEvents.ts
+++ b/client/src/shared/lib/gaEvents.ts
@@ -1,0 +1,25 @@
+import { event } from './gtag';
+
+export const trackClickEventCard = (title: string) => {
+  event({
+    action: 'click_event_card',
+    category: 'engagement',
+    label: title,
+  });
+};
+
+export const trackSendAlarm = (selectedGuestCount: number) => {
+  event({
+    action: 'click_send_alarm',
+    category: 'notification',
+    label: `${selectedGuestCount}명에게 알람 전송`,
+  });
+};
+
+export const trackCreateEvent = (title: string) => {
+  event({
+    action: 'click_create_event',
+    category: 'engagement',
+    label: title,
+  });
+};


### PR DESCRIPTION

## 관련 이슈

close #398 

## ✨ 작업 내용

기존에는 GA에서 기본적인 정보만 수집되어, 사용자 행동에 대한 인사이트 확보에 한계가 있었습니다.
이에 따라 주요 사용자 행동에 대한 이벤트 트래킹 코드를 추가하였습니다.

현재 다음과 같은 사용자 행동에 대해 GA 이벤트가 수집됩니다.

- 이벤트 카드 클릭
- 이벤트 만들기 버튼 클릭
- 리마인드 알림 보내기 버튼 클릭

서비스의 핵심 기능이라고 판단되는 영역에 우선 적용하였으며,
추후 기능 추가 시 함께 확장해 나가면 좋을 것 같습니다!

## 🙏 기타 참고 사항

<img width="283" height="373" alt="image" src="https://github.com/user-attachments/assets/d558f20f-e57c-4e55-a6ed-0f6be743e248" />

