### PR TITLE
[FE] 알림 history UI 퍼블리싱, api 연결

### DIFF
--- a/client/src/api/mutations/useAddAlarm.ts
+++ b/client/src/api/mutations/useAddAlarm.ts
@@ -1,6 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { fetcher } from '../fetcher';
+import { eventQueryKeys } from '../queries/event';
 import { NotificationAPIRequest } from '../types/notification';
 
 export const postAlarm = async (eventId: number, data: NotificationAPIRequest) => {
@@ -8,7 +9,13 @@ export const postAlarm = async (eventId: number, data: NotificationAPIRequest) =
 };
 
 export const useAddAlarm = ({ eventId }: { eventId: number }) => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: NotificationAPIRequest) => postAlarm(eventId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [...eventQueryKeys.history(), eventId],
+      });
+    },
   });
 };

--- a/client/src/api/queries/event.ts
+++ b/client/src/api/queries/event.ts
@@ -10,6 +10,7 @@ import {
   StatisticsAPIResponse,
   EventTemplateAPIResponse,
   EventTitleAPIResponse,
+  NotifyHistoryAPIResponse,
 } from '../types/event';
 import { NotificationAPIRequest } from '../types/notification';
 
@@ -30,6 +31,7 @@ export const eventQueryKeys = {
   statistic: () => [...eventQueryKeys.all(), 'statistic'],
   titles: () => [...eventQueryKeys.all(), 'titles'],
   template: () => [...eventQueryKeys.all(), 'template'],
+  history: () => [...eventQueryKeys.all(), 'history'],
 };
 
 export const eventQueryOptions = {
@@ -82,6 +84,11 @@ export const eventQueryOptions = {
       queryKey: [...eventQueryKeys.template(), eventId],
       queryFn: () => getEventTemplate(eventId),
     }),
+  history: (eventId: number) =>
+    queryOptions({
+      queryKey: [...eventQueryKeys.history(), eventId],
+      queryFn: () => getNotifyHistory(eventId),
+    }),
 };
 
 const getGuests = async (eventId: number) => {
@@ -124,4 +131,8 @@ const getEventTemplate = async (eventId: number) => {
   return await fetcher.get<EventTemplateAPIResponse>(
     `organizations/events/${eventId}/owned/template`
   );
+};
+
+const getNotifyHistory = async (eventId: number) => {
+  return await fetcher.get<NotifyHistoryAPIResponse[]>(`events/${eventId}/notify/history`);
 };

--- a/client/src/api/types/event.ts
+++ b/client/src/api/types/event.ts
@@ -38,3 +38,9 @@ export type EventTemplateAPIResponse = Pick<
 > & {
   eventId: number;
 };
+
+export type NotifyHistoryAPIResponse = {
+  recipientCount: number;
+  content: string;
+  sentAt: string;
+};

--- a/client/src/features/Event/Manage/components/AlarmHistoryModal.tsx
+++ b/client/src/features/Event/Manage/components/AlarmHistoryModal.tsx
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { NotifyHistoryAPIResponse } from '@/api/types/event';
+import { Badge } from '@/shared/components/Badge';
+import { Flex } from '@/shared/components/Flex';
+import { Modal } from '@/shared/components/Modal';
+import { ModalProps } from '@/shared/components/Modal/Modal';
+import { Text } from '@/shared/components/Text';
+import { theme } from '@/shared/styles/theme';
+
+import { HistoryContainer } from '../containers/HistoryContainer';
+
+import { HistoryCard } from './HistoryCard';
+
+type AlarmHistoryModalProps = { notifyData: NotifyHistoryAPIResponse[] } & ModalProps;
+
+export const AlarmHistoryModal = ({ notifyData, isOpen, onClose }: AlarmHistoryModalProps) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      css={css`
+        width: 380px;
+      `}
+    >
+      <Text as="h3" type="Heading" weight="bold">
+        알림 내역
+      </Text>
+      <HistoryContainer>
+        {notifyData.map((history, index) => (
+          <HistoryCard key={index} {...history} />
+        ))}
+      </HistoryContainer>
+    </Modal>
+  );
+};

--- a/client/src/features/Event/Manage/components/AlarmHistoryModal.tsx
+++ b/client/src/features/Event/Manage/components/AlarmHistoryModal.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/shared/components/Badge';
 import { Flex } from '@/shared/components/Flex';
 import { Modal } from '@/shared/components/Modal';
 import { ModalProps } from '@/shared/components/Modal/Modal';
+import { Spacing } from '@/shared/components/Spacing';
 import { Text } from '@/shared/components/Text';
 import { theme } from '@/shared/styles/theme';
 
@@ -27,10 +28,11 @@ export const AlarmHistoryModal = ({ notifyData, isOpen, onClose }: AlarmHistoryM
       <Text as="h3" type="Heading" weight="bold">
         알림 내역
       </Text>
+      <Spacing height="12px" />
       <HistoryContainer>
         {notifyData.length === 0 ? (
           <Flex height="200px" justifyContent="center" alignItems="center">
-            <Text type="Body" weight="regular" color={theme.colors.gray500}>
+            <Text type="Body" weight="regular">
               알림 내역이 없습니다.
             </Text>
           </Flex>

--- a/client/src/features/Event/Manage/components/AlarmHistoryModal.tsx
+++ b/client/src/features/Event/Manage/components/AlarmHistoryModal.tsx
@@ -1,14 +1,11 @@
 import { css } from '@emotion/react';
-import styled from '@emotion/styled';
 
 import { NotifyHistoryAPIResponse } from '@/api/types/event';
-import { Badge } from '@/shared/components/Badge';
 import { Flex } from '@/shared/components/Flex';
 import { Modal } from '@/shared/components/Modal';
 import { ModalProps } from '@/shared/components/Modal/Modal';
 import { Spacing } from '@/shared/components/Spacing';
 import { Text } from '@/shared/components/Text';
-import { theme } from '@/shared/styles/theme';
 
 import { HistoryContainer } from '../containers/HistoryContainer';
 

--- a/client/src/features/Event/Manage/components/AlarmHistoryModal.tsx
+++ b/client/src/features/Event/Manage/components/AlarmHistoryModal.tsx
@@ -28,9 +28,15 @@ export const AlarmHistoryModal = ({ notifyData, isOpen, onClose }: AlarmHistoryM
         알림 내역
       </Text>
       <HistoryContainer>
-        {notifyData.map((history, index) => (
-          <HistoryCard key={index} {...history} />
-        ))}
+        {notifyData.length === 0 ? (
+          <Flex height="200px" justifyContent="center" alignItems="center">
+            <Text type="Body" weight="regular" color={theme.colors.gray500}>
+              알림 내역이 없습니다.
+            </Text>
+          </Flex>
+        ) : (
+          notifyData.map((history, index) => <HistoryCard key={index} {...history} />)
+        )}
       </HistoryContainer>
     </Modal>
   );

--- a/client/src/features/Event/Manage/components/AlarmSection.tsx
+++ b/client/src/features/Event/Manage/components/AlarmSection.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom';
 
 import { useAddAlarm } from '@/api/mutations/useAddAlarm';
+import { NotifyHistoryAPIResponse } from '@/api/types/event';
 import { Button } from '@/shared/components/Button';
 import { Card } from '@/shared/components/Card';
 import { Flex } from '@/shared/components/Flex';
@@ -10,17 +11,26 @@ import { Spacing } from '@/shared/components/Spacing';
 import { Text } from '@/shared/components/Text';
 import { trackSendAlarm } from '@/shared/lib/gaEvents';
 
+import { useModal } from '../../../../shared/hooks/useModal';
 import { useNotificationForm } from '../hooks/useNotificationForm';
 
+import { AlarmHistoryModal } from './AlarmHistoryModal';
+
 export type AlarmSectionProps = {
+  notifyData: NotifyHistoryAPIResponse[];
   organizationMemberIds: number[];
   selectedGuestCount: number;
 };
 
-export const AlarmSection = ({ organizationMemberIds, selectedGuestCount }: AlarmSectionProps) => {
+export const AlarmSection = ({
+  notifyData,
+  organizationMemberIds,
+  selectedGuestCount,
+}: AlarmSectionProps) => {
   const { content, handleContentChange, resetContent } = useNotificationForm();
   const { eventId: eventIdParam } = useParams();
   const { mutate: postAlarm, isPending } = useAddAlarm({ eventId: Number(eventIdParam) });
+  const { isOpen, open, close } = useModal();
 
   const handleSendAlarm = () => {
     trackSendAlarm(selectedGuestCount);
@@ -40,37 +50,45 @@ export const AlarmSection = ({ organizationMemberIds, selectedGuestCount }: Alar
   };
 
   return (
-    <Card>
-      <Flex as="section" dir="column">
-        <Flex alignItems="center" gap="8px">
-          <Icon name="alarm" size={14} color="secondary" />
-          <Text type="Body" weight="medium" color="#F54900">
-            미신청자 알람
-          </Text>
-        </Flex>
-        <Flex dir="column">
-          <Input
-            id="alarm-message"
-            label=""
-            placeholder="알람 메시지를 입력하세요..."
-            value={content}
-            onChange={handleContentChange}
-          />
+    <>
+      <Card>
+        <Flex as="section" dir="column">
+          <Flex justifyContent="space-between" alignItems="center" gap="8px">
+            <Flex alignItems="center">
+              <Icon name="alarm" size={14} color="secondary" />
+              <Text type="Body" weight="medium" color="#F54900">
+                미신청자 알람
+              </Text>
+            </Flex>
+            <Button size="sm" color="tertiary" onClick={open}>
+              알람 내역
+            </Button>
+          </Flex>
+          <Flex dir="column">
+            <Input
+              id="alarm-message"
+              label=""
+              placeholder="알람 메시지를 입력하세요..."
+              value={content}
+              onChange={handleContentChange}
+            />
 
-          <Button
-            size="full"
-            color="primary"
-            disabled={!content || organizationMemberIds.length === 0 || isPending}
-            onClick={handleSendAlarm}
-          >
-            {isPending ? '전송 중...' : '보내기'}
-          </Button>
-          <Spacing height="8px" />
-          <Text type="Label" weight="regular" color="#6A7282">
-            {`선택한 ${selectedGuestCount}명에게 알람이 전송됩니다.`}
-          </Text>
+            <Button
+              size="full"
+              color="primary"
+              disabled={!content || organizationMemberIds.length === 0 || isPending}
+              onClick={handleSendAlarm}
+            >
+              {isPending ? '전송 중...' : '보내기'}
+            </Button>
+            <Spacing height="8px" />
+            <Text type="Label" weight="regular" color="#6A7282">
+              {`선택한 ${selectedGuestCount}명에게 알람이 전송됩니다.`}
+            </Text>
+          </Flex>
         </Flex>
-      </Flex>
-    </Card>
+      </Card>
+      <AlarmHistoryModal notifyData={notifyData} isOpen={isOpen} onClose={close} />
+    </>
   );
 };

--- a/client/src/features/Event/Manage/components/AlarmSection.tsx
+++ b/client/src/features/Event/Manage/components/AlarmSection.tsx
@@ -61,7 +61,7 @@ export const AlarmSection = ({
               </Text>
             </Flex>
             <Button size="sm" color="tertiary" onClick={open}>
-              알람 내역
+              알림 내역
             </Button>
           </Flex>
           <Flex dir="column">

--- a/client/src/features/Event/Manage/components/GuestManageSection.tsx
+++ b/client/src/features/Event/Manage/components/GuestManageSection.tsx
@@ -14,14 +14,19 @@ export const GuestManageSection = () => {
   const { eventId: eventIdParam } = useParams();
   const eventId = Number(eventIdParam);
 
-  const [{ data: guests = [] }, { data: nonGuests = [] }, { data: statisticsData = [] }] =
-    useSuspenseQueries({
-      queries: [
-        eventQueryOptions.guests(eventId),
-        eventQueryOptions.nonGuests(eventId),
-        eventQueryOptions.statistic(eventId),
-      ],
-    });
+  const [
+    { data: guests = [] },
+    { data: nonGuests = [] },
+    { data: statisticsData = [] },
+    { data: notifyData = [] },
+  ] = useSuspenseQueries({
+    queries: [
+      eventQueryOptions.guests(eventId),
+      eventQueryOptions.nonGuests(eventId),
+      eventQueryOptions.statistic(eventId),
+      eventQueryOptions.history(eventId),
+    ],
+  });
 
   const {
     guestData,
@@ -50,6 +55,7 @@ export const GuestManageSection = () => {
     <Flex as="section" dir="column" gap="24px" width="100%" margin="0 auto" padding="20px 0">
       <Statistics statistics={statisticsData} />
       <AlarmSection
+        notifyData={notifyData}
         organizationMemberIds={selectedMemberIds}
         selectedGuestCount={selectedGuestCount}
       />

--- a/client/src/features/Event/Manage/components/HistoryCard.tsx
+++ b/client/src/features/Event/Manage/components/HistoryCard.tsx
@@ -30,6 +30,6 @@ export const HistoryCard = ({ recipientCount, content, sentAt }: NotifyHistoryAP
 };
 
 const StyledHistoryCard = styled(Flex)`
-  padding: 12px;
+  padding: 12px 8px;
   border-bottom: 1px solid ${theme.colors.gray200};
 `;

--- a/client/src/features/Event/Manage/components/HistoryCard.tsx
+++ b/client/src/features/Event/Manage/components/HistoryCard.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+
+import { NotifyHistoryAPIResponse } from '@/api/types/event';
+import { Badge } from '@/shared/components/Badge';
+import { Flex } from '@/shared/components/Flex';
+import { Text } from '@/shared/components/Text';
+import { theme } from '@/shared/styles/theme';
+
+import { formatKoreanDateTime } from '../../Detail/utils/formatKoreanDateTime';
+
+export const HistoryCard = ({ recipientCount, content, sentAt }: NotifyHistoryAPIResponse) => {
+  return (
+    <StyledHistoryCard
+      dir="column"
+      justifyContent="space-between"
+      alignItems="flex-start"
+      gap="4px"
+    >
+      <Flex width="100%" justifyContent="space-between" alignItems="center">
+        <Text type="Body" weight="semibold">
+          {content}
+        </Text>
+        <Badge variant="blue">{recipientCount}명</Badge>
+      </Flex>
+      <Text type="Label" color={theme.colors.gray500}>
+        {formatKoreanDateTime(sentAt)}
+      </Text>
+    </StyledHistoryCard>
+  );
+};
+
+const StyledHistoryCard = styled(Flex)`
+  padding: 12px;
+  border-bottom: 1px solid ${theme.colors.gray200};
+`;

--- a/client/src/features/Event/Manage/components/HistoryCard.tsx
+++ b/client/src/features/Event/Manage/components/HistoryCard.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { NotifyHistoryAPIResponse } from '@/api/types/event';
@@ -18,7 +19,7 @@ export const HistoryCard = ({ recipientCount, content, sentAt }: NotifyHistoryAP
     >
       <Flex width="100%" justifyContent="space-between" alignItems="center">
         <Text type="Body" weight="semibold">
-          {content}
+          {content.length > 20 ? `${content.slice(0, 20)}...` : content}
         </Text>
         <Badge variant="blue">{recipientCount}명</Badge>
       </Flex>

--- a/client/src/features/Event/Manage/containers/HistoryContainer.tsx
+++ b/client/src/features/Event/Manage/containers/HistoryContainer.tsx
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+type HistoryContainerProps = {
+  children: React.ReactNode;
+};
+
+export const HistoryContainer = ({ children }: HistoryContainerProps) => {
+  return <StyledHistoryContainer>{children}</StyledHistoryContainer>;
+};
+const StyledHistoryContainer = styled.div`
+  max-height: 300px;
+  overflow-y: auto;
+`;

--- a/client/src/features/Event/Manage/containers/HistoryContainer.tsx
+++ b/client/src/features/Event/Manage/containers/HistoryContainer.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { theme } from '@/shared/styles/theme';
+
 type HistoryContainerProps = {
   children: React.ReactNode;
 };
@@ -10,4 +12,13 @@ export const HistoryContainer = ({ children }: HistoryContainerProps) => {
 const StyledHistoryContainer = styled.div`
   max-height: 300px;
   overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${theme.colors.gray300};
+    border-radius: 4px;
+  }
 `;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #470

## ✨ 작업 내용

- 알림 히스토리 보여주는 UI 퍼블리싱, api 연결 완료했습니다.

**데이터가 존재하지 않는 경우**
<img width="730" height="750" alt="스크린샷 2025-08-13 오전 12 11 14" src="https://github.com/user-attachments/assets/926528e3-605d-4da8-b229-b4dec6439094" />


**데이터가 존재하는 경우**
![Aug-13-2025 00-11-49](https://github.com/user-attachments/assets/1ca19947-9537-4666-91b5-f5aaba2f57a3)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 이벤트별 알림 내역 조회 기능 추가 및 알림 내역 모달(스크롤 가능) 도입
  * 알림 내역을 표시하는 카드 컴포넌트(수신 인원 배지, 메시지 요약, 발송 시간) 추가
* Improvements
  * 알림 전송 성공 시 해당 이벤트의 알림 내역이 자동으로 새로고침되어 최신 상태 유지
* UI
  * 게스트 관리 화면에 ‘알람 내역’ 버튼 추가로 모달 접근성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->