### PR TITLE
[BE] 푸시/이메일 알림 메시지에 대한 유효성 검증 추가

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventNotificationService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationService.java
@@ -42,6 +42,7 @@ public class EventNotificationService {
     ) {
         Event event = getEvent(eventId);
         validateOrganizer(event, loginMember.memberId());
+        validateContentLength(request.content());
 
         List<OrganizationMember> recipients =
                 getOrganizationMemberFromIds(event, request.organizationMemberIds());
@@ -61,6 +62,12 @@ public class EventNotificationService {
 
         if (!event.isOrganizer(member)) {
             throw new AccessDeniedException("이벤트 주최자가 아닙니다.");
+        }
+    }
+
+    private void validateContentLength(final String content) {
+        if (content.length() > 20) {
+            throw new BusinessFlowViolatedException("알림 메시지는 20자 이하여야 합니다.");
         }
     }
 

--- a/server/src/main/java/com/ahmadda/application/dto/SelectedOrganizationMembersNotificationRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/SelectedOrganizationMembersNotificationRequest.java
@@ -2,7 +2,6 @@ package com.ahmadda.application.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
@@ -11,7 +10,6 @@ public record SelectedOrganizationMembersNotificationRequest(
         @NotEmpty
         List<Long> organizationMemberIds,
         @NotBlank
-        @Size(max = 20)
         String content
 ) {
 

--- a/server/src/main/java/com/ahmadda/application/dto/SelectedOrganizationMembersNotificationRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/SelectedOrganizationMembersNotificationRequest.java
@@ -2,6 +2,7 @@ package com.ahmadda.application.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
@@ -10,6 +11,7 @@ public record SelectedOrganizationMembersNotificationRequest(
         @NotEmpty
         List<Long> organizationMemberIds,
         @NotBlank
+        @Size(max = 20)
         String content
 ) {
 

--- a/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationServiceTest.java
@@ -18,8 +18,8 @@ import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.domain.Reminder;
 import com.ahmadda.domain.ReminderHistoryRepository;
-import com.ahmadda.domain.Role;
 import com.ahmadda.domain.ReminderRecipient;
+import com.ahmadda.domain.Role;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -195,6 +195,49 @@ class EventNotificationServiceTest {
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("이벤트 주최자가 아닙니다.");
     }
+
+    @Test
+    void 알림_내용이_20자를_초과하면_예외가_발생한다() {
+        // given
+        var organization = organizationRepository.save(Organization.create("조직명", "설명", "img.png"));
+        var organizer = saveOrganizationMember("주최자", "host@email.com", organization);
+        var now = LocalDateTime.now();
+
+        var event = eventRepository.save(Event.create(
+                "이벤트제목",
+                "설명",
+                "장소",
+                organizer,
+                organization,
+                EventOperationPeriod.create(
+                        now.minusDays(2), now.minusDays(1),
+                        now.plusDays(1), now.plusDays(2),
+                        now.minusDays(3)
+                ),
+                100
+        ));
+
+        var om1 = saveOrganizationMember("선택1", "sel1@email.com", organization);
+        var om2 = saveOrganizationMember("선택2", "sel2@email.com", organization);
+
+        var overLengthContent = "이 메시지는 20자를 초과합니다. 예외를 발생시켜야 합니다.";
+        var request = new SelectedOrganizationMembersNotificationRequest(
+                List.of(om1.getId(), om2.getId()),
+                overLengthContent
+        );
+
+        // when // then
+        assertThatThrownBy(() ->
+                sut.notifySelectedOrganizationMembers(
+                        event.getId(),
+                        request,
+                        createLoginMember(organizer)
+                )
+        )
+                .isInstanceOf(BusinessFlowViolatedException.class)
+                .hasMessage("알림 메시지는 20자 이하여야 합니다.");
+    }
+
 
     @Test
     void 요청에_존재하지_않는_조직원_ID가_포함되면_예외가_발생한다() {


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #517

## ✨ 작업 내용

- 푸시 및 이메일 알림 메시지의 길이를 20자 이하로 제한합니다.
- 메시지 길이에 대한 유효성 검증은 application 계층에서 처리되도록 구현했습니다.
- 관련된 테스트 코드도 함께 작성하였습니다.

## 🙏 기타 참고 사항

클라이언트 측에서 푸시 및 이메일 알림 메시지의 길이를 **20자 이하로 제한**해달라는 요구사항이 있었습니다. 이에 따라 메시지 내용에 대한 유효성 검증을 어디에서 처리하는 것이 적절할지에 대해 고민한 결과, 다음과 같은 이유로 **application 계층**에서 검증 로직을 수행하도록 결정했습니다!! 이에 대해서 의견 부탁드립니다~~

### 1. Presentation 계층은 적절하지 않다고 판단한 이유

Spring의 `@Valid`, `@Size` 등을 사용하여 controller 단에서 메시지 길이를 제한할 수 있는 방법도 고려해보았습니다. 하지만 Presentation 계층은 요청을 수신하고 해석하여 적절한 응답을 반환하는 것이 주요 역할입니다. 메시지 길이 제한은 단순한 입력 포맷 제약이 아니라, 특정 시나리오에만 적용되는 **비즈니스 흐름 상의 조건**에 더 가깝다고 판단하여 배제했습니다!! 👍

### 2. Domain 계층에서 검증하지 않은 이유

도메인 모델인 `EventEmailPayload`와 `PushNotificationPayload`는 이벤트 생성, 수정, 리마인더 전송, 포키 전송 등 다양한 플로우에서 재사용됩니다. 그러나 이번 메시지 길이 제한은 **‘선택된 조직원에게 알림을 보내는 기능’** 에만 해당되는 제약이므로, 도메인 모델에 포함시키면 오히려 해당 객체들의 범용성과 재사용성이 저해된다고 판단했습니다. ㅠㅠ 😭

즉, 이 제약은 특정 기능에 종속적인 것으로, 도메인 로직 전체에 일반화할 수 있는 비즈니스 규칙이 아니라고 보았습니다. 따라서 도메인 객체 내부에 검증 로직을 두는 것은 과도한 책임 부여라고 판단했습니다!! 👍

### 3. Application 계층에서 검증한 이유

Application 계층은 여러 도메인을 조합하여 하나의 기능 흐름을 만드는 **비즈니스 오케스트레이션 계층**입니다. "선택된 조직원에게 알림을 발송한다"는 하나의 명확한 use-case 내에서만 메시지 길이 제한이 유효한 상황이며, 이는 application 계층의 책임이라고 생각했습니다!!

당연히 이 로직이 **의미 있는 동작**이라고 생각했기에, 이에 대한 테스트도 함께 작성했습니다!! 

