### PR TITLE
[BE] 이벤트 정원 초과 시 알람 미전송 처리 및 테스트 보완  by 머피

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
@@ -34,15 +34,17 @@ public class EventNotificationScheduler {
         List<Event> upcomingEvents =
                 eventRepository.findAllByEventOperationPeriodRegistrationPeriodEndBetween(now, targetTime);
 
-        upcomingEvents.forEach(upcomingEvent -> {
-            List<OrganizationMember> recipients = upcomingEvent.getNonGuestOrganizationMembers(
-                    upcomingEvent.getOrganization()
-                            .getOrganizationMembers()
-            );
-            String content = "이벤트 신청 마감이 임박했습니다.";
+        upcomingEvents.stream()
+                .filter(event -> !event.isFull()).
+                forEach(upcomingEvent -> {
+                    List<OrganizationMember> recipients = upcomingEvent.getNonGuestOrganizationMembers(
+                            upcomingEvent.getOrganization()
+                                    .getOrganizationMembers()
+                    );
+                    String content = "이벤트 신청 마감이 임박했습니다.";
 
-            sendNotificationToRecipients(recipients, upcomingEvent, content);
-        });
+                    sendNotificationToRecipients(recipients, upcomingEvent, content);
+                });
     }
 
     private void sendNotificationToRecipients(

--- a/server/src/main/java/com/ahmadda/domain/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/Event.java
@@ -233,6 +233,10 @@ public class Event extends BaseEntity {
                 .isAfter(currentDateTime);
     }
 
+    public boolean isFull() {
+        return guests.size() >= maxCapacity;
+    }
+    
     private void validateCancelParticipation(final LocalDateTime cancelParticipationTime) {
         if (eventOperationPeriod.willStartWithin(
                 cancelParticipationTime,


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #400

## ✨ 작업 내용

- 이벤트 신청 인원이 정원을 초과한 경우 알람을 보내지 않도록 변경
- 기존 테스트(정원이 다 찼다면 알람을 전송하지 않는다) 보완

## 🙏 기타 참고 사항
- 마감 기한이 지나지 않은 이벤트는 쿼리로 필터링했는데, 해당 로직은 향후 변경 가능성이 낮다고 판단했기 떄문이엇죠!
- 반면, "정원이 찼는지" 여부는 쿼리로 처리하기 까다롭고, 향후 알람 필터링 조건이 자주 바뀔 수 있어 **객체 그래프 기반 필터링**으로 처리했습니다.
- 역시나, 머피 계정이 정지되어 **가이온 계정으로 머피가 올립니다.** ㅠㅠ 내 계정 돌려줘 ㅠㅠㅠ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이벤트가 정원에 도달한 경우, 등록 마감 알림이 전송되지 않도록 개선되었습니다.

* **버그 수정**
  * 정원이 다 찬 이벤트에 대해 알림이 전송되지 않는지 확인하는 테스트가 추가되었습니다.

* **테스트**
  * 이벤트가 정원에 도달했는지 확인하는 단위 테스트가 추가되었습니다.
  * 정원이 다 찬 이벤트에 알림이 전송되지 않는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->