### PR TITLE
[FE] Header 스토리북 에러 해결

### DIFF
--- a/client/src/shared/components/Header/Header.stories.tsx
+++ b/client/src/shared/components/Header/Header.stories.tsx
@@ -1,32 +1,40 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { Button } from '../Button';
+import { Flex } from '../Flex';
+import { Icon } from '../Icon';
+
 import { Header } from './Header';
 
 const meta = {
   title: 'components/Header',
   component: Header,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The Header component is a customizable header that can contain a left and right element.',
+      },
+    },
+  },
 } satisfies Meta<typeof Header>;
 
 export default meta;
 type Story = StoryObj<typeof Header>;
 
-export const LeftOnly: Story = {
-  args: {
-    left: <h2 style={{ margin: 0 }}>아맞다!</h2>,
-  },
-  render: (args) => <Header {...args} />,
+export const Basic: Story = {
+  render: () => (
+    <Flex justifyContent="center" alignItems="center" height="30vh">
+      <Header left={<Icon name="logo" />} />
+    </Flex>
+  ),
 };
 
 export const LeftAndRight: Story = {
   args: {
-    left: <h2 style={{ margin: 0 }}>아맞다!</h2>,
-    right: (
-      <div style={{ display: 'flex', gap: '12px' }}>
-        <button>로그아웃</button>
-        <button>내 이벤트</button>
-      </div>
-    ),
+    left: <Icon name="logo" />,
+    right: <Button size="sm">로그아웃</Button>,
   },
   render: (args) => <Header {...args} />,
 };

--- a/client/src/shared/components/Header/Header.tsx
+++ b/client/src/shared/components/Header/Header.tsx
@@ -22,7 +22,7 @@ export type HeaderProps = {
 export const Header = ({ left, right, ...props }: HeaderProps) => {
   return (
     <StyledHeader {...props}>
-      <StyledHeaderContent right={right}>
+      <StyledHeaderContent right={!!right}>
         {left}
         {right}
       </StyledHeaderContent>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #447

## ✨ 작업 내용

**문제 상황**
스토리북 Header 컴포넌트의 docs에서 `Cannot convert a Symbol value to a string` 과 같은 에러 문구가 출력되고 있었습니다. right props가 현재는 ReactNode 타입으로 저장되어 있는데, 스토리북의 docs는 args를 문서화할 때 props 값을 문자열로 변환하려고 해서 생긴 문제였습니다. 

**해결 방법**
docs는 args serialize 과정에서만 문제가 생기므로, args 없이 render 함수에서 직접 jsx를 반환하도록 수정했습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서화
  - Header 스토리 개편: LeftOnly → Basic으로 교체하고 중앙 정렬 예제를 추가.
  - LeftAndRight 스토리 업데이트: 로고 아이콘과 소형 “로그아웃” 버튼으로 예시 단순화.
  - Storybook에 Header 컴포넌트 설명 추가로 문서 가독성 향상.

- 리팩터링
  - Header 내부 스타일 조건 처리 로직 개선(외부 API와 동작 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->