### PR TITLE
[FE] 잘못된 url 접근 시 에러 페이지 렌더링 테스트 작성

### DIFF
--- a/client/src/__test__/ErrorPageRender.test.tsx
+++ b/client/src/__test__/ErrorPageRender.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect } from 'vitest';
+
+import { ErrorPage } from '@/features/Error/pages/ErrorPage';
+
+import { RouterWithQueryClient } from './customRender';
+
+describe('잘못된 URL 접근 시 Error 페이지 렌더링', () => {
+  test('잘못된 경로로 접근 시 Error 페이지가 렌더링된다', async () => {
+    render(
+      <RouterWithQueryClient
+        initialRoute="/asdfasdf"
+        routes={[{ path: '*', element: <ErrorPage /> }]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('문제가 발생했습니다')).toBeInTheDocument();
+    });
+  });
+  //E.TODO 에러바운더리 설정 후 fallback UI에 대한 테스트 추가
+});


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #446 

## ✨ 작업 내용

- 잘못된 url 접근 시 에러 페이지가 렌더링 되는 테스트를 작성하였습니다.
- 추후 에러바운더리 적용 이후에 관련된 다른 테스트 더 추가하겠습니다.

## 🙏 기타 참고 사항

<img width="856" height="217" alt="image" src="https://github.com/user-attachments/assets/2bf5a029-3302-4118-b3f6-8c34dc944521" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 잘못된 URL 경로 접근 시 ErrorPage가 정상적으로 렌더링되는지 확인하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->