### PR TITLE
[BE] 이벤트 시작 시간 24시간 전 리마인드 기능 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
@@ -32,11 +32,11 @@ public class EventNotificationScheduler {
     @Scheduled(fixedRate = 180_000)
     @Transactional
     public void notifyRegistrationClosingEvents() {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime windowEnd = now.plus(SCHEDULER_SCAN_WINDOW);
+        LocalDateTime windowStart = LocalDateTime.now();
+        LocalDateTime windowEnd = windowStart.plus(SCHEDULER_SCAN_WINDOW);
 
         List<Event> upcomingEvents =
-                eventRepository.findAllByEventOperationPeriodRegistrationPeriodEndBetween(now, windowEnd);
+                eventRepository.findAllByEventOperationPeriodRegistrationPeriodEndBetween(windowStart, windowEnd);
 
         upcomingEvents.stream()
                 .filter(event -> !event.isFull()).

--- a/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
@@ -2,6 +2,7 @@ package com.ahmadda.application;
 
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.domain.Reminder;
 import com.ahmadda.domain.ReminderHistory;
@@ -20,7 +21,8 @@ import java.util.List;
 public class EventNotificationScheduler {
 
     // TODO. 추후 5분이라는 시간을 보장하도록 구현
-    private static final Duration REMINDER_BEFORE = Duration.ofMinutes(5);
+    private static final Duration SCHEDULER_SCAN_WINDOW = Duration.ofMinutes(5);
+    private static final Duration START_REMINDER_LEAD_TIME = Duration.ofHours(24);
 
     private final EventRepository eventRepository;
     private final Reminder reminder;
@@ -31,10 +33,10 @@ public class EventNotificationScheduler {
     @Transactional
     public void notifyRegistrationClosingEvents() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime targetTime = now.plus(REMINDER_BEFORE);
+        LocalDateTime windowEnd = now.plus(SCHEDULER_SCAN_WINDOW);
 
         List<Event> upcomingEvents =
-                eventRepository.findAllByEventOperationPeriodRegistrationPeriodEndBetween(now, targetTime);
+                eventRepository.findAllByEventOperationPeriodRegistrationPeriodEndBetween(now, windowEnd);
 
         upcomingEvents.stream()
                 .filter(event -> !event.isFull()).
@@ -47,6 +49,28 @@ public class EventNotificationScheduler {
 
                     sendAndRecordReminder(upcomingEvent, recipients, content);
                 });
+    }
+
+    // TODO. 추후 중복 알람을 방지하도록 구현
+    @Scheduled(fixedRate = 180_000)
+    @Transactional
+    public void notifyEventStartIn24Hours() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime windowStart = now.plus(START_REMINDER_LEAD_TIME);
+        LocalDateTime windowEnd = windowStart.plus(SCHEDULER_SCAN_WINDOW);
+
+        List<Event> eventsStartingSoon =
+                eventRepository.findAllByEventOperationPeriodEventPeriodStartBetween(windowStart, windowEnd);
+
+        eventsStartingSoon.forEach(event -> {
+            List<OrganizationMember> recipients = event.getGuests()
+                    .stream()
+                    .map(Guest::getOrganizationMember)
+                    .toList();
+            String content = "내일 이벤트가 시작됩니다. 준비되셨나요?";
+
+            sendAndRecordReminder(event, recipients, content);
+        });
     }
 
     private void sendAndRecordReminder(

--- a/server/src/main/java/com/ahmadda/domain/EventRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/EventRepository.java
@@ -13,4 +13,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
             final LocalDateTime from,
             final LocalDateTime to
     );
+
+    List<Event> findAllByEventOperationPeriodEventPeriodStartBetween(
+            final LocalDateTime from,
+            final LocalDateTime to
+    );
 }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #464

## ✨ 작업 내용

- 스케줄러를 활용해 이벤트 시작 당일, 게스트들에게 이벤트 시작 리마인드 기능 구현

## 🙏 기타 참고 사항
### 기능 관련
여러분이 의견을 빨르 주셔서 덕분에 빠르게 개발할 수 있었습니다~! 감사합니다! 👍
<img width="690" height="296" alt="image" src="https://github.com/user-attachments/assets/8af911b0-fd6e-4e58-b139-7b8ed2632bd9" />

논의한 대로, 이벤트 시작 24시간 전에 리마인드를 전송하도록 구현했습니다~!

또한, 지난번 [등록 마감 임박 이벤트의 비게스트에게 알람 기능](https://github.com/woowacourse-teams/2025-ah-madda/pull/383)에서와 비슷하게 구현했고, 문제점 역시 비슷한데
현재 스케줄링은 3분 간격으로 동작하며 ‘이벤트 시작 24시간 전’과 ‘24시간 5분 전’을 기준으로 시작 예정 이벤트를 조회하는 방식입니다. 이로 인해 간헐적으로 중복 발송이 발생할 수 있지만, 이는 추후 같이 개선해보죠~!

그리고 이번 기능 역시 정확히 ‘24시간 전’ 시점을 보장하기 어려운 특성이 있어 문구를 "이벤트가 내일 시작됩니다."로 설정했습니다. 다만, 등록 마감 임박 알람과 달리 시작 시각의 경우 24시간을 정확히 맞춰 얻을 수 있는 이점이 크지 않아, 별도의 정밀 보정은 하지 않아도 무방하다고 생각해요~! 이에 대한 생각도 궁금하네요 🙋

### 화이팅~!
그리고 저희가 요구사항이 많을 법한 문제 영역에서, 최대한 객체 지향적으로 풀어낸 덕분에 
기능 개발을 정말 빠르게 마무리할 수 있었던 것 같습니다.

슬슬 저희의 설계가 빛을 발하고 있는 것 같아 뿌듯하네요! 화이팅입니다~!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 이벤트 시작 24시간 전에 알림을 자동 발송합니다. 참석 예정 게스트(조직 구성원 포함)에게 안내 메시지가 전달되며, 주기적 스캔으로 누락을 줄였습니다.
* 버그 수정
  * 이벤트 신청 마감 임박 알림의 전송 타이밍을 개선해, 마감 직전 구간에서 보다 정확하게 도착하도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->