### PR TITLE
[FE] Mobile에서 조직 초대 복사가 안되는 문제 해결

### DIFF
--- a/client/src/api/mutations/useCreateInviteCode.ts
+++ b/client/src/api/mutations/useCreateInviteCode.ts
@@ -1,14 +1,6 @@
-import { useMutation } from '@tanstack/react-query';
-
 import { fetcher } from '../fetcher';
 import { InviteCodeAPIResponse } from '../types/organizations';
 
-const createInviteCode = (organizationId: number) => {
+export const createInviteCode = (organizationId: number) => {
   return fetcher.post<InviteCodeAPIResponse>(`organizations/${organizationId}/invite-codes`);
-};
-
-export const useCreateInviteCode = (organizationId: number) => {
-  return useMutation({
-    mutationFn: () => createInviteCode(organizationId),
-  });
 };

--- a/client/src/features/Event/Overview/components/EventList.tsx
+++ b/client/src/features/Event/Overview/components/EventList.tsx
@@ -28,13 +28,10 @@ export const EventList = ({ organizationId, events }: EventListProps) => {
     mutateCreateInviteCode(undefined, {
       onSuccess: (data) => {
         const baseUrl =
-          process.env.NODE_ENV === 'production'
-            ? 'https://www.ahmadda.com'
-            : 'http://localhost:5173';
+          process.env.NODE_ENV === 'production' ? 'https://ahmadda.com' : 'http://localhost:5173';
 
         const inviteUrl = `${baseUrl}/invite?code=${data.inviteCode}`;
         copyInviteMessage(inviteUrl);
-        alert(`초대 코드가 복사되었습니다.`);
       },
     });
   };

--- a/client/src/features/Event/Overview/components/EventList.tsx
+++ b/client/src/features/Event/Overview/components/EventList.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { useCreateInviteCode } from '@/api/mutations/useCreateInviteCode';
+import { createInviteCode } from '@/api/mutations/useCreateInviteCode';
 import { Flex } from '@/shared/components/Flex';
 import { Icon } from '@/shared/components/Icon';
 import { Text } from '@/shared/components/Text';
@@ -22,18 +22,19 @@ type EventListProps = {
 
 export const EventList = ({ organizationId, events }: EventListProps) => {
   const groupedEvents = groupEventsByDate(events);
-  const { mutate: mutateCreateInviteCode } = useCreateInviteCode(Number(organizationId));
 
-  const handleCreateInviteCode = () => {
-    mutateCreateInviteCode(undefined, {
-      onSuccess: (data) => {
-        const baseUrl =
-          process.env.NODE_ENV === 'production' ? 'https://ahmadda.com' : 'http://localhost:5173';
+  const handleCreateInviteCode = async () => {
+    try {
+      const data = await createInviteCode(Number(organizationId));
+      const baseUrl =
+        process.env.NODE_ENV === 'production' ? 'https://ahmadda.com' : 'http://localhost:5173';
+      const inviteUrl = `${baseUrl}/invite?code=${data.inviteCode}`;
+      await copyInviteMessage(inviteUrl);
 
-        const inviteUrl = `${baseUrl}/invite?code=${data.inviteCode}`;
-        copyInviteMessage(inviteUrl);
-      },
-    });
+      alert('초대 코드가 복사되었습니다.');
+    } catch {
+      alert('초대 코드 생성에 실패했습니다.');
+    }
   };
 
   return (

--- a/client/src/features/Event/Overview/utils/copyInviteMessage.ts
+++ b/client/src/features/Event/Overview/utils/copyInviteMessage.ts
@@ -2,7 +2,6 @@ export const copyInviteMessage = async (link: string) => {
   const message = `[조직 초대 링크]\n조직에 합류하려면 아래 링크를 클릭하세요! 🙌\n${link}`;
   try {
     await navigator.clipboard.writeText(message);
-    alert(`초대 코드가 복사되었습니다.`);
   } catch {
     alert('잠시 후 다시 시도해 주세요');
   }

--- a/client/src/features/Event/Overview/utils/copyInviteMessage.ts
+++ b/client/src/features/Event/Overview/utils/copyInviteMessage.ts
@@ -2,6 +2,7 @@ export const copyInviteMessage = async (link: string) => {
   const message = `[조직 초대 링크]\n조직에 합류하려면 아래 링크를 클릭하세요! 🙌\n${link}`;
   try {
     await navigator.clipboard.writeText(message);
+    alert(`초대 코드가 복사되었습니다.`);
   } catch {
     alert('잠시 후 다시 시도해 주세요');
   }

--- a/client/src/shared/components/Button/Button.styled.ts
+++ b/client/src/shared/components/Button/Button.styled.ts
@@ -81,10 +81,9 @@ const variantStyles = {
     background-color: ${theme.colors.white};
 
     &:hover {
-      background-color: white;
+      background-color: ${theme.colors.white};
       color: ${theme.colors.gray600};
       border: 1.5px solid ${theme.colors.gray400};
-      opacity: 0.8;
     }
 
     &:disabled {


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #419

## ✨ 작업 내용

- 모바일에서 클립보드 복사 이슈의 원인을 분석해보았고, 실제 배포 환경에서의 테스트도 필요할 것 같습니다.

### 문제상황
데스크톱 환경에서는 사용자 이벤트 여부에 비교적 관대한 편이라, 일부 브라우저에서는 비동기 흐름 안에서도 `navigator.clipboard.writeText()`가 정상 동작합니다. 하지만 모바일 사파리와 같은 브라우저에서는 보안상의 이유로 사용자의 직접적인 제스처(터치, 클릭 등) 안에서만 클립보드 접근이 허용된다고 합니다.

현재 구조는 버튼 클릭 시 `navigator.clipboard.writeText()`가 호출되긴 하지만, mutation의 onSuccess 콜백처럼 사용자 이벤트 이후의 비동기 흐름 안에서 호출되고 있기 때문에, 모바일에서는 이를 사용자 제스처로 인식하지 않아 클립보드 복사가 차단된다고 합니다.

### 해결 방법
이러한 제한을 피하기 위해, 기존의 mutation 호출 방식을 제거하고 사용자 클릭 이벤트 내부에서 클립보드 복사가 직접 실행되도록 구조를 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 초대 코드 생성 기능이 직접 함수 호출 방식으로 변경되어, 초대 코드 생성 시 더 직관적인 흐름과 에러 처리 방식을 제공합니다.
  * 초대 URL의 기본 도메인이 `https://www.ahmadda.com`에서 `https://ahmadda.com`으로 변경되었습니다.

* **Style**
  * 버튼 아웃라인 스타일의 호버 배경색이 테마 색상으로 통일되었으며, 호버 시 투명도 효과가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->