### PR TITLE
[BE] 메일 템플릿 로고를 s3 이미지 url을 사용하도록 변경

### DIFF
--- a/server/src/main/resources/templates/mail/event-notification.html
+++ b/server/src/main/resources/templates/mail/event-notification.html
@@ -14,7 +14,7 @@
                 <tr>
                     <td style="padding:16px 20px; background:#3D84FF; color:#ffffff; font-family:Arial, Helvetica, sans-serif; font-size:18px; font-weight:600;">
                         <div style="display:flex; align-items:center;">
-                            <img src="https://private-user-images.githubusercontent.com/118044367/477144027-259d9e05-8904-405b-b148-80bfe88142bc.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTUwMTM2ODIsIm5iZiI6MTc1NTAxMzM4MiwicGF0aCI6Ii8xMTgwNDQzNjcvNDc3MTQ0MDI3LTI1OWQ5ZTA1LTg5MDQtNDA1Yi1iMTQ4LTgwYmZlODgxNDJiYy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwODEyJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDgxMlQxNTQzMDJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1mYzY3NzJhNzRkZWI5MDBmNGExYjI1NWRjMmE0ZTMxMGViY2VkZWJmYzRlNzA3ZTk3YmFmMGI0YjY2NmU5OGM3JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.1ps-slNyQvAqdYqAI81LgoToxIftZfnsehNcusN0jl8"
+                            <img src="https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/ahmadda-image/ahmadda-logo.png"
                                  alt="로고" style="height:32px; margin-right:8px; vertical-align:middle;"/>
                             <span th:text="${organizationName}">조직 이름</span>
                         </div>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #473


## ✨ 작업 내용

- GitHub 이미지 URL을 사용하려 했으나, GitHub에서 JWT를 이용해 이미지에 만료 기한을 두고 있어 사용이 어려웠습니다 ㅠㅠ

## 🙏 기타 참고 사항

- 정직하게 S3에 이미지를 업로드하여 로고를 사용하도록 변경했습니다~!
