### PR TITLE
[BE] 이벤트 알림 안받기 기능 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
@@ -43,9 +43,9 @@ public class EventNotificationOptOutService {
     public void cancelOptOut(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
         OrganizationMember organizationMember = getOrganizationMember(
-                loginMember.memberId(),
                 event.getOrganization()
-                        .getId()
+                        .getId(),
+                loginMember.memberId()
         );
 
         EventNotificationOptOut optOut =

--- a/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
@@ -36,6 +36,7 @@ public class EventNotificationOptOutService {
         }
 
         EventNotificationOptOut optOut = EventNotificationOptOut.create(organizationMember, event);
+
         return optOutRepository.save(optOut);
     }
 

--- a/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
@@ -28,7 +28,6 @@ public class EventNotificationOptOutService {
                 event.getOrganization()
                         .getId(),
                 loginMember.memberId()
-
         );
 
         if (optOutRepository.existsByEventAndOrganizationMember(event, organizationMember)) {

--- a/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
@@ -1,0 +1,67 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.application.exception.BusinessFlowViolatedException;
+import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.Event;
+import com.ahmadda.domain.EventNotificationOptOut;
+import com.ahmadda.domain.EventNotificationOptOutRepository;
+import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EventNotificationOptOutService {
+
+    private final EventRepository eventRepository;
+    private final OrganizationMemberRepository organizationMemberRepository;
+    private final EventNotificationOptOutRepository optOutRepository;
+
+    @Transactional
+    public EventNotificationOptOut optOut(final Long eventId, final LoginMember loginMember) {
+        Event event = getEvent(eventId);
+        OrganizationMember organizationMember = getOrganizationMember(
+                event.getOrganization()
+                        .getId(),
+                loginMember.memberId()
+
+        );
+
+        if (optOutRepository.existsByEventAndOrganizationMember(event, organizationMember)) {
+            throw new BusinessFlowViolatedException("이미 해당 이벤트에 대한 알림 수신 거부가 설정되어 있습니다.");
+        }
+
+        EventNotificationOptOut optOut = EventNotificationOptOut.create(organizationMember, event);
+        return optOutRepository.save(optOut);
+    }
+
+    @Transactional
+    public void cancelOptOut(final Long eventId, final LoginMember loginMember) {
+        Event event = getEvent(eventId);
+        OrganizationMember organizationMember = getOrganizationMember(
+                loginMember.memberId(),
+                event.getOrganization()
+                        .getId()
+        );
+
+        EventNotificationOptOut optOut =
+                optOutRepository.findByEventAndOrganizationMember(event, organizationMember)
+                        .orElseThrow(() -> new NotFoundException("수신 거부 설정이 존재하지 않습니다."));
+
+        optOutRepository.delete(optOut);
+    }
+
+    private Event getEvent(final Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 이벤트입니다."));
+    }
+
+    private OrganizationMember getOrganizationMember(final Long organizationId, final Long memberId) {
+        return organizationMemberRepository.findByOrganizationIdAndMemberId(organizationId, memberId)
+                .orElseThrow(() -> new NotFoundException("해당 조직의 구성원이 아닙니다."));
+    }
+}

--- a/server/src/main/java/com/ahmadda/domain/EventNotificationOptOut.java
+++ b/server/src/main/java/com/ahmadda/domain/EventNotificationOptOut.java
@@ -1,0 +1,59 @@
+package com.ahmadda.domain;
+
+import com.ahmadda.domain.util.Assert;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventNotificationOptOut extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_notification_opt_out_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_member_id", nullable = false)
+    private OrganizationMember organizationMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    private EventNotificationOptOut(
+            final OrganizationMember organizationMember,
+            final Event event
+    ) {
+        validateOrganizationMember(organizationMember);
+        validateEvent(event);
+
+        this.organizationMember = organizationMember;
+        this.event = event;
+    }
+
+    public static EventNotificationOptOut create(
+            final OrganizationMember organizationMember,
+            final Event event
+    ) {
+        return new EventNotificationOptOut(organizationMember, event);
+    }
+
+    private void validateOrganizationMember(final OrganizationMember organizationMember) {
+        Assert.notNull(organizationMember, "알림 수신 거부의 조직원은 null이 될 수 없습니다.");
+    }
+
+    private void validateEvent(final Event event) {
+        Assert.notNull(event, "알림 수신 거부의 이벤트는 null이 될 수 없습니다.");
+    }
+}

--- a/server/src/main/java/com/ahmadda/domain/EventNotificationOptOutRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/EventNotificationOptOutRepository.java
@@ -1,0 +1,15 @@
+package com.ahmadda.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EventNotificationOptOutRepository extends JpaRepository<EventNotificationOptOut, Long> {
+
+    boolean existsByEventAndOrganizationMember(final Event event, final OrganizationMember organizationMember);
+
+    Optional<EventNotificationOptOut> findByEventAndOrganizationMember(
+            final Event event,
+            final OrganizationMember organizationMember
+    );
+}

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationController.java
@@ -141,7 +141,7 @@ public class EventNotificationController {
                                               "title": "Unauthorized",
                                               "status": 401,
                                               "detail": "유효하지 않은 인증 정보 입니다.",
-                                              "instance": "/api/events/{eventId}/notify/history"
+                                              "instance": "/api/events/{eventId}/notification/history"
                                             }
                                             """
                             )
@@ -157,7 +157,7 @@ public class EventNotificationController {
                                               "title": "Forbidden",
                                               "status": 403,
                                               "detail": "리마인더 히스토리는 이벤트의 주최자만 조회할 수 있습니다.",
-                                              "instance": "/api/events/{eventId}/notify/history"
+                                              "instance": "/api/events/{eventId}/notification/history"
                                             }
                                             """
                             )
@@ -175,7 +175,7 @@ public class EventNotificationController {
                                                       "title": "Not Found",
                                                       "status": 404,
                                                       "detail": "존재하지 않는 이벤트입니다.",
-                                                      "instance": "/api/events/{eventId}/notify/history"
+                                                      "instance": "/api/events/{eventId}/notification/history"
                                                     }
                                                     """
                                     ),
@@ -187,7 +187,7 @@ public class EventNotificationController {
                                                       "title": "Not Found",
                                                       "status": 404,
                                                       "detail": "존재하지 않는 조직원 정보입니다.",
-                                                      "instance": "/api/events/{eventId}/notify/history"
+                                                      "instance": "/api/events/{eventId}/notification/history"
                                                     }
                                                     """
                                     )
@@ -195,7 +195,7 @@ public class EventNotificationController {
                     )
             )
     })
-    @GetMapping("/{eventId}/notify/history")
+    @GetMapping("/{eventId}/notification/history")
     public ResponseEntity<List<ReminderHistorySummaryResponse>> getNotifyHistory(
             @PathVariable final Long eventId,
             @AuthMember final LoginMember loginMember

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationOptOutController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationOptOutController.java
@@ -1,0 +1,123 @@
+package com.ahmadda.presentation;
+
+import com.ahmadda.application.EventNotificationOptOutService;
+import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.presentation.resolver.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Event Notification Opt-Out", description = "이벤트 알림 수신 거부 설정 API")
+@RestController
+@RequestMapping("/api/events")
+@RequiredArgsConstructor
+public class EventNotificationOptOutController {
+
+    private final EventNotificationOptOutService optOutService;
+
+    @Operation(
+            summary = "이벤트 알림 수신 거부 설정",
+            description = "해당 이벤트에 대해 이메일 및 푸시 알림을 더 이상 받지 않도록 설정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(examples = @ExampleObject(value = """
+                            {
+                              "type": "about:blank",
+                              "title": "Unauthorized",
+                              "status": 401,
+                              "detail": "유효하지 않은 인증 정보입니다.",
+                              "instance": "/api/events/{eventId}/notification/opt-out"
+                            }
+                            """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(examples = @ExampleObject(value = """
+                            {
+                              "type": "about:blank",
+                              "title": "Not Found",
+                              "status": 404,
+                              "detail": "존재하지 않는 이벤트입니다.",
+                              "instance": "/api/events/{eventId}/notification/opt-out"
+                            }
+                            """))
+            ),
+            @ApiResponse(
+                    responseCode = "422",
+                    content = @Content(examples = @ExampleObject(value = """
+                            {
+                              "type": "about:blank",
+                              "title": "Unprocessable Entity",
+                              "status": 422,
+                              "detail": "이미 해당 이벤트에 대한 알림 수신 거부가 설정되어 있습니다.",
+                              "instance": "/api/events/{eventId}/notification/opt-out"
+                            }
+                            """))
+            )
+    })
+    @PostMapping("/{eventId}/notification/opt-out")
+    public ResponseEntity<Void> optOut(
+            @PathVariable final Long eventId,
+            @AuthMember final LoginMember loginMember
+    ) {
+        optOutService.optOut(eventId, loginMember);
+        
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @Operation(
+            summary = "이벤트 알림 수신 거부 해제",
+            description = "기존에 설정한 알림 수신 거부를 해제하여 다시 알림을 받을 수 있도록 설정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(examples = @ExampleObject(value = """
+                            {
+                              "type": "about:blank",
+                              "title": "Unauthorized",
+                              "status": 401,
+                              "detail": "유효하지 않은 인증 정보입니다.",
+                              "instance": "/api/events/{eventId}/notification/opt-out"
+                            }
+                            """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(examples = @ExampleObject(value = """
+                            {
+                              "type": "about:blank",
+                              "title": "Not Found",
+                              "status": 404,
+                              "detail": "수신 거부 설정이 존재하지 않습니다.",
+                              "instance": "/api/events/{eventId}/notification/opt-out"
+                            }
+                            """))
+            )
+    })
+    @DeleteMapping("/{eventId}/notification/opt-out")
+    public ResponseEntity<Void> cancelOptOut(
+            @PathVariable final Long eventId,
+            @AuthMember final LoginMember loginMember
+    ) {
+        optOutService.cancelOptOut(eventId, loginMember);
+
+        return ResponseEntity.noContent()
+                .build();
+    }
+}

--- a/server/src/test/java/com/ahmadda/application/EventNotificationOptOutServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationOptOutServiceTest.java
@@ -1,0 +1,155 @@
+package com.ahmadda.application;
+
+import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.application.exception.BusinessFlowViolatedException;
+import com.ahmadda.application.exception.NotFoundException;
+import com.ahmadda.domain.Event;
+import com.ahmadda.domain.EventNotificationOptOutRepository;
+import com.ahmadda.domain.EventOperationPeriod;
+import com.ahmadda.domain.EventRepository;
+import com.ahmadda.domain.Member;
+import com.ahmadda.domain.MemberRepository;
+import com.ahmadda.domain.Organization;
+import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberRepository;
+import com.ahmadda.domain.OrganizationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class EventNotificationOptOutServiceTest {
+
+    @Autowired
+    private EventNotificationOptOutService sut;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private OrganizationMemberRepository organizationMemberRepository;
+
+    @Autowired
+    private EventNotificationOptOutRepository optOutRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Test
+    void 이벤트에_대한_알림_수신_거부를_설정할_수_있다() {
+        // given
+        var organization = createOrganization();
+        var member = createMember("user", "user@mail.com");
+        var organizationMember = createOrganizationMember("닉네임", member, organization);
+        var event = createEvent(organizationMember, organization);
+        var loginMember = new LoginMember(member.getId());
+
+        // when
+        var saved = sut.optOut(event.getId(), loginMember);
+
+        // then
+        assertThat(optOutRepository.findById(saved.getId()))
+                .isPresent()
+                .hasValueSatisfying(savedOptOut -> {
+                    assertSoftly(softly -> {
+                        softly.assertThat(savedOptOut.getEvent())
+                                .isEqualTo(event);
+                        softly.assertThat(savedOptOut.getOrganizationMember())
+                                .isEqualTo(organizationMember);
+                    });
+                });
+    }
+
+    @Test
+    void 이미_수신거부가_설정된_경우_예외가_발생한다() {
+        // given
+        var org = createOrganization();
+        var member = createMember("user", "user@mail.com");
+        var orgMember = createOrganizationMember("닉네임", member, org);
+        var event = createEvent(orgMember, org);
+
+        var loginMember = new LoginMember(member.getId());
+        sut.optOut(event.getId(), loginMember);
+
+        // when // then
+        assertThatThrownBy(() -> sut.optOut(event.getId(), loginMember))
+                .isInstanceOf(BusinessFlowViolatedException.class)
+                .hasMessage("이미 해당 이벤트에 대한 알림 수신 거부가 설정되어 있습니다.");
+    }
+
+    @Test
+    void 알림_수신거부를_취소할_수_있다() {
+        // given
+        var org = createOrganization();
+        var member = createMember("user", "user@mail.com");
+        var orgMember = createOrganizationMember("닉네임", member, org);
+        var event = createEvent(orgMember, org);
+
+        var loginMember = new LoginMember(member.getId());
+        sut.optOut(event.getId(), loginMember);
+
+        // when
+        sut.cancelOptOut(event.getId(), loginMember);
+
+        // then
+        assertThat(optOutRepository.existsByEventAndOrganizationMember(event, orgMember)).isFalse();
+    }
+
+    @Test
+    void 수신거부_정보가_없으면_취소시_예외가_발생한다() {
+        // given
+        var org = createOrganization();
+        var member = createMember("user", "user@mail.com");
+        var orgMember = createOrganizationMember("닉네임", member, org);
+        var event = createEvent(orgMember, org);
+
+        var loginMember = new LoginMember(member.getId());
+
+        // when // then
+        assertThatThrownBy(() -> sut.cancelOptOut(event.getId(), loginMember))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("수신 거부 설정이 존재하지 않습니다.");
+    }
+
+    private Organization createOrganization() {
+        return organizationRepository.save(Organization.create("조직", "설명", "image.png"));
+    }
+
+    private Member createMember(String name, String email) {
+        return memberRepository.save(Member.create(name, email, "picture"));
+    }
+
+    private OrganizationMember createOrganizationMember(String nickname, Member member, Organization org) {
+        return organizationMemberRepository.save(OrganizationMember.create(nickname, member, org));
+    }
+
+    private Event createEvent(OrganizationMember organizer, Organization organization) {
+        var now = LocalDateTime.now();
+        return eventRepository.save(Event.create(
+                "이벤트 제목",
+                "설명",
+                "장소",
+                organizer,
+                organization,
+                EventOperationPeriod.create(
+                        now.minusDays(3),
+                        now.minusDays(1),
+                        now.plusDays(1),
+                        now.plusDays(2),
+                        now.minusDays(5)
+                ),
+                100
+        ));
+    }
+}

--- a/server/src/test/java/com/ahmadda/application/EventNotificationOptOutServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationOptOutServiceTest.java
@@ -136,6 +136,7 @@ class EventNotificationOptOutServiceTest {
 
     private Event createEvent(OrganizationMember organizer, Organization organization) {
         var now = LocalDateTime.now();
+
         return eventRepository.save(Event.create(
                 "이벤트 제목",
                 "설명",

--- a/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
@@ -1,27 +1,22 @@
 package com.ahmadda.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
-import com.ahmadda.domain.OrganizationMemberRepository;
-import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.infra.jwt.JwtProvider;
 import com.ahmadda.infra.oauth.GoogleOAuthProvider;
 import com.ahmadda.infra.oauth.dto.OAuthUserInfoResponse;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @Transactional
-@ExtendWith(OutputCaptureExtension.class)
 class LoginServiceTest {
 
     @Autowired
@@ -29,12 +24,6 @@ class LoginServiceTest {
 
     @Autowired
     private MemberRepository memberRepository;
-
-    @Autowired
-    private OrganizationRepository organizationRepository;
-
-    @Autowired
-    private OrganizationMemberRepository organizationMemberRepository;
 
     @MockitoBean
     private GoogleOAuthProvider googleOAuthProvider;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #440

## ✨ 작업 내용

- 이벤트 알림 수신 거부 API 추가
- 이벤트 알림 수신 거부 취소 API 추가
- 수신 거부 여부 저장을 위한 event_notification_opt_out 테이블 생성 및 엔티티 구현

## 🙏 기타 참고 사항

저희가 아침에 논의한 대로, "이벤트 참여 안함"보다는 "이벤트 알림 안받기" 기능이 사용자 플로우 상 더 명확하다는 결론에 따라 해당 기능을 구현했습니다~! 또한, 이번 기능은 실험적인 성격의 기능이라 추후 제거될 수 있다는 점을 고려해 별도의 테이블로 구성했습니다.

앞으로 진행될 작업 계획은 다음과 같습니다
- 이벤트 게스트 및 비게스트 조회 응답에 사용자의 수신 거부 여부 포함 예정
- 별도 PR에서, 수신 거부한 사용자에게는 알림을 전송하지 않도록 처리할 예정입니다!

또한 해당 기능들을 한 PR에 모두 담기에는 리뷰 범위가 커질 수 있고,
클라이언트 작업도 병렬적으로 빠르게 진행될 수 있도록 기능별로 PR을 분리해 구현 중입니다~!
리뷰하시는 데 조금이라도 부담이 덜되셨으면 좋겠습니다 :) ㅎㅎㅎㅎ 👍

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 이벤트 알림 수신 거부/해제 API 추가(POST/DELETE), 처리 성공 시 204 No Content 반환
- Refactor
  - 알림 이력 조회 엔드포인트 경로를 /api/events/{eventId}/notification/history 로 정비
- Documentation
  - 수신 거부/해제 및 알림 이력 API의 응답 예시와 상태 코드 문서화 보강
- Tests
  - 수신 거부 기능에 대한 통합 테스트 추가
  - 로그인 서비스 테스트 의존성 정리 및 단순화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->