### PR TITLE
[BE]  이벤트 게스트 및 비게스트 조회 응답에 사용자의 수신 거부 포함 기능 구현 

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
@@ -50,7 +50,7 @@ public class EventNotificationOptOutService {
 
         EventNotificationOptOut optOut =
                 optOutRepository.findByEventAndOrganizationMember(event, organizationMember)
-                        .orElseThrow(() -> new NotFoundException("수신 거부 설정이 존재하지 않습니다."));
+                        .orElseThrow(() -> new BusinessFlowViolatedException("수신 거부 설정이 존재하지 않습니다."));
 
         optOutRepository.delete(optOut);
     }

--- a/server/src/main/java/com/ahmadda/domain/GuestWithOptOut.java
+++ b/server/src/main/java/com/ahmadda/domain/GuestWithOptOut.java
@@ -1,0 +1,53 @@
+package com.ahmadda.domain;
+
+import com.ahmadda.domain.exception.BusinessRuleViolatedException;
+import com.ahmadda.domain.util.Assert;
+import lombok.Getter;
+
+@Getter
+public class GuestWithOptOut {
+
+    private final Guest guest;
+    private final boolean optedOut;
+
+    private GuestWithOptOut(final Guest guest, final boolean optedOut) {
+        validateGuest(guest);
+        validateEvent(guest.getEvent());
+        validateOrganizationMember(guest.getOrganizationMember());
+        validateOrganizerCannotOptOut(guest, optedOut);
+
+        this.guest = guest;
+        this.optedOut = optedOut;
+    }
+
+    public static GuestWithOptOut create(final Guest guest, final boolean optedOut) {
+        return new GuestWithOptOut(guest, optedOut);
+    }
+
+    private void validateGuest(final Guest guest) {
+        Assert.notNull(guest, "게스트는 null이 될 수 없습니다.");
+    }
+
+    private void validateEvent(final Event event) {
+        Assert.notNull(event, "게스트는 반드시 이벤트에 속해야 합니다.");
+    }
+
+    private void validateOrganizationMember(final OrganizationMember organizationMember) {
+        Assert.notNull(organizationMember, "게스트는 반드시 조직원이어야 합니다.");
+    }
+
+    private void validateOrganizerCannotOptOut(final Guest guest, final boolean optedOut) {
+        if (guest.getEvent()
+                .isOrganizer(guest.getOrganizationMember()) && optedOut) {
+            throw new BusinessRuleViolatedException("이벤트 주최자는 알림 수신 거부 상태일 수 없습니다.");
+        }
+    }
+
+    public Event getEvent() {
+        return guest.getEvent();
+    }
+
+    public OrganizationMember getOrganizationMember() {
+        return guest.getOrganizationMember();
+    }
+}

--- a/server/src/main/java/com/ahmadda/domain/OrganizationMemberWithOptOut.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationMemberWithOptOut.java
@@ -1,0 +1,51 @@
+package com.ahmadda.domain;
+
+import com.ahmadda.domain.exception.BusinessRuleViolatedException;
+import com.ahmadda.domain.util.Assert;
+import lombok.Getter;
+
+@Getter
+public class OrganizationMemberWithOptOut {
+
+    private final OrganizationMember organizationMember;
+    private final boolean optedOut;
+
+    private OrganizationMemberWithOptOut(
+            final OrganizationMember organizationMember,
+            final boolean optedOut,
+            final Event event
+    ) {
+        validateOrganizationMember(organizationMember);
+        validateEvent(event);
+        validateOrganizerCannotOptOut(organizationMember, optedOut, event);
+
+        this.organizationMember = organizationMember;
+        this.optedOut = optedOut;
+    }
+
+    public static OrganizationMemberWithOptOut create(
+            final OrganizationMember organizationMember,
+            final boolean optedOut,
+            final Event event
+    ) {
+        return new OrganizationMemberWithOptOut(organizationMember, optedOut, event);
+    }
+
+    private void validateOrganizationMember(final OrganizationMember organizationMember) {
+        Assert.notNull(organizationMember, "조직원은 null이 될 수 없습니다.");
+    }
+
+    private void validateEvent(final Event event) {
+        Assert.notNull(event, "조직원은 반드시 이벤트와 함께 전달되어야 합니다.");
+    }
+
+    private void validateOrganizerCannotOptOut(
+            final OrganizationMember organizationMember,
+            final boolean optedOut,
+            final Event event
+    ) {
+        if (event.isOrganizer(organizationMember) && optedOut) {
+            throw new BusinessRuleViolatedException("이벤트 주최자는 알림 수신 거부 상태일 수 없습니다.");
+        }
+    }
+}

--- a/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventGuestController.java
@@ -7,12 +7,10 @@ import com.ahmadda.application.dto.GuestAnswerResponse;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.domain.Answer;
 import com.ahmadda.domain.Event;
-import com.ahmadda.domain.Guest;
-import com.ahmadda.domain.OrganizationMember;
 import com.ahmadda.presentation.dto.EventDetailResponse;
-import com.ahmadda.presentation.dto.GuestResponse;
 import com.ahmadda.presentation.dto.GuestStatusResponse;
-import com.ahmadda.presentation.dto.OrganizationMemberResponse;
+import com.ahmadda.presentation.dto.GuestWithOptOutResponse;
+import com.ahmadda.presentation.dto.OrganizationMemberWithOptOutResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -45,14 +43,12 @@ public class EventGuestController {
     private final EventGuestService eventGuestService;
     private final EventService eventService;
 
-    @Operation(summary = "이벤트 게스트 목록 조회", description = "해당 이벤트에 참여한 게스트 목록을 조회합니다.")
+    @Operation(summary = "이벤트 게스트 목록 및 알림 수신 거부 여부 조회", description = "해당 이벤트에 참여한 게스트 목록과, 각 게스트의 알림 수신 거부 여부를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
                     content = @Content(
-                            schema = @Schema(
-                                    implementation = GuestResponse.class
-                            )
+                            array = @ArraySchema(schema = @Schema(implementation = GuestWithOptOutResponse.class))
                     )
             ),
             @ApiResponse(
@@ -105,27 +101,21 @@ public class EventGuestController {
             )
     })
     @GetMapping("/{eventId}/guests")
-    public ResponseEntity<List<GuestResponse>> getGuests(
+    public ResponseEntity<List<GuestWithOptOutResponse>> getGuests(
             @PathVariable final Long eventId,
             @AuthMember final LoginMember loginMember
     ) {
-        List<Guest> guestMembers = eventGuestService.getGuests(eventId, loginMember);
-
-        List<GuestResponse> responses = guestMembers.stream()
-                .map(GuestResponse::from)
-                .toList();
+        List<GuestWithOptOutResponse> responses = eventGuestService.getGuestsWithOptOut(eventId, loginMember);
 
         return ResponseEntity.ok(responses);
     }
 
-    @Operation(summary = "이벤트 미참여 조직원 목록 조회", description = "해당 이벤트에 아직 참여하지 않은 조직원 목록을 조회합니다.")
+    @Operation(summary = "이벤트 미참여 조직원 목록 및 알림 수신 거부 여부 조회", description = "해당 이벤트에 아직 참여하지 않은 조직원 목록과, 각 조직원의 알림 수신 거부 여부를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
                     content = @Content(
-                            schema = @Schema(
-                                    implementation = OrganizationMemberResponse.class
-                            )
+                            array = @ArraySchema(schema = @Schema(implementation = OrganizationMemberWithOptOutResponse.class))
                     )
             ),
             @ApiResponse(
@@ -178,16 +168,12 @@ public class EventGuestController {
             )
     })
     @GetMapping("/{eventId}/non-guests")
-    public ResponseEntity<List<OrganizationMemberResponse>> getNonGuests(
+    public ResponseEntity<List<OrganizationMemberWithOptOutResponse>> getNonGuests(
             @PathVariable final Long eventId,
             @AuthMember final LoginMember loginMember
     ) {
-        List<OrganizationMember> nonGuestMembers =
-                eventGuestService.getNonGuestOrganizationMembers(eventId, loginMember);
-
-        List<OrganizationMemberResponse> responses = nonGuestMembers.stream()
-                .map(OrganizationMemberResponse::from)
-                .toList();
+        List<OrganizationMemberWithOptOutResponse> responses =
+                eventGuestService.getNonGuestOrganizationMembersWithOptOut(eventId, loginMember);
 
         return ResponseEntity.ok(responses);
     }

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationOptOutController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationOptOutController.java
@@ -74,7 +74,7 @@ public class EventNotificationOptOutController {
             @AuthMember final LoginMember loginMember
     ) {
         optOutService.optOut(eventId, loginMember);
-        
+
         return ResponseEntity.noContent()
                 .build();
     }
@@ -98,12 +98,12 @@ public class EventNotificationOptOutController {
                             """))
             ),
             @ApiResponse(
-                    responseCode = "404",
+                    responseCode = "422",
                     content = @Content(examples = @ExampleObject(value = """
                             {
                               "type": "about:blank",
-                              "title": "Not Found",
-                              "status": 404,
+                              "title": "Unprocessable Entity",
+                              "status": 422,
                               "detail": "수신 거부 설정이 존재하지 않습니다.",
                               "instance": "/api/events/{eventId}/notification/opt-out"
                             }

--- a/server/src/main/java/com/ahmadda/presentation/EventStatisticController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventStatisticController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Tag(name = "이벤트 통계", description = "이벤트 통계 관련 API")
+@Tag(name = "Event Statistic", description = "이벤트 통계 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/events/{eventId}/statistic")

--- a/server/src/main/java/com/ahmadda/presentation/dto/GuestWithOptOutResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/GuestWithOptOutResponse.java
@@ -3,19 +3,21 @@ package com.ahmadda.presentation.dto;
 import com.ahmadda.domain.Guest;
 import com.ahmadda.domain.OrganizationMember;
 
-public record GuestResponse(
+public record GuestWithOptOutResponse(
         Long guestId,
         Long organizationMemberId,
-        String nickname
+        String nickname,
+        boolean optedOut
 ) {
 
-    public static GuestResponse from(final Guest guest) {
+    public static GuestWithOptOutResponse from(final Guest guest, final boolean optedOut) {
         OrganizationMember organizationMember = guest.getOrganizationMember();
 
-        return new GuestResponse(
+        return new GuestWithOptOutResponse(
                 guest.getId(),
                 organizationMember.getId(),
-                organizationMember.getNickname()
+                organizationMember.getNickname(),
+                optedOut
         );
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/GuestWithOptOutResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/GuestWithOptOutResponse.java
@@ -1,7 +1,6 @@
 package com.ahmadda.presentation.dto;
 
-import com.ahmadda.domain.Guest;
-import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.GuestWithOptOut;
 
 public record GuestWithOptOutResponse(
         Long guestId,
@@ -10,14 +9,17 @@ public record GuestWithOptOutResponse(
         boolean optedOut
 ) {
 
-    public static GuestWithOptOutResponse from(final Guest guest, final boolean optedOut) {
-        OrganizationMember organizationMember = guest.getOrganizationMember();
-
+    public static GuestWithOptOutResponse from(final GuestWithOptOut guestWithOptOut) {
         return new GuestWithOptOutResponse(
-                guest.getId(),
-                organizationMember.getId(),
-                organizationMember.getNickname(),
-                optedOut
+                guestWithOptOut.getGuest()
+                        .getId(),
+                guestWithOptOut.getGuest()
+                        .getOrganizationMember()
+                        .getId(),
+                guestWithOptOut.getGuest()
+                        .getOrganizationMember()
+                        .getNickname(),
+                guestWithOptOut.isOptedOut()
         );
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberWithOptOutResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberWithOptOutResponse.java
@@ -1,6 +1,6 @@
 package com.ahmadda.presentation.dto;
 
-import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.OrganizationMemberWithOptOut;
 
 public record OrganizationMemberWithOptOutResponse(
         Long organizationMemberId,
@@ -8,14 +8,13 @@ public record OrganizationMemberWithOptOutResponse(
         boolean optedOut
 ) {
 
-    public static OrganizationMemberWithOptOutResponse from(
-            final OrganizationMember organizationMember,
-            final boolean optedOut
-    ) {
+    public static OrganizationMemberWithOptOutResponse from(final OrganizationMemberWithOptOut organizationMemberWithOptOut) {
         return new OrganizationMemberWithOptOutResponse(
-                organizationMember.getId(),
-                organizationMember.getNickname(),
-                optedOut
+                organizationMemberWithOptOut.getOrganizationMember()
+                        .getId(),
+                organizationMemberWithOptOut.getOrganizationMember()
+                        .getNickname(),
+                organizationMemberWithOptOut.isOptedOut()
         );
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberWithOptOutResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberWithOptOutResponse.java
@@ -1,0 +1,21 @@
+package com.ahmadda.presentation.dto;
+
+import com.ahmadda.domain.OrganizationMember;
+
+public record OrganizationMemberWithOptOutResponse(
+        Long organizationMemberId,
+        String nickname,
+        boolean optedOut
+) {
+
+    public static OrganizationMemberWithOptOutResponse from(
+            final OrganizationMember organizationMember,
+            final boolean optedOut
+    ) {
+        return new OrganizationMemberWithOptOutResponse(
+                organizationMember.getId(),
+                organizationMember.getNickname(),
+                optedOut
+        );
+    }
+}

--- a/server/src/test/java/com/ahmadda/application/EventNotificationOptOutServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationOptOutServiceTest.java
@@ -2,7 +2,6 @@ package com.ahmadda.application;
 
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.exception.BusinessFlowViolatedException;
-import com.ahmadda.application.exception.NotFoundException;
 import com.ahmadda.domain.Event;
 import com.ahmadda.domain.EventNotificationOptOutRepository;
 import com.ahmadda.domain.EventOperationPeriod;
@@ -118,7 +117,7 @@ class EventNotificationOptOutServiceTest {
 
         // when // then
         assertThatThrownBy(() -> sut.cancelOptOut(event.getId(), loginMember))
-                .isInstanceOf(NotFoundException.class)
+                .isInstanceOf(BusinessFlowViolatedException.class)
                 .hasMessage("수신 거부 설정이 존재하지 않습니다.");
     }
 


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #488

## ✨ 작업 내용

- 게스트/비게스트 조회 응답에 수신 거부 여부 필드 추가

## 🙏 기타 참고 사항
기존에 게스트/비게스트 조회 응답을 담당하던 Application Service에서 구현을 이어갈지 논의한 결과,

- 알림 수신 거부 기능은 언제든 제거될 수 있다는 점
- 이미 Application Service에서 OSIV를 이용하여 도메인을 반환하고 있다는 점
- 게스트/조직원의 알림 수신 거부 여부가 도메인에 속한다는 점

등을 고려하여, 새로운 도메인을 만들고 별도의 Application Service를 정의해 기능을 리팩토링했습니다.

이번에 새롭게 시도한 방식이라 작업 과정이 무척 즐거웠습니다.
이를 통해 알림 수신 거부 기능이 추후 제거되더라도 빠르게 반영할 수 있고, 
기능 요구사항이 변경되더라도 유연하게 대응할 수 있을 것으로 기대됩니다!!!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 게스트/비게스트 목록에 알림 수신 거부(opt-out) 상태를 포함해 반환합니다.
  - 새 응답 포맷으로 수신 거부 여부를 명확히 표시합니다.
- Documentation
  - Opt-out API의 오류 응답을 404에서 422(Unprocessable Entity)로 문서화했습니다.
  - 이벤트 통계 태그명을 영문화하고, 목록 응답 스키마에 수신 거부 상태를 반영했습니다.
- Tests
  - 수신 거부 설정/해제 및 게스트·조직원 매핑 시나리오를 추가하고 예외 메시지 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->