### PR TITLE
[FE] 20억명 -> 무제한으로 워딩 변경

### DIFF
--- a/client/src/features/Event/Manage/components/EventInfoSection.tsx
+++ b/client/src/features/Event/Manage/components/EventInfoSection.tsx
@@ -4,8 +4,10 @@ import { Icon } from '@/shared/components/Icon';
 import { ProgressBar } from '@/shared/components/ProgressBar';
 import { Spacing } from '@/shared/components/Spacing';
 import { Text } from '@/shared/components/Text';
+import { theme } from '@/shared/styles/theme';
 
 import { formatDateTime } from '../../My/utils/date';
+import { UNLIMITED_CAPACITY } from '../../New/constants/errorMessages';
 import type { Event } from '../../types/Event';
 
 type EventInfoSectionProps = {
@@ -13,6 +15,12 @@ type EventInfoSectionProps = {
 };
 
 export const EventInfoSection = ({ event }: EventInfoSectionProps) => {
+  const isUnlimited = event.maxCapacity === UNLIMITED_CAPACITY;
+  const maxNumberOfGuests = isUnlimited ? '무제한' : `${event.maxCapacity}명`;
+  const progressValue = isUnlimited ? 1 : Number(event.currentGuestCount);
+  const progressMax = isUnlimited ? 1 : event.maxCapacity;
+  const progressColor = isUnlimited ? theme.colors.primary700 : 'black';
+
   return (
     <Flex as="section" dir="column" gap="24px" width="100%" margin="0 auto" padding="20px 0">
       <Card>
@@ -72,10 +80,10 @@ export const EventInfoSection = ({ event }: EventInfoSectionProps) => {
                 </Text>
               </Flex>
               <Text type="Label" weight="regular" color="#4A5565">
-                {`${event.currentGuestCount}/${event.maxCapacity}명`}
+                {`${event.currentGuestCount}/${maxNumberOfGuests}`}
               </Text>
             </Flex>
-            <ProgressBar value={event.currentGuestCount} max={event.maxCapacity} color="#0A0A0A" />
+            <ProgressBar value={progressValue} max={progressMax} color={progressColor} />
           </Flex>
         </Flex>
       </Card>

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -106,7 +106,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <Flex as="form" onSubmit={handleSubmit}>
       <Flex dir="column" gap="20px" padding="60px 0" width="100%">
         <Text type="Title" weight="bold">
           {isEdit ? '이벤트 수정' : '새 이벤트 만들기'}
@@ -247,17 +247,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
         />
 
         <Flex justifyContent="flex-end">
-          <Button
-            type="submit"
-            color="tertiary"
-            size="sm"
-            disabled={!isFormReady}
-            css={css`
-              border-radius: 5px;
-              font-size: 12px;
-              padding: 7px;
-            `}
-          >
+          <Button type="submit" color="primary" size="full" disabled={!isFormReady}>
             {isEdit ? '이벤트 수정' : '이벤트 만들기'}
           </Button>
         </Flex>
@@ -270,6 +260,6 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
         onSelect={handleSelectEvent}
         selectedEventId={selectedEventId}
       />
-    </form>
+    </Flex>
   );
 };


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #425

## ✨ 작업 내용

- 20억명 -> 무제한으로 워딩 변경했습니다.

<img width="1149" height="485" alt="image" src="https://github.com/user-attachments/assets/5d2bd95e-b3d1-49d9-935f-2fc2fe403480" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 최대 인원이 무제한일 경우, "무제한"으로 표시되고 진행률 바와 색상이 이에 맞게 변경됩니다.

* **스타일**
  * 이벤트 생성 폼의 레이아웃이 개선되고, 제출 버튼이 전체 너비의 주요 색상 버튼으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->