### PR TITLE
[FE] 수용인원 Modal 디자인 변경, hook 분리

### DIFF
--- a/client/src/features/Event/New/components/MaxCapacityModal.tsx
+++ b/client/src/features/Event/New/components/MaxCapacityModal.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/shared/components/Input';
 import { Modal } from '@/shared/components/Modal';
 import { Text } from '@/shared/components/Text';
 
+import { UNLIMITED_CAPACITY } from '../constants/errorMessages';
 import { useMaxCapacity } from '../hooks/useMaxCapacity';
 
 type Props = {
@@ -23,7 +24,7 @@ export const MaxCapacityModal = ({ isOpen, initialValue, onClose, onSubmit }: Pr
   };
 
   const handleUnlimitedCapacity = () => {
-    onSubmit(Number.POSITIVE_INFINITY);
+    onSubmit(UNLIMITED_CAPACITY);
     onClose();
   };
 

--- a/client/src/features/Event/New/components/MaxCapacityModal.tsx
+++ b/client/src/features/Event/New/components/MaxCapacityModal.tsx
@@ -1,12 +1,10 @@
-import { useState } from 'react';
-
 import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
 import { Input } from '@/shared/components/Input';
 import { Modal } from '@/shared/components/Modal';
 import { Text } from '@/shared/components/Text';
 
-import { UNLIMITED_CAPACITY } from '../constants/errorMessages';
+import { useMaxCapacity } from '../hooks/useMaxCapacity';
 
 type Props = {
   isOpen: boolean;
@@ -16,23 +14,22 @@ type Props = {
 };
 
 export const MaxCapacityModal = ({ isOpen, initialValue, onClose, onSubmit }: Props) => {
-  const [value, setValue] = useState(initialValue.toString());
+  const { maxCapacity, handleMaxCapacityChange } = useMaxCapacity(initialValue);
 
-  const handleConfirm = () => {
-    const parsed = Number(value);
+  const handleLimitedCapacity = () => {
+    if (maxCapacity === 0) return alert('수용 인원은 1명 이상이여야 합니다.');
+    onSubmit(Number(maxCapacity));
+    onClose();
+  };
 
-    if (!Number.isInteger(parsed) || parsed < 1) {
-      alert('수용 인원은 1 이상의 정수여야 합니다.');
-      return;
-    }
-
-    onSubmit(parsed);
+  const handleUnlimitedCapacity = () => {
+    onSubmit(Number.POSITIVE_INFINITY);
     onClose();
   };
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      <Flex dir="column" gap="20px" width="300px">
+      <Flex dir="column" gap="10px" width="380px">
         <Text type="Heading" weight="bold">
           최대 수용 인원
         </Text>
@@ -42,29 +39,15 @@ export const MaxCapacityModal = ({ isOpen, initialValue, onClose, onSubmit }: Pr
           label="수용 인원을 입력해주세요."
           type="text"
           autoFocus
-          value={value}
-          onChange={(e) => {
-            const raw = e.target.value;
-
-            if (/^\d*$/.test(raw)) {
-              setValue(raw);
-            }
-          }}
+          value={maxCapacity}
+          onChange={handleMaxCapacityChange}
         />
 
-        <Flex justifyContent="space-between" width="100%">
-          <Button
-            onClick={() => {
-              onSubmit(UNLIMITED_CAPACITY);
-              onClose();
-            }}
-            size="sm"
-            color="tertiary"
-          >
+        <Flex justifyContent="space-between" gap="12px">
+          <Button onClick={handleUnlimitedCapacity} size="full" variant="outline">
             무제한
           </Button>
-
-          <Button onClick={handleConfirm} size="sm" color="secondary">
+          <Button onClick={handleLimitedCapacity} size="full" color="secondary">
             설정
           </Button>
         </Flex>

--- a/client/src/features/Event/New/components/TemplateModal.tsx
+++ b/client/src/features/Event/New/components/TemplateModal.tsx
@@ -30,15 +30,11 @@ export const TemplateModal = ({
   onSelect,
   selectedEventId,
 }: TemplateModalProps) => {
-  //E.TODO organizationId 받아오기
+  // E.TODO organizationId 받아오기
   const { data: eventTitles } = useQuery(eventQueryOptions.titles(1));
 
   const handleConfirm = () => {
     onConfirm(selectedEventId);
-    onClose();
-  };
-
-  const handleClose = () => {
     onClose();
   };
 
@@ -117,7 +113,7 @@ export const TemplateModal = ({
         <Spacing height="1px" />
 
         <Flex gap="12px" justifyContent="center">
-          <Button color="secondary" variant="outline" size="full" onClick={handleClose}>
+          <Button color="secondary" variant="outline" size="full" onClick={onClose}>
             취소
           </Button>
           <Button

--- a/client/src/features/Event/New/hooks/useMaxCapacity.ts
+++ b/client/src/features/Event/New/hooks/useMaxCapacity.ts
@@ -1,0 +1,22 @@
+import { ChangeEvent, useState } from 'react';
+
+export const useMaxCapacity = (initialValue: number | string) => {
+  const [maxCapacity, setMaxCapacity] = useState(initialValue);
+
+  const handleMaxCapacityChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const numberValue = Number(e.target.value);
+
+    if (!Number.isInteger(numberValue)) {
+      alert('수용 인원은 숫자만 입력가능합니다.');
+      setMaxCapacity(Number(maxCapacity));
+      return;
+    }
+
+    setMaxCapacity(Number(numberValue));
+  };
+
+  return {
+    maxCapacity,
+    handleMaxCapacityChange,
+  };
+};


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #404

## ✨ 작업 내용

- 수용인원 디자인 변경했습니다.
- 수용인원 관련 상태 관리 hook으로 분리했습니다. 

<img width="653" height="904" alt="스크린샷 2025-08-07 오후 10 29 12" src="https://github.com/user-attachments/assets/78d00bf6-b9bb-40a4-a8a0-c920f334f957" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩터**
  * 최대 인원 설정 모달의 입력값 상태 관리 및 검증 로직이 커스텀 훅으로 분리되어 코드 구조가 개선되었습니다.
  * 모달 레이아웃과 버튼 스타일이 조정되었습니다.

* **버그 수정**
  * 최대 인원 입력 시 숫자만 허용되도록 검증 및 알림 기능이 추가되었습니다.

* **기타**
  * 취소 버튼 동작이 간소화되어 코드가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->