### PR TITLE
[BE] 이벤트 조회수 관련 방어 로직 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventReadListener.java
+++ b/server/src/main/java/com/ahmadda/application/EventReadListener.java
@@ -36,22 +36,24 @@ public class EventReadListener {
         eventStatisticRepository.findByEventId(eventRead.eventId())
                 .ifPresentOrElse(
                         eventStatistic -> {
-                            eventStatistic.increaseViewCount(
-                                    LocalDate.now(),
-                                    member
-                            );
+                            increaseViewCount(eventStatistic, member);
                         },
                         () -> {
                             Event event = eventRepository.findById(eventRead.eventId())
                                     .orElseThrow((() -> new NotFoundException("존재하지 않는 이벤트입니다")));
 
                             EventStatistic eventStatistic = EventStatistic.create(event);
-                            eventStatistic.increaseViewCount(
-                                    LocalDate.now(),
-                                    member
-                            );
+
+                            increaseViewCount(eventStatistic, member);
                             eventStatisticRepository.save(eventStatistic);
                         }
                 );
+    }
+
+    private static void increaseViewCount(EventStatistic eventStatistic, Member member) {
+        eventStatistic.increaseViewCount(
+                LocalDate.now(),
+                member
+        );
     }
 }

--- a/server/src/main/java/com/ahmadda/application/EventReadListener.java
+++ b/server/src/main/java/com/ahmadda/application/EventReadListener.java
@@ -28,7 +28,7 @@ public class EventReadListener {
 
     @EventListener
     @Transactional
-    public void onEventCreated(final EventRead eventRead) {
+    public void onEventReaded(final EventRead eventRead) {
         Member member = memberRepository.findById(eventRead.loginMember()
                         .memberId())
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -103,7 +103,7 @@ public class EventService {
 
         validateOrganizationAccess(organization.getId(), loginMember.memberId());
 
-        eventPublisher.publishEvent(EventRead.from(event));
+        eventPublisher.publishEvent(EventRead.from(event, loginMember));
 
         return event;
     }

--- a/server/src/main/java/com/ahmadda/application/dto/EventRead.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventRead.java
@@ -2,9 +2,15 @@ package com.ahmadda.application.dto;
 
 import com.ahmadda.domain.Event;
 
-public record EventRead(Long eventId) {
+public record EventRead(
+        Long eventId,
+        LoginMember loginMember
+) {
 
-    public static EventRead from(final Event event) {
-        return new EventRead(event.getId());
+    public static EventRead from(
+            final Event event,
+            final LoginMember loginMember
+    ) {
+        return new EventRead(event.getId(), loginMember);
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/EventStatistic.java
+++ b/server/src/main/java/com/ahmadda/domain/EventStatistic.java
@@ -52,7 +52,7 @@ public class EventStatistic extends BaseEntity {
         return new EventStatistic(event);
     }
 
-    public void increaseViewCount(final LocalDate currentDate, Member member) {
+    public void increaseViewCount(final LocalDate currentDate, final Member member) {
         if (event.isOrganizer(member)) {
             return;
         }

--- a/server/src/main/java/com/ahmadda/domain/EventStatistic.java
+++ b/server/src/main/java/com/ahmadda/domain/EventStatistic.java
@@ -52,7 +52,11 @@ public class EventStatistic extends BaseEntity {
         return new EventStatistic(event);
     }
 
-    public void increaseViewCount(final LocalDate currentDate) {
+    public void increaseViewCount(final LocalDate currentDate, Member member) {
+        if (event.isOrganizer(member)) {
+            return;
+        }
+
         eventViewMetrics.stream()
                 .filter((eventViewMetric) -> eventViewMetric.isSameDate(currentDate))
                 .findFirst()

--- a/server/src/test/java/com/ahmadda/application/EventCreatedListenerTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventCreatedListenerTest.java
@@ -1,0 +1,113 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.dto.EventCreated;
+import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.Event;
+import com.ahmadda.domain.EventOperationPeriod;
+import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.EventStatisticRepository;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
+import com.ahmadda.domain.Organization;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberRepository;
+import com.ahmadda.domain.OrganizationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class EventCreatedListenerTest {
+
+    @Autowired
+    private EventCreatedListener sut;
+
+    @Autowired
+    private EventStatisticRepository eventStatisticRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private OrganizationMemberRepository organizationMemberRepository;
+
+    @Test
+    void 이벤트가_생성되면_이벤트_통계가_저장된다() {
+        // given
+        var organization = createOrganization();
+        var member = createMember();
+        var organizationMember = createOrganizationMember(organization, member);
+        var event = createEvent(organizationMember, organization);
+        var eventCreated = new EventCreated(event.getId());
+
+        // when
+        sut.onEventCreated(eventCreated);
+
+        // then
+        var eventStatistic = eventStatisticRepository.findByEventId(event.getId());
+
+        assertSoftly(softly -> {
+            softly.assertThat(eventStatistic)
+                    .isPresent();
+            softly.assertThat(eventStatistic.get()
+                            .getEvent())
+                    .isEqualTo(event);
+        });
+    }
+
+    @Test
+    void 존재하지_않는_이벤트ID로_이벤트가_생성되면_예외가_발생한다() {
+        // given
+        var eventCreated = new EventCreated(999L);
+
+        // when // then
+        assertThatThrownBy(() -> sut.onEventCreated(eventCreated))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 이벤트입니다.");
+    }
+
+    private Organization createOrganization() {
+        var organization = Organization.create("우테코", "우테코입니다.", "image");
+        return organizationRepository.save(organization);
+    }
+
+    private Member createMember() {
+        return memberRepository.save(Member.create("name", "ahmadda@ahmadda.com", "testPicture"));
+    }
+
+    private OrganizationMember createOrganizationMember(Organization organization, Member member) {
+        var organizationMember = OrganizationMember.create("surf", member, organization);
+        return organizationMemberRepository.save(organizationMember);
+    }
+
+    private Event createEvent(final OrganizationMember organizationMember, final Organization organization) {
+        var now = LocalDateTime.now();
+        var event = Event.create(
+                "title",
+                "description",
+                "place",
+                organizationMember,
+                organization,
+                EventOperationPeriod.create(
+                        now.plusDays(1), now.plusDays(2),
+                        now.plusDays(3), now.plusDays(4),
+                        now
+                ),
+                10
+        );
+        return eventRepository.save(event);
+    }
+}

--- a/server/src/test/java/com/ahmadda/application/EventCreatedListenerTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventCreatedListenerTest.java
@@ -81,6 +81,7 @@ class EventCreatedListenerTest {
 
     private Organization createOrganization() {
         var organization = Organization.create("우테코", "우테코입니다.", "image");
+
         return organizationRepository.save(organization);
     }
 
@@ -90,6 +91,7 @@ class EventCreatedListenerTest {
 
     private OrganizationMember createOrganizationMember(Organization organization, Member member) {
         var organizationMember = OrganizationMember.create("surf", member, organization);
+        
         return organizationMemberRepository.save(organizationMember);
     }
 
@@ -108,6 +110,7 @@ class EventCreatedListenerTest {
                 ),
                 10
         );
+
         return eventRepository.save(event);
     }
 }

--- a/server/src/test/java/com/ahmadda/application/EventReadListenerTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventReadListenerTest.java
@@ -148,6 +148,7 @@ class EventReadListenerTest {
         var now = LocalDateTime.now();
         var period = EventOperationPeriod.create(now, now.plusDays(1), now.plusDays(2), now.plusDays(3), now);
         var event = Event.create("title", "description", "place", organizer, organization, period, 100);
+
         return eventRepository.save(event);
     }
 }

--- a/server/src/test/java/com/ahmadda/application/EventReadListenerTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventReadListenerTest.java
@@ -48,7 +48,7 @@ class EventReadListenerTest {
     private OrganizationMemberRepository organizationMemberRepository;
 
     @Test
-    void 이벤트_조회_이벤트가_발행되고_해당_이벤트에_대한_통계가_존재하면_조회수가_1_증가한다() {
+    void 해당_이벤트에_대한_통계가_존재하면_조회수가_1_증가한다() {
         // given
         var organization = createOrganization();
         var organizer = createMember("organizer", "organizer@mail.com");
@@ -63,9 +63,10 @@ class EventReadListenerTest {
         sut.onEventReaded(eventRead);
 
         // then
-        var actual = eventStatisticRepository.findByEventId(event.getId())
+        var eventStatistic = eventStatisticRepository.findByEventId(event.getId())
                 .get();
-        var viewCount = actual.getEventViewMetrics()
+
+        var viewCount = eventStatistic.getEventViewMetrics()
                 .stream()
                 .filter(metric -> metric.isSameDate(LocalDate.now()))
                 .findFirst()
@@ -75,7 +76,7 @@ class EventReadListenerTest {
     }
 
     @Test
-    void 이벤트_조회_이벤트가_발행되고_해당_이벤트에_대한_통계가_존재하지_않으면_통계를_생성하고_조회수를_1로_만든다() {
+    void 해당_이벤트에_대한_통계가_존재하지_않으면_통계를_생성하고_조회수를_1로_만든다() {
         // given
         var organization = createOrganization();
         var organizer = createMember("organizer", "organizer@mail.com");
@@ -89,9 +90,9 @@ class EventReadListenerTest {
         sut.onEventReaded(eventRead);
 
         // then
-        var actual = eventStatisticRepository.findByEventId(event.getId())
+        var eventStatistic = eventStatisticRepository.findByEventId(event.getId())
                 .get();
-        var viewCount = actual.getEventViewMetrics()
+        var viewCount = eventStatistic.getEventViewMetrics()
                 .stream()
                 .filter(metric -> metric.isSameDate(LocalDate.now()))
                 .findFirst()

--- a/server/src/test/java/com/ahmadda/application/EventReadListenerTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventReadListenerTest.java
@@ -1,0 +1,122 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.dto.EventRead;
+import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.domain.Event;
+import com.ahmadda.domain.EventOperationPeriod;
+import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.EventStatistic;
+import com.ahmadda.domain.EventStatisticRepository;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
+import com.ahmadda.domain.Organization;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberRepository;
+import com.ahmadda.domain.OrganizationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class EventReadListenerTest {
+
+    @Autowired
+    private EventReadListener sut;
+
+    @Autowired
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    private EventStatisticRepository eventStatisticRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private OrganizationMemberRepository organizationMemberRepository;
+
+    @Test
+    void 이벤트_조회_이벤트가_발행되고_해당_이벤트에_대한_통계가_존재하면_조회수가_1_증가한다() {
+        // given
+        var organization = createOrganization();
+        var organizer = createMember("organizer", "organizer@mail.com");
+        var reader = createMember("reader", "reader@mail.com");
+        var organizationMember = createOrganizationMember(organization, organizer);
+        var event = createEvent(organizationMember, organization);
+        eventStatisticRepository.save(EventStatistic.create(event));
+
+        var eventRead = new EventRead(event.getId(), new LoginMember(reader.getId()));
+
+        // when
+        applicationEventPublisher.publishEvent(eventRead);
+
+        // then
+        var actual = eventStatisticRepository.findByEventId(event.getId()).get();
+        var viewCount = actual.getEventViewMetrics().stream()
+                .filter(metric -> metric.isSameDate(LocalDate.now()))
+                .findFirst()
+                .get()
+                .getViewCount();
+        assertThat(viewCount).isEqualTo(1);
+    }
+
+    @Test
+    void 이벤트_조회_이벤트가_발행되고_해당_이벤트에_대한_통계가_존재하지_않으면_통계를_생성하고_조회수를_1로_만든다() {
+        // given
+        var organization = createOrganization();
+        var organizer = createMember("organizer", "organizer@mail.com");
+        var reader = createMember("reader", "reader@mail.com");
+        var organizationMember = createOrganizationMember(organization, organizer);
+        var event = createEvent(organizationMember, organization);
+
+        var eventRead = new EventRead(event.getId(), new LoginMember(reader.getId()));
+
+        // when
+        applicationEventPublisher.publishEvent(eventRead);
+
+        // then
+        var actual = eventStatisticRepository.findByEventId(event.getId()).get();
+        var viewCount = actual.getEventViewMetrics().stream()
+                .filter(metric -> metric.isSameDate(LocalDate.now()))
+                .findFirst()
+                .get()
+                .getViewCount();
+        assertThat(viewCount).isEqualTo(1);
+    }
+
+    private Organization createOrganization() {
+        var organization = Organization.create("우테코", "우테코입니다.", "image");
+        return organizationRepository.save(organization);
+    }
+
+    private Member createMember(String name, String email) {
+        var member = Member.create(name, email, "testPicture");
+        return memberRepository.save(member);
+    }
+
+    private OrganizationMember createOrganizationMember(Organization organization, Member member) {
+        var organizationMember = OrganizationMember.create("surf", member, organization);
+        return organizationMemberRepository.save(organizationMember);
+    }
+
+    private Event createEvent(OrganizationMember organizer, Organization organization) {
+        var now = LocalDateTime.now();
+        var period = EventOperationPeriod.create(now, now.plusDays(1), now.plusDays(2), now.plusDays(3), now);
+        var event = Event.create("title", "description", "place", organizer, organization, period, 100);
+        return eventRepository.save(event);
+    }
+}

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -25,7 +25,6 @@ import com.ahmadda.domain.exception.UnauthorizedOperationException;
 import com.ahmadda.infra.notification.push.FcmRegistrationToken;
 import com.ahmadda.infra.notification.push.FcmRegistrationTokenRepository;
 import org.assertj.core.groups.Tuple;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -368,7 +367,6 @@ class EventServiceTest {
         verify(pushNotifier).sendPushs(List.of(om1, om2), pushPayload);
     }
 
-    @Disabled
     @Test
     void 이벤트를_수정할_수_있다() {
         // given
@@ -500,7 +498,6 @@ class EventServiceTest {
                 .hasMessage("존재하지 않는 회원입니다.");
     }
 
-    @Disabled
     @Test
     void 이벤트_수정_시_게스트들에게_알림을_보낸다() {
         // given

--- a/server/src/test/java/com/ahmadda/application/EventStatisticServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventStatisticServiceTest.java
@@ -128,6 +128,7 @@ class EventStatisticServiceTest {
                 operationPeriod,
                 30
         );
+
         return eventRepository.save(event);
     }
 

--- a/server/src/test/java/com/ahmadda/application/EventUpdateListenerTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventUpdateListenerTest.java
@@ -1,0 +1,110 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.dto.EventUpdated;
+import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.Event;
+import com.ahmadda.domain.EventOperationPeriod;
+import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.EventStatisticRepository;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
+import com.ahmadda.domain.Organization;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberRepository;
+import com.ahmadda.domain.OrganizationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class EventUpdateListenerTest {
+
+    @Autowired
+    private EventUpdateListener sut;
+
+    @Autowired
+    private EventStatisticRepository eventStatisticRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private OrganizationMemberRepository organizationMemberRepository;
+
+    @Test
+    void 이벤트_기간이_연장되어_수정되면_연장된_기간만큼_통계가_추가_생성된다() {
+        // given
+        var now = LocalDateTime.now();
+        var initialPeriod = EventOperationPeriod.create(now, now.plusDays(1), now.plusDays(2), now.plusDays(3), now);
+        var organization = createOrganization();
+        var organizer = createMember("organizer", "organizer@mail.com");
+        var organizationMember = createOrganizationMember(organization, organizer);
+        var event = createEvent(organizationMember, organization, initialPeriod);
+
+        var extendedPeriod = EventOperationPeriod.create(now, now.plusDays(1), now.plusDays(4), now.plusDays(5), now);
+        event.update(organizer, "title", "description", "place", extendedPeriod, 100);
+        eventRepository.save(event);
+
+        var eventUpdated = new EventUpdated(event.getId());
+
+        // when
+        sut.onEventUpdated(eventUpdated);
+
+        var eventDuration = ChronoUnit.DAYS
+                .between(
+                        extendedPeriod.getRegistrationPeriod()
+                                .start(),
+                        extendedPeriod.getEventPeriod()
+                                .end()
+                ) + 1;
+
+        // then
+        var statisticAfterSecondUpdate = eventStatisticRepository.findByEventId(event.getId())
+                .get();
+
+        assertThat(statisticAfterSecondUpdate.getEventViewMetrics())
+                .hasSize((int) eventDuration);
+    }
+
+    @Test
+    void 이벤트자체가_생성되지_않았으면_예외가_발생한다() {
+        //when //then
+        assertThatThrownBy(() -> sut.onEventUpdated(new EventUpdated(-1L)))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 이벤트입니다");
+    }
+
+    private Organization createOrganization() {
+        var organization = Organization.create("우테코", "우테코입니다.", "image");
+        return organizationRepository.save(organization);
+    }
+
+    private Member createMember(String name, String email) {
+        var member = Member.create(name, email, "testPicture");
+        return memberRepository.save(member);
+    }
+
+    private OrganizationMember createOrganizationMember(Organization organization, Member member) {
+        var organizationMember = OrganizationMember.create("surf", member, organization);
+        return organizationMemberRepository.save(organizationMember);
+    }
+
+    private Event createEvent(OrganizationMember organizer, Organization organization, EventOperationPeriod period) {
+        var event = Event.create("title", "description", "place", organizer, organization, period, 100);
+        return eventRepository.save(event);
+    }
+}

--- a/server/src/test/java/com/ahmadda/application/EventUpdateListenerTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventUpdateListenerTest.java
@@ -90,21 +90,25 @@ class EventUpdateListenerTest {
 
     private Organization createOrganization() {
         var organization = Organization.create("우테코", "우테코입니다.", "image");
+        
         return organizationRepository.save(organization);
     }
 
     private Member createMember(String name, String email) {
         var member = Member.create(name, email, "testPicture");
+
         return memberRepository.save(member);
     }
 
     private OrganizationMember createOrganizationMember(Organization organization, Member member) {
         var organizationMember = OrganizationMember.create("surf", member, organization);
+
         return organizationMemberRepository.save(organizationMember);
     }
 
     private Event createEvent(OrganizationMember organizer, Organization organization, EventOperationPeriod period) {
         var event = Event.create("title", "description", "place", organizer, organization, period, 100);
+
         return eventRepository.save(event);
     }
 }

--- a/server/src/test/java/com/ahmadda/application/OrganizationMemberEventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationMemberEventServiceTest.java
@@ -268,6 +268,7 @@ class OrganizationMemberEventServiceTest {
                 ),
                 maxCapacity
         );
+        
         return eventRepository.save(event);
     }
 

--- a/server/src/test/java/com/ahmadda/domain/EventStatisticTest.java
+++ b/server/src/test/java/com/ahmadda/domain/EventStatisticTest.java
@@ -61,7 +61,7 @@ class EventStatisticTest {
 
         //then
         assertThat(sut.findEventViewMetrics(organizationMember, LocalDate.MAX)
-                           .size())
+                .size())
                 .isEqualTo(eventDuration);
     }
 
@@ -124,7 +124,7 @@ class EventStatisticTest {
 
         //then
         assertThat(sut.findEventViewMetrics(organizationMember, endLocalDate)
-                           .size())
+                .size())
                 .isEqualTo(eventDuration);
     }
 
@@ -144,8 +144,8 @@ class EventStatisticTest {
 
         //then
         assertThat(sut.findEventViewMetrics(organizationMember, beforeEventEndDatetime)
-                           .getLast()
-                           .getViewDate())
+                .getLast()
+                .getViewDate())
                 .isEqualTo(beforeEventEndDatetime);
     }
 
@@ -173,12 +173,12 @@ class EventStatisticTest {
 
         //then
         assertThat(sut.findEventViewMetrics(organizationMember, LocalDate.MAX)
-                           .size())
+                .size())
                 .isEqualTo(eventDuration);
     }
 
     @Test
-    void 오늘_날짜의_조회수를_증가시킬_수_있다() {
+    void 주최자는_조회해도_조회수가_오르지_않는다() {
         //given
         var organization = createOrganization("우테코1");
         var organizationMember = createOrganizationMember(createMember("서프", "surf@gmail.com"), organization);
@@ -191,12 +191,41 @@ class EventStatisticTest {
         var sut = EventStatistic.create(event);
 
         //when
-        sut.increaseViewCount(startDatetime);
+        sut.increaseViewCount(
+                startDatetime,
+                organizationMember.getMember()
+        );
 
         //then
         assertThat(sut.findEventViewMetrics(organizationMember, startDatetime)
-                           .getFirst()
-                           .getViewCount()).isEqualTo(1L);
+                .getFirst()
+                .getViewCount()).isEqualTo(0L);
+    }
+
+    @Test
+    void 오늘_날짜의_조회수를_증가시킬_수_있다() {
+        //given
+        var organization = createOrganization("우테코1");
+        var organizationMember = createOrganizationMember(createMember("서프", "surf@gmail.com"), organization);
+        var organizationMember2 = createOrganizationMember(createMember("투다", "praisebak@gmail.com"), organization);
+        var event = createEvent(organizationMember, organization);
+
+        var startDatetime = event.getEventOperationPeriod()
+                .getRegistrationPeriod()
+                .start()
+                .toLocalDate();
+        var sut = EventStatistic.create(event);
+
+        //when
+        sut.increaseViewCount(
+                startDatetime,
+                organizationMember2.getMember()
+        );
+
+        //then
+        assertThat(sut.findEventViewMetrics(organizationMember, startDatetime)
+                .getFirst()
+                .getViewCount()).isEqualTo(1L);
     }
 
     @Test
@@ -213,13 +242,16 @@ class EventStatisticTest {
         var sut = EventStatistic.create(event);
 
         //when
-        sut.increaseViewCount(LocalDate.MAX);
+        sut.increaseViewCount(
+                LocalDate.MAX,
+                organizationMember.getMember()
+        );
 
         //then
         assertThat(sut.findEventViewMetrics(organizationMember, startDatetime)
-                           .stream()
-                           .map(EventViewMetric::getViewCount)
-                           .toList())
+                .stream()
+                .map(EventViewMetric::getViewCount)
+                .toList())
                 .contains(0, 0);
     }
 


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #454 

## ✨ 작업 내용

- 데이터베이스에 직접 이벤트를 생성하는 등의 경우에는 이벤트 조회수 통계가 생성되지 않는 문제가 발생했습니다.
  - 이에 방어로직을 작성하였습니다.