### PR TITLE
[FE] 모바일에서 초대코드 복사가 안되는 문제해결

### DIFF
--- a/client/src/features/Event/Overview/components/EventList.tsx
+++ b/client/src/features/Event/Overview/components/EventList.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -7,6 +9,7 @@ import { Icon } from '@/shared/components/Icon';
 import { Text } from '@/shared/components/Text';
 import { theme } from '@/shared/styles/theme';
 
+import { useModal } from '../../../../shared/hooks/useModal';
 import { Event, Organization } from '../../types/Event';
 import { EventContainer } from '../containers/EventContainer';
 import { copyInviteMessage } from '../utils/copyInviteMessage';
@@ -15,13 +18,16 @@ import { groupEventsByDate } from '../utils/groupEventsByDate';
 import { ActionButtons } from './ActionButtons';
 import { EventCard } from './EventCard';
 import { EventSection } from './EventSection';
+import { InviteCodeModal } from './InviteCodeModal';
 
 type EventListProps = {
   events: Event[];
 } & Pick<Organization, 'organizationId'>;
 
 export const EventList = ({ organizationId, events }: EventListProps) => {
+  const [inviteCode, setInviteCode] = useState('');
   const groupedEvents = groupEventsByDate(events);
+  const { isOpen, open, close } = useModal();
 
   const handleCreateInviteCode = async () => {
     try {
@@ -29,53 +35,55 @@ export const EventList = ({ organizationId, events }: EventListProps) => {
       const baseUrl =
         process.env.NODE_ENV === 'production' ? 'https://ahmadda.com' : 'http://localhost:5173';
       const inviteUrl = `${baseUrl}/invite?code=${data.inviteCode}`;
-      await copyInviteMessage(inviteUrl);
-
-      alert('초대 코드가 복사되었습니다.');
+      setInviteCode(inviteUrl);
+      open();
     } catch {
       alert('초대 코드 생성에 실패했습니다.');
     }
   };
 
   return (
-    <EventContainer>
-      <Flex
-        width="100%"
-        justifyContent="flex-start"
-        alignItems="center"
-        gap="5px"
-        padding="10px"
-        css={css`
-          border-radius: 8px;
-          background-color: ${theme.colors.primary50};
-        `}
-      >
-        <Icon name="calendar" color="primary500" size={20} />
-        <Text weight="bold" color={theme.colors.primary500}>
-          {events.length}개의 이벤트가 열려있어요!
-        </Text>
-      </Flex>
-      <Flex dir="column" width="100%" gap="20px">
-        <ActionButtons onIssueInviteCode={handleCreateInviteCode} />
-        {groupedEvents.length === 0 ? (
-          <Flex justifyContent="center" alignItems="center" height="200px">
-            <Text type="Heading" weight="semibold">
-              등록된 이벤트가 없습니다.
-            </Text>
-          </Flex>
-        ) : (
-          groupedEvents.map(({ label, events }) => (
-            <EventSection key={label} title={label}>
-              <EventGrid>
-                {events.map((event, index) => (
-                  <EventCard key={index} {...event} />
-                ))}
-              </EventGrid>
-            </EventSection>
-          ))
-        )}
-      </Flex>
-    </EventContainer>
+    <>
+      <EventContainer>
+        <Flex
+          width="100%"
+          justifyContent="flex-start"
+          alignItems="center"
+          gap="5px"
+          padding="10px"
+          css={css`
+            border-radius: 8px;
+            background-color: ${theme.colors.primary50};
+          `}
+        >
+          <Icon name="calendar" color="primary500" size={20} />
+          <Text weight="bold" color={theme.colors.primary500}>
+            {events.length}개의 이벤트가 열려있어요!
+          </Text>
+        </Flex>
+        <Flex dir="column" width="100%" gap="20px">
+          <ActionButtons onIssueInviteCode={handleCreateInviteCode} />
+          {groupedEvents.length === 0 ? (
+            <Flex justifyContent="center" alignItems="center" height="200px">
+              <Text type="Heading" weight="semibold">
+                등록된 이벤트가 없습니다.
+              </Text>
+            </Flex>
+          ) : (
+            groupedEvents.map(({ label, events }) => (
+              <EventSection key={label} title={label}>
+                <EventGrid>
+                  {events.map((event, index) => (
+                    <EventCard key={index} {...event} />
+                  ))}
+                </EventGrid>
+              </EventSection>
+            ))
+          )}
+        </Flex>
+      </EventContainer>
+      <InviteCodeModal inviteCode={inviteCode} isOpen={isOpen} onClose={close} />
+    </>
   );
 };
 

--- a/client/src/features/Event/Overview/components/InviteCodeModal.tsx
+++ b/client/src/features/Event/Overview/components/InviteCodeModal.tsx
@@ -1,0 +1,52 @@
+import { css } from '@emotion/react';
+
+import { Button } from '@/shared/components/Button';
+import { Flex } from '@/shared/components/Flex';
+import { Modal } from '@/shared/components/Modal';
+import { ModalProps } from '@/shared/components/Modal/Modal';
+import { Text } from '@/shared/components/Text';
+
+import { copyInviteMessage } from '../utils/copyInviteMessage';
+
+type InviteCodeProps = {
+  inviteCode: string;
+} & ModalProps;
+
+export const InviteCodeModal = ({ inviteCode, isOpen, onClose }: InviteCodeProps) => {
+  const handleCopyInviteCode = () => {
+    copyInviteMessage(inviteCode);
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      css={css`
+        width: 380px;
+      `}
+    >
+      <Flex dir="column" alignItems="flex-start" gap="16px">
+        <Text type="Heading" weight="semibold">
+          초대 코드가 생성됐어요.
+        </Text>
+        <Text type="Body">초대 코드를 복사해 조직원과 공유하세요!</Text>
+        <Text
+          type="Body"
+          color="primary"
+          css={css`
+            &:hover {
+              cursor: pointer;
+              text-decoration: underline;
+            }
+          `}
+        >
+          {inviteCode}
+        </Text>
+        <Button size="full" onClick={handleCopyInviteCode}>
+          초대코드 복사하기
+        </Button>
+      </Flex>
+    </Modal>
+  );
+};


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #이슈번호

## ✨ 작업 내용

- 모달에서 초대 코드를 복사할 수 있도록 개선했습니다.
- 조직 초대 버튼 클릭 시 비동기 함수를 호출하고, 모달 내부에 별도의 복사 함수를 정의했습니다.
- 기존에는 비동기 함수 내에서 clip 함수를 호출했으나, 조직 초대 함수와 복사 함수를 분리하여 구조를 개선했습니다.




<img width="1249" height="853" alt="스크린샷 2025-08-08 오전 11 11 42" src="https://github.com/user-attachments/assets/de5b4548-b868-4e90-b618-515054873990" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 초대 코드 생성 시 즉시 복사 및 알림 대신, 초대 코드 모달 창이 표시됩니다.
  * 초대 코드 모달에서 "초대코드 복사하기" 버튼을 통해 초대 메시지를 복사할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->