### PR TITLE
[BE] Async 환경에서 JPA 삭제 시 트랜잭션 미전파로 인한 InvalidDataAccessApiUsageException 해결

### DIFF
--- a/.github/workflows/prod-deploy-on-release.yml
+++ b/.github/workflows/prod-deploy-on-release.yml
@@ -1,13 +1,13 @@
 name: Prod Deploy On Release
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
     paths:
       - 'server/**'
-  release:
-    types: [published]
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   setup:

--- a/.github/workflows/prod-deploy-on-release.yml
+++ b/.github/workflows/prod-deploy-on-release.yml
@@ -1,13 +1,13 @@
 name: Prod Deploy On Release
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
     paths:
       - 'server/**'
-    types:
-      - opened
-      - synchronize
-      - reopened
+  release:
+    types: [published]
 
 jobs:
   setup:

--- a/server/src/main/java/com/ahmadda/infra/notification/push/FcmRegistrationTokenRepository.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/FcmRegistrationTokenRepository.java
@@ -1,6 +1,7 @@
 package com.ahmadda.infra.notification.push;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,5 +15,6 @@ public interface FcmRegistrationTokenRepository extends JpaRepository<FcmRegistr
 
     List<FcmRegistrationToken> findAllByMemberIdIn(final List<Long> memberIds);
 
+    @Transactional
     void deleteAllByRegistrationTokenIn(final List<String> registrationTokens);
 }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #452

## ✨ 작업 내용

- 현재 Spring Data JPA가 생성한 삭제 메서드가 내부적으로 EntityManager.remove(...)를 호출하는데, 실행 스레드에 트랜잭션이 없어 오류가 발생하고 있습니다 ㅠㅠ

- 이를 해결하기 위해 FcmRegistrationTokenRepository의 deleteAllByRegistrationTokenIn 메서드에 `@Transactional`을 적용하여 트랜잭션 범위 안에서 실행되도록 수정했습니다~~!

## 🙏 기타 참고 사항
왜 오류가 발생하는지는 https://www.objectdb.com/java/jpa/persistence/delete 에서  
> A TransactionRequiredException is thrown if there is no active transaction when remove is called because operations that modify the database require an active transaction.  

이 부분을 참고하면 이해하는 데 도움이 될 거예요~~



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 해당 없음

- 개선/리팩터링
  - 서버 측 일부 작업에 트랜잭션을 적용해 데이터 처리의 일관성과 안정성을 강화했습니다.

- 작업(Chores)
  - 배포 워크플로 트리거를 메인/릴리스 기준에서 특정 PR 이벤트 기준으로 전환해, 서버 관련 변경이 포함된 PR에서만 동작하도록 조정했습니다.
  - 애플리케이션 동작에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->