### PR TITLE
[BE]  리마인드시 히스토리를 저장하도록 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
@@ -1,17 +1,15 @@
 package com.ahmadda.application;
 
-import com.ahmadda.domain.EmailNotifier;
 import com.ahmadda.domain.Event;
-import com.ahmadda.domain.EventEmailPayload;
 import com.ahmadda.domain.EventRepository;
 import com.ahmadda.domain.OrganizationMember;
-import com.ahmadda.domain.PushNotificationPayload;
-import com.ahmadda.domain.PushNotifier;
+import com.ahmadda.domain.ReminderNotifier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -20,18 +18,17 @@ import java.util.List;
 public class EventNotificationScheduler {
 
     // TODO. 추후 5분이라는 시간을 보장하도록 구현
-    private static final int REMINDER_MINUTES_BEFORE = 5;
+    private static final Duration REMINDER_BEFORE = Duration.ofMinutes(5);
 
     private final EventRepository eventRepository;
-    private final EmailNotifier emailNotifier;
-    private final PushNotifier pushNotifier;
+    private final ReminderNotifier reminderNotifier;
 
     // TODO. 추후 중복 알람을 방지하도록 구현
     @Scheduled(fixedRate = 180_000)
     @Transactional(readOnly = true)
     public void notifyRegistrationClosingEvents() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime targetTime = now.plusMinutes(REMINDER_MINUTES_BEFORE);
+        LocalDateTime targetTime = now.plus(REMINDER_BEFORE);
 
         List<Event> upcomingEvents =
                 eventRepository.findAllByEventOperationPeriodRegistrationPeriodEndBetween(now, targetTime);
@@ -45,36 +42,7 @@ public class EventNotificationScheduler {
                     );
                     String content = "이벤트 신청 마감이 임박했습니다.";
 
-                    sendNotificationToRecipients(recipients, upcomingEvent, content);
+                    reminderNotifier.remind(recipients, upcomingEvent, content);
                 });
-    }
-
-    private void sendNotificationToRecipients(
-            final List<OrganizationMember> recipients,
-            final Event event,
-            final String content
-    ) {
-        sendEmailsToRecipients(recipients, event, content);
-        sendPushNotificationsToRecipients(recipients, event, content);
-    }
-
-    private void sendEmailsToRecipients(
-            final List<OrganizationMember> recipients,
-            final Event event,
-            final String content
-    ) {
-        EventEmailPayload eventEmailPayload = EventEmailPayload.of(event, content);
-
-        emailNotifier.sendEmails(recipients, eventEmailPayload);
-    }
-
-    private void sendPushNotificationsToRecipients(
-            final List<OrganizationMember> recipients,
-            final Event event,
-            final String content
-    ) {
-        PushNotificationPayload pushNotificationPayload = PushNotificationPayload.of(event, content);
-
-        pushNotifier.sendPushs(recipients, pushNotificationPayload);
     }
 }

--- a/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
@@ -3,7 +3,9 @@ package com.ahmadda.application;
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventRepository;
 import com.ahmadda.domain.OrganizationMember;
-import com.ahmadda.domain.ReminderNotifier;
+import com.ahmadda.domain.Reminder;
+import com.ahmadda.domain.ReminderHistory;
+import com.ahmadda.domain.ReminderHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -21,7 +23,8 @@ public class EventNotificationScheduler {
     private static final Duration REMINDER_BEFORE = Duration.ofMinutes(5);
 
     private final EventRepository eventRepository;
-    private final ReminderNotifier reminderNotifier;
+    private final Reminder reminder;
+    private final ReminderHistoryRepository reminderHistoryRepository;
 
     // TODO. 추후 중복 알람을 방지하도록 구현
     @Scheduled(fixedRate = 180_000)
@@ -42,7 +45,16 @@ public class EventNotificationScheduler {
                     );
                     String content = "이벤트 신청 마감이 임박했습니다.";
 
-                    reminderNotifier.remind(recipients, upcomingEvent, content);
+                    sendAndRecordReminder(upcomingEvent, recipients, content);
                 });
+    }
+
+    private void sendAndRecordReminder(
+            final Event upcomingEvent,
+            final List<OrganizationMember> recipients,
+            final String content
+    ) {
+        List<ReminderHistory> reminderHistories = reminder.remind(recipients, upcomingEvent, content);
+        reminderHistoryRepository.saveAll(reminderHistories);
     }
 }

--- a/server/src/main/java/com/ahmadda/application/EventNotificationService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationService.java
@@ -5,17 +5,13 @@ import com.ahmadda.application.dto.NonGuestsNotificationRequest;
 import com.ahmadda.application.dto.SelectedOrganizationMembersNotificationRequest;
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
-import com.ahmadda.domain.EmailNotifier;
 import com.ahmadda.domain.Event;
-import com.ahmadda.domain.EventEmailPayload;
 import com.ahmadda.domain.EventRepository;
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
 import com.ahmadda.domain.Organization;
 import com.ahmadda.domain.OrganizationMember;
-import com.ahmadda.domain.PushNotificationPayload;
-import com.ahmadda.domain.PushNotifier;
-import com.ahmadda.infra.notification.push.FcmRegistrationTokenRepository;
+import com.ahmadda.domain.ReminderNotifier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -29,11 +25,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class EventNotificationService {
 
-    private final EmailNotifier emailNotifier;
-    private final PushNotifier pushNotifier;
+    private final ReminderNotifier reminderNotifier;
     private final EventRepository eventRepository;
     private final MemberRepository memberRepository;
-    private final FcmRegistrationTokenRepository fcmRegistrationTokenRepository;
 
     public void notifyNonGuestOrganizationMembers(
             final Long eventId,
@@ -46,7 +40,7 @@ public class EventNotificationService {
                 .getOrganizationMembers();
 
         List<OrganizationMember> recipients = event.getNonGuestOrganizationMembers(organizationMembers);
-        sendNotificationToRecipients(recipients, event, request.content());
+        reminderNotifier.remind(recipients, event, request.content());
     }
 
     public void notifySelectedOrganizationMembers(
@@ -58,7 +52,7 @@ public class EventNotificationService {
         validateOrganizer(event, loginMember.memberId());
 
         List<OrganizationMember> recipients = getEventRecipientsFromIds(event, request.organizationMemberIds());
-        sendNotificationToRecipients(recipients, event, request.content());
+        reminderNotifier.remind(recipients, event, request.content());
     }
 
     private Event getEvent(final Long eventId) {
@@ -105,34 +99,5 @@ public class EventNotificationService {
         if (!allExist) {
             throw new NotFoundException("존재하지 않는 조직원입니다.");
         }
-    }
-
-    private void sendNotificationToRecipients(
-            final List<OrganizationMember> recipients,
-            final Event event,
-            final String content
-    ) {
-        sendEmailsToRecipients(recipients, event, content);
-        sendPushNotificationsToRecipients(recipients, event, content);
-    }
-
-    private void sendEmailsToRecipients(
-            final List<OrganizationMember> recipients,
-            final Event event,
-            final String content
-    ) {
-        EventEmailPayload eventEmailPayload = EventEmailPayload.of(event, content);
-
-        emailNotifier.sendEmails(recipients, eventEmailPayload);
-    }
-
-    private void sendPushNotificationsToRecipients(
-            final List<OrganizationMember> recipients,
-            final Event event,
-            final String content
-    ) {
-        PushNotificationPayload pushNotificationPayload = PushNotificationPayload.of(event, content);
-
-        pushNotifier.sendPushs(recipients, pushNotificationPayload);
     }
 }

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -9,13 +9,9 @@ import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.QuestionCreateRequest;
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
-import com.ahmadda.domain.EmailNotifier;
 import com.ahmadda.domain.Event;
-import com.ahmadda.domain.EventEmailPayload;
 import com.ahmadda.domain.EventOperationPeriod;
 import com.ahmadda.domain.EventRepository;
-import com.ahmadda.domain.EventStatistic;
-import com.ahmadda.domain.EventStatisticRepository;
 import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
@@ -23,10 +19,8 @@ import com.ahmadda.domain.Organization;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
-import com.ahmadda.domain.PushNotificationPayload;
-import com.ahmadda.domain.PushNotifier;
 import com.ahmadda.domain.Question;
-import com.ahmadda.infra.notification.push.FcmRegistrationTokenRepository;
+import com.ahmadda.domain.ReminderNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -46,10 +40,7 @@ public class EventService {
     private final EventRepository eventRepository;
     private final OrganizationRepository organizationRepository;
     private final OrganizationMemberRepository organizationMemberRepository;
-    private final EmailNotifier emailNotifier;
-    private final PushNotifier pushNotifier;
-    private final FcmRegistrationTokenRepository fcmRegistrationTokenRepository;
-    private final EventStatisticRepository eventStatisticRepository;
+    private final ReminderNotifier reminderNotifier;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -202,7 +193,7 @@ public class EventService {
         List<OrganizationMember> recipients =
                 event.getNonGuestOrganizationMembers(organization.getOrganizationMembers());
 
-        notifyEventChange(event, content, recipients);
+        reminderNotifier.remind(recipients, event, content);
     }
 
     private void notifyEventUpdated(final Event event) {
@@ -212,31 +203,6 @@ public class EventService {
                 .map(Guest::getOrganizationMember)
                 .toList();
 
-        notifyEventChange(event, content, recipients);
-    }
-
-    private void notifyEventChange(
-            final Event event,
-            final String content,
-            final List<OrganizationMember> recipients
-    ) {
-        sendEmailsToRecipients(event, content, recipients);
-        sendPushNotificationsToRecipients(event, content, recipients);
-    }
-
-    private void sendPushNotificationsToRecipients(Event event, String content, List<OrganizationMember> recipients) {
-        PushNotificationPayload pushPayload = PushNotificationPayload.of(event, content);
-
-        pushNotifier.sendPushs(recipients, pushPayload);
-    }
-
-    private void sendEmailsToRecipients(Event event, String content, List<OrganizationMember> recipients) {
-        EventEmailPayload emailPayload = EventEmailPayload.of(event, content);
-
-        emailNotifier.sendEmails(recipients, emailPayload);
-    }
-
-    private void createEventStatistic(final Event savedEvent) {
-        eventStatisticRepository.save(EventStatistic.create(savedEvent));
+        reminderNotifier.remind(recipients, event, content);
     }
 }

--- a/server/src/main/java/com/ahmadda/application/FcmRegistrationTokenService.java
+++ b/server/src/main/java/com/ahmadda/application/FcmRegistrationTokenService.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-
 @Service
 @RequiredArgsConstructor
 public class FcmRegistrationTokenService {
@@ -33,10 +31,9 @@ public class FcmRegistrationTokenService {
                     Member member = memberRepository.findById(loginMember.memberId())
                             .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));
 
-                    FcmRegistrationToken registrationToken = FcmRegistrationToken.create(
+                    FcmRegistrationToken registrationToken = FcmRegistrationToken.createNow(
                             member.getId(),
-                            request.registrationToken(),
-                            LocalDateTime.now()
+                            request.registrationToken()
                     );
 
                     return fcmRegistrationTokenRepository.save(registrationToken);

--- a/server/src/main/java/com/ahmadda/application/dto/SelectedOrganizationMembersNotificationRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/SelectedOrganizationMembersNotificationRequest.java
@@ -9,7 +9,6 @@ public record SelectedOrganizationMembersNotificationRequest(
         // TODO. 추후 요청 Body 크기 자체를 제한하도록 변경
         @NotEmpty
         List<Long> organizationMemberIds,
-
         @NotBlank
         String content
 ) {

--- a/server/src/main/java/com/ahmadda/domain/Reminder.java
+++ b/server/src/main/java/com/ahmadda/domain/Reminder.java
@@ -7,14 +7,13 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class ReminderNotifier {
+public class Reminder {
 
     private final EmailNotifier emailNotifier;
     private final PushNotifier pushNotifier;
-    private final ReminderHistoryRepository reminderHistoryRepository;
 
     // TODO. 추후 recipients의 알람 타입 에 따라 이메일, 푸시 알림을 선택적으로 보낼 수 있도록 구현
-    public void remind(
+    public List<ReminderHistory> remind(
             final List<OrganizationMember> recipients,
             final Event event,
             final String content
@@ -25,9 +24,8 @@ public class ReminderNotifier {
         PushNotificationPayload pushPayload = PushNotificationPayload.of(event, content);
         pushNotifier.sendPushs(recipients, pushPayload);
 
-        List<ReminderHistory> histories = recipients.stream()
+        return recipients.stream()
                 .map(recipient -> ReminderHistory.createNow(event, recipient, content))
                 .toList();
-        reminderHistoryRepository.saveAll(histories);
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/ReminderHistory.java
+++ b/server/src/main/java/com/ahmadda/domain/ReminderHistory.java
@@ -1,0 +1,91 @@
+package com.ahmadda.domain;
+
+import com.ahmadda.domain.util.Assert;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReminderHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reminder_history_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_member_id", nullable = false)
+    private OrganizationMember organizationMember;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime sentAt;
+
+    private ReminderHistory(
+            final Event event,
+            final OrganizationMember organizationMember,
+            final String content,
+            final LocalDateTime sentAt
+    ) {
+        validateEvent(event);
+        validateOrganizationMember(organizationMember);
+        validateContent(content);
+        validateSentAt(sentAt);
+
+        this.event = event;
+        this.organizationMember = organizationMember;
+        this.content = content;
+        this.sentAt = sentAt;
+    }
+
+    public static ReminderHistory create(
+            final Event event,
+            final OrganizationMember organizationMember,
+            final String content,
+            final LocalDateTime sentAt
+    ) {
+        return new ReminderHistory(event, organizationMember, content, sentAt);
+    }
+
+    public static ReminderHistory createNow(
+            final Event event,
+            final OrganizationMember organizationMember,
+            final String content
+    ) {
+        return new ReminderHistory(event, organizationMember, content, LocalDateTime.now());
+    }
+
+    private void validateEvent(final Event event) {
+        Assert.notNull(event, "리마인더 히스토리의 이벤트가 null일 수 없습니다.");
+    }
+
+    private void validateOrganizationMember(final OrganizationMember organizationMember) {
+        Assert.notNull(organizationMember, "리마인더 히스토리의 조직원이 null일 수 없습니다.");
+    }
+
+    private void validateContent(final String content) {
+        Assert.notBlank(content, "리마인더 히스토리의 콘텐츠는 공백일 수 없습니다.");
+    }
+
+    private void validateSentAt(final LocalDateTime sentAt) {
+        Assert.notNull(sentAt, "리마인더 발송 시각이 null일 수 없습니다.");
+    }
+}

--- a/server/src/main/java/com/ahmadda/domain/ReminderHistoryRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/ReminderHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.ahmadda.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReminderHistoryRepository extends JpaRepository<ReminderHistory, Long> {
+
+}

--- a/server/src/main/java/com/ahmadda/domain/ReminderNotifier.java
+++ b/server/src/main/java/com/ahmadda/domain/ReminderNotifier.java
@@ -1,0 +1,27 @@
+package com.ahmadda.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ReminderNotifier {
+
+    private final EmailNotifier emailNotifier;
+    private final PushNotifier pushNotifier;
+
+    // TODO. 추후 recipients의 알람 타입 에 따라 이메일, 푸시 알림을 선택적으로 보낼 수 있도록 구현
+    public void remind(
+            final List<OrganizationMember> recipients,
+            final Event event,
+            final String content
+    ) {
+        EventEmailPayload emailPayload = EventEmailPayload.of(event, content);
+        emailNotifier.sendEmails(recipients, emailPayload);
+
+        PushNotificationPayload pushPayload = PushNotificationPayload.of(event, content);
+        pushNotifier.sendPushs(recipients, pushPayload);
+    }
+}

--- a/server/src/main/java/com/ahmadda/domain/ReminderNotifier.java
+++ b/server/src/main/java/com/ahmadda/domain/ReminderNotifier.java
@@ -11,6 +11,7 @@ public class ReminderNotifier {
 
     private final EmailNotifier emailNotifier;
     private final PushNotifier pushNotifier;
+    private final ReminderHistoryRepository reminderHistoryRepository;
 
     // TODO. 추후 recipients의 알람 타입 에 따라 이메일, 푸시 알림을 선택적으로 보낼 수 있도록 구현
     public void remind(
@@ -23,5 +24,10 @@ public class ReminderNotifier {
 
         PushNotificationPayload pushPayload = PushNotificationPayload.of(event, content);
         pushNotifier.sendPushs(recipients, pushPayload);
+
+        List<ReminderHistory> histories = recipients.stream()
+                .map(recipient -> ReminderHistory.createNow(event, recipient, content))
+                .toList();
+        reminderHistoryRepository.saveAll(histories);
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/push/FcmRegistrationToken.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/FcmRegistrationToken.java
@@ -54,6 +54,13 @@ public class FcmRegistrationToken {
         return new FcmRegistrationToken(memberId, registrationToken, timeStamp);
     }
 
+    public static FcmRegistrationToken createNow(
+            final Long memberId,
+            final String registrationToken
+    ) {
+        return new FcmRegistrationToken(memberId, registrationToken, LocalDateTime.now());
+    }
+
     private void validateMemberId(final Long memberId) {
         if (memberId == null) {
             throw new InvalidFcmRegistrationTokenException("memberId는 null일 수 없습니다.");

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
@@ -80,6 +80,7 @@ public class EventNotificationController {
                     )
             )
     })
+    @Deprecated
     @PostMapping("/{eventId}/notify-non-guests")
     public ResponseEntity<Void> notifyNonGuests(
             @PathVariable final Long eventId,

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -6,7 +6,6 @@ import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Answer;
-import com.ahmadda.domain.AnswerRepository;
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventOperationPeriod;
 import com.ahmadda.domain.EventRepository;
@@ -54,10 +53,7 @@ class EventGuestServiceTest {
 
     @Autowired
     private GuestRepository guestRepository;
-
-    @Autowired
-    private AnswerRepository answerRepository;
-
+    
     @Test
     void 이벤트에_참여한_게스트들을_조회한다() {
         // given
@@ -262,12 +258,12 @@ class EventGuestServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.participantEvent(
-                                           event.getId(),
-                                           new LoginMember(member2.getId()),
-                                           event.getRegistrationStart(),
-                                           request
-                                   )
+                sut.participantEvent(
+                        event.getId(),
+                        new LoginMember(member2.getId()),
+                        event.getRegistrationStart(),
+                        request
+                )
         )
                 .isInstanceOf(BusinessRuleViolatedException.class)
                 .hasMessageContaining("필수 질문에 대한 답변이 누락되었습니다");
@@ -291,12 +287,12 @@ class EventGuestServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.participantEvent(
-                                           event.getId(),
-                                           new LoginMember(member2.getId()),
-                                           event.getRegistrationStart(),
-                                           request
-                                   )
+                sut.participantEvent(
+                        event.getId(),
+                        new LoginMember(member2.getId()),
+                        event.getRegistrationStart(),
+                        request
+                )
         )
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("존재하지 않는 질문입니다.");

--- a/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
@@ -5,9 +5,7 @@ import com.ahmadda.application.dto.NonGuestsNotificationRequest;
 import com.ahmadda.application.dto.SelectedOrganizationMembersNotificationRequest;
 import com.ahmadda.application.exception.AccessDeniedException;
 import com.ahmadda.application.exception.NotFoundException;
-import com.ahmadda.domain.EmailNotifier;
 import com.ahmadda.domain.Event;
-import com.ahmadda.domain.EventEmailPayload;
 import com.ahmadda.domain.EventOperationPeriod;
 import com.ahmadda.domain.EventRepository;
 import com.ahmadda.domain.Guest;
@@ -18,10 +16,7 @@ import com.ahmadda.domain.Organization;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
-import com.ahmadda.domain.PushNotificationPayload;
-import com.ahmadda.domain.PushNotifier;
-import com.ahmadda.infra.notification.push.FcmRegistrationToken;
-import com.ahmadda.infra.notification.push.FcmRegistrationTokenRepository;
+import com.ahmadda.domain.ReminderNotifier;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -56,20 +51,14 @@ class EventNotificationServiceTest {
     @Autowired
     private GuestRepository guestRepository;
 
-    @Autowired
-    private FcmRegistrationTokenRepository fcmRegistrationTokenRepository;
-
     @MockitoBean
-    private EmailNotifier emailNotifier;
-
-    @MockitoBean
-    private PushNotifier pushNotifier;
+    private ReminderNotifier reminderNotifier;
 
     @Test
     void 비게스트_조직원에게_알람을_전송한다() {
         // given
         var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
-        var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);
+        var organizer = saveOrganizationMember("주최자", "host@email.com", organization);
         var now = LocalDateTime.now();
 
         var event = eventRepository.save(Event.create(
@@ -85,31 +74,24 @@ class EventNotificationServiceTest {
 
         var request = createNotificationRequest();
 
-        var guest = createAndSaveOrganizationMember("게스트", "guest@email.com", organization);
+        var guest = saveOrganizationMember("게스트", "guest@email.com", organization);
         guestRepository.save(Guest.create(event, guest, event.getRegistrationStart()));
 
-        var ng1 = createAndSaveOrganizationMember("비게스트1", "ng1@email.com", organization);
-        var ng2 = createAndSaveOrganizationMember("비게스트2", "ng2@email.com", organization);
-
-        savePushToken(ng1, "token-ng1");
-        savePushToken(ng2, "token-ng2");
+        var ng1 = saveOrganizationMember("비게스트1", "ng1@email.com", organization);
+        var ng2 = saveOrganizationMember("비게스트2", "ng2@email.com", organization);
 
         // when
         sut.notifyNonGuestOrganizationMembers(event.getId(), request, createLoginMember(organizer));
 
         // then
-        var email = EventEmailPayload.of(event, request.content());
-        var pushPayload = PushNotificationPayload.of(event, request.content());
-
-        verify(emailNotifier).sendEmails(List.of(ng1, ng2), email);
-        verify(pushNotifier).sendPushs(List.of(ng1, ng2), pushPayload);
+        verify(reminderNotifier).remind(List.of(ng1, ng2), event, request.content());
     }
 
     @Test
     void 존재하지_않는_이벤트로_메일_전송시_예외가_발생한다() {
         // given
         var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
-        var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);
+        var organizer = saveOrganizationMember("주최자", "host@email.com", organization);
         var loginMember = createLoginMember(organizer);
 
         // when // then
@@ -126,8 +108,8 @@ class EventNotificationServiceTest {
     void 주최자가_아닌_회원이_메일을_전송하면_예외가_발생한다() {
         // given
         var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
-        var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);
-        var other = createAndSaveOrganizationMember("다른사람", "other@email.com", organization);
+        var organizer = saveOrganizationMember("주최자", "host@email.com", organization);
+        var other = saveOrganizationMember("다른사람", "other@email.com", organization);
         var now = LocalDateTime.now();
 
         var event = eventRepository.save(Event.create(
@@ -159,7 +141,7 @@ class EventNotificationServiceTest {
     void 선택된_조직원에게_알람을_전송한다() {
         // given
         var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
-        var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);
+        var organizer = saveOrganizationMember("주최자", "host@email.com", organization);
         var now = LocalDateTime.now();
 
         var event = eventRepository.save(Event.create(
@@ -176,36 +158,30 @@ class EventNotificationServiceTest {
                 100
         ));
 
-        var om1 = createAndSaveOrganizationMember("선택1", "sel1@email.com", organization);
-        var om2 = createAndSaveOrganizationMember("선택2", "sel2@email.com", organization);
-        var om3 = createAndSaveOrganizationMember("비선택", "nsel@email.com", organization);
-
-        savePushToken(om1, "token-ng1");
-        savePushToken(om2, "token-ng2");
+        var om1 = saveOrganizationMember("선택1", "sel1@email.com", organization);
+        var om2 = saveOrganizationMember("선택2", "sel2@email.com", organization);
+        saveOrganizationMember("비선택", "nsel@email.com", organization);
 
         var request = createSelectedMembersRequest(List.of(om1.getId(), om2.getId()));
-        var email = EventEmailPayload.of(event, request.content());
-        var pushPayload = PushNotificationPayload.of(event, request.content());
 
         // when
         sut.notifySelectedOrganizationMembers(event.getId(), request, createLoginMember(organizer));
 
         // then
-        verify(emailNotifier).sendEmails(List.of(om1, om2), email);
-        verify(pushNotifier).sendPushs(List.of(om1, om2), pushPayload);
+        verify(reminderNotifier).remind(List.of(om1, om2), event, request.content());
     }
 
     @Test
     void 존재하지_않는_이벤트로_알람_전송시_예외가_발생한다() {
         // given
         var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
-        var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);
-        var om = createAndSaveOrganizationMember("대상자", "target@email.com", organization);
+        var organizer = saveOrganizationMember("주최자", "host@email.com", organization);
+        var om = saveOrganizationMember("대상자", "target@email.com", organization);
         var request = createSelectedMembersRequest(java.util.List.of(om.getId()));
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.notifySelectedOrganizationMembers(999L, request, createLoginMember(organizer))
+                sut.notifySelectedOrganizationMembers(999L, request, createLoginMember(organizer))
         )
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 이벤트입니다.");
@@ -215,8 +191,8 @@ class EventNotificationServiceTest {
     void 주최자가_아닌_회원이_전송하면_예외가_발생한다() {
         // given
         var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
-        var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);
-        var other = createAndSaveOrganizationMember("다른사람", "other@email.com", organization);
+        var organizer = saveOrganizationMember("주최자", "host@email.com", organization);
+        var other = saveOrganizationMember("다른사람", "other@email.com", organization);
 
         var now = LocalDateTime.now();
         var event = eventRepository.save(Event.create(
@@ -233,15 +209,16 @@ class EventNotificationServiceTest {
                 100
         ));
 
-        var om = createAndSaveOrganizationMember("대상자", "target@email.com", organization);
+        var om = saveOrganizationMember("대상자", "target@email.com", organization);
         var request = createSelectedMembersRequest(java.util.List.of(om.getId()));
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.notifySelectedOrganizationMembers(event.getId(),
-                                                                         request,
-                                                                         createLoginMember(other)
-                                   )
+                sut.notifySelectedOrganizationMembers(
+                        event.getId(),
+                        request,
+                        createLoginMember(other)
+                )
         )
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("이벤트 주최자가 아닙니다.");
@@ -251,7 +228,7 @@ class EventNotificationServiceTest {
     void 요청에_존재하지_않는_조직원_ID가_포함되면_예외가_발생한다() {
         // given
         var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
-        var organizer = createAndSaveOrganizationMember("주최자", "host@email.com", organization);
+        var organizer = saveOrganizationMember("주최자", "host@email.com", organization);
 
         var now = LocalDateTime.now();
         var event = eventRepository.save(Event.create(
@@ -268,19 +245,20 @@ class EventNotificationServiceTest {
                 100
         ));
 
-        var validOm = createAndSaveOrganizationMember("유효", "valid@email.com", organization);
+        var validOm = saveOrganizationMember("유효", "valid@email.com", organization);
 
         var otherOrg = organizationRepository.save(Organization.create("다른조직", "설명", "img2.png"));
-        var otherOm = createAndSaveOrganizationMember("다른조직원", "otherorg@email.com", otherOrg);
+        var otherOm = saveOrganizationMember("다른조직원", "otherorg@email.com", otherOrg);
 
         var request = createSelectedMembersRequest(java.util.List.of(validOm.getId(), otherOm.getId()));
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.notifySelectedOrganizationMembers(event.getId(),
-                                                                         request,
-                                                                         createLoginMember(organizer)
-                                   )
+                sut.notifySelectedOrganizationMembers(
+                        event.getId(),
+                        request,
+                        createLoginMember(organizer)
+                )
         )
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 조직원입니다.");
@@ -294,7 +272,7 @@ class EventNotificationServiceTest {
         return new SelectedOrganizationMembersNotificationRequest(organizationMemberIds, "이메일 내용입니다.");
     }
 
-    private OrganizationMember createAndSaveOrganizationMember(
+    private OrganizationMember saveOrganizationMember(
             String nickname,
             String email,
             Organization organization
@@ -308,14 +286,5 @@ class EventNotificationServiceTest {
         var member = organizationMember.getMember();
 
         return new LoginMember(member.getId());
-    }
-
-    private void savePushToken(OrganizationMember organizationMember, String token) {
-        var fcmRegistrationToken = FcmRegistrationToken.create(
-                organizationMember.getMember()
-                        .getId(), token, LocalDateTime.now()
-        );
-
-        fcmRegistrationTokenRepository.save(fcmRegistrationToken);
     }
 }

--- a/server/src/test/java/com/ahmadda/domain/ReminderTest.java
+++ b/server/src/test/java/com/ahmadda/domain/ReminderTest.java
@@ -1,0 +1,133 @@
+package com.ahmadda.domain;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class ReminderTest {
+
+    @Autowired
+    private Reminder sut;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private OrganizationMemberRepository organizationMemberRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @MockitoBean
+    private PushNotifier pushNotifier;
+
+    @MockitoBean
+    private EmailNotifier emailNotifier;
+
+    @Test
+    void 수신자들에게_이메일과_푸시를_발송한다() {
+        // given
+        var organization = organizationRepository.save(Organization.create("우테코", "설명", "img.png"));
+        var organizerMember = memberRepository.save(Member.create("주최자", "host@example.com", "pic"));
+        var organizer =
+                organizationMemberRepository.save(OrganizationMember.create("host", organizerMember, organization));
+
+        var now = LocalDateTime.now();
+        var event = eventRepository.save(Event.create(
+                "타이틀", "내용", "장소", organizer, organization,
+                EventOperationPeriod.create(
+                        now.plusDays(1), now.plusDays(3),
+                        now.plusDays(4), now.plusDays(5),
+                        now
+                ),
+                10
+        ));
+
+        var m1 = memberRepository.save(Member.create("게스트1", "g1@example.com", "pic"));
+        var m2 = memberRepository.save(Member.create("게스트2", "g2@example.com", "pic"));
+        var om1 = organizationMemberRepository.save(OrganizationMember.create("g1", m1, organization));
+        var om2 = organizationMemberRepository.save(OrganizationMember.create("g2", m2, organization));
+        var recipients = List.of(om1, om2);
+        var content = "이벤트 알림입니다.";
+
+        // when
+        sut.remind(recipients, event, content);
+
+        // then
+        verify(emailNotifier).sendEmails(
+                eq(recipients),
+                argThat(payload -> payload != null && payload.body()
+                        .eventId()
+                        .equals(event.getId()))
+        );
+        verify(pushNotifier).sendPushs(
+                eq(recipients),
+                argThat(payload -> payload != null && payload.eventId()
+                        .equals(event.getId()))
+        );
+    }
+
+    @Test
+    void 알람_히스토리가_생성된다() {
+        // given
+        var organization = organizationRepository.save(Organization.create("우테코", "설명", "img.png"));
+        var organizerMember = memberRepository.save(Member.create("주최자", "host@example.com", "pic"));
+        var organizer =
+                organizationMemberRepository.save(OrganizationMember.create("host", organizerMember, organization));
+
+        var now = LocalDateTime.now();
+        var event = eventRepository.save(Event.create(
+                "타이틀", "내용", "장소", organizer, organization,
+                EventOperationPeriod.create(
+                        now.plusDays(1), now.plusDays(3),
+                        now.plusDays(4), now.plusDays(5),
+                        now
+                ),
+                10
+        ));
+
+        var m1 = memberRepository.save(Member.create("게스트1", "g1@example.com", "pic"));
+        var m2 = memberRepository.save(Member.create("게스트2", "g2@example.com", "pic"));
+        var om1 = organizationMemberRepository.save(OrganizationMember.create("g1", m1, organization));
+        var om2 = organizationMemberRepository.save(OrganizationMember.create("g2", m2, organization));
+        var recipients = List.of(om1, om2);
+
+        var content = "이벤트 알림입니다.";
+
+        // when
+        var histories = sut.remind(recipients, event, content);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(histories)
+                    .hasSize(2)
+                    .extracting(ReminderHistory::getEvent)
+                    .containsOnly(event);
+            softly.assertThat(histories)
+                    .extracting(ReminderHistory::getOrganizationMember)
+                    .containsExactlyInAnyOrder(om1, om2);
+            softly.assertThat(histories)
+                    .extracting(ReminderHistory::getContent)
+                    .containsOnly(content);
+            softly.assertThat(histories)
+                    .allSatisfy(history -> softly.assertThat(history.getSentAt())
+                            .isNotNull());
+        });
+
+    }
+}

--- a/server/src/test/java/com/ahmadda/infra/notification/push/FcmPushErrorHandlerTest.java
+++ b/server/src/test/java/com/ahmadda/infra/notification/push/FcmPushErrorHandlerTest.java
@@ -27,7 +27,7 @@ class FcmPushErrorHandlerTest {
         // given
         var tokenValue = "expired-token";
         var saved = fcmRegistrationTokenRepository.save(
-                FcmRegistrationToken.create(1L, tokenValue, java.time.LocalDateTime.now())
+                FcmRegistrationToken.createNow(1L, tokenValue)
         );
 
         var exception = mock(FirebaseMessagingException.class);

--- a/server/src/test/java/com/ahmadda/learning/notification/FcmPushNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/notification/FcmPushNotifierTest.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Disabled
@@ -34,10 +33,9 @@ class FcmPushNotifierTest {
         var organization = Organization.create("테스트 조직", "설명", "logo.png");
         var organizationMember = OrganizationMember.create("푸시대상", member, organization);
 
-        var token = FcmRegistrationToken.create(
+        var token = FcmRegistrationToken.createNow(
                 member.getId(),
-                "f6L6AzpUV0TkUKEUOmIta8:APA91bH10zajy9WmAqqbfKl0c_9lUuNmggKaw82WDH-C9PqiK-KN2M5XUaL9CiKgl3oq61jRoRTrq7mZqZbqlb7887FLCY6BzctUE5l_25zWKMbbJ6EJ3Lg",
-                LocalDateTime.now()
+                "f6L6AzpUV0TkUKEUOmIta8:APA91bH10zajy9WmAqqbfKl0c_9lUuNmggKaw82WDH-C9PqiK-KN2M5XUaL9CiKgl3oq61jRoRTrq7mZqZbqlb7887FLCY6BzctUE5l_25zWKMbbJ6EJ3Lg"
         );
 
         fcmRegistrationTokenRepository.save(token);


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #258

## ✨ 작업 내용

- 리마인드(이메일/푸시) 발송 후 수신자별 히스토리 저장 기능 추가
- 알림 전송 책임을 Reminder 도메인 컴포넌트로 응집하고, 애플리케이션 서비스/스케줄러는 이를 호출하도록 의존성 역전

## 🙏 기타 참고 사항
리마인드라는 책임을 domain에 둘지 application에 둘지에 대해 팀원들과 논의하는 과정이 재밌었네요~
로버트 C. 마틴이 말한 "좋은 아키텍트는 결정되지 않은 사항의 수를 최대화한다"는 원칙처럼,
이번에는 우선 도메인 계층에 두고, 추후 필요 시 다시 검토하기로 한 결론도 의미 있었네요~!!!

<img width="400" height="550" alt="image" src="https://github.com/user-attachments/assets/ef254658-206d-4d93-85e8-60fae138cfb4" />