### PR TITLE
[BE] 내가 가입한 조직 조회 api 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/OrganizationService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationService.java
@@ -135,7 +135,7 @@ public class OrganizationService {
         );
     }
 
-    public List<Organization> getParticipatingOrganizations(LoginMember loginMember) {
+    public List<Organization> getParticipatingOrganizations(final LoginMember loginMember) {
         Member member = getMember(loginMember);
 
         return organizationRepository.findMemberOrganizations(member);

--- a/server/src/main/java/com/ahmadda/application/OrganizationService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationService.java
@@ -135,6 +135,12 @@ public class OrganizationService {
         );
     }
 
+    public List<Organization> getParticipatingOrganizations(LoginMember loginMember) {
+        Member member = getMember(loginMember);
+
+        return organizationRepository.findMemberOrganizations(member);
+    }
+
     private String resolveUpdateImageUrl(final String imageUrl, final ImageFile thumbnailImageFile) {
         String updateImageUrl = imageUrl;
 

--- a/server/src/main/java/com/ahmadda/domain/OrganizationRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/OrganizationRepository.java
@@ -1,10 +1,20 @@
 package com.ahmadda.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OrganizationRepository extends JpaRepository<Organization, Long> {
 
     Optional<Organization> findByName(final String name);
+
+    @Query("""
+                select org
+                from OrganizationMember om
+                join om.organization org
+                where om.member = :member
+            """)
+    List<Organization> findMemberOrganizations(final Member member);
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -465,7 +465,7 @@ public class OrganizationController {
     })
     @GetMapping("/participated")
     public ResponseEntity<List<OrganizationResponse>> getParticipatedOrganizations(
-            @AuthMember LoginMember loginMember
+            @AuthMember final LoginMember loginMember
     ) {
         List<Organization> participatingOrganizations = organizationService.getParticipatingOrganizations(loginMember);
 

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -13,6 +13,7 @@ import com.ahmadda.presentation.dto.OrganizationParticipateResponse;
 import com.ahmadda.presentation.dto.OrganizationResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -36,6 +37,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 
 @Tag(name = "Organization", description = "조직 관련 API")
 @RestController
@@ -418,5 +420,59 @@ public class OrganizationController {
 
         return ResponseEntity.ok()
                 .build();
+    }
+
+    @Operation(summary = "내가 참여중인 조직 목록 조회", description = "로그인한 사용자가 참여중인 조직 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = OrganizationResponse.class))
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/organizations/participated"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Not Found",
+                                              "status": 404,
+                                              "detail": "존재하지 않는 회원입니다",
+                                              "instance": "/api/organizations/participated"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @GetMapping("/participated")
+    public ResponseEntity<List<OrganizationResponse>> getParticipatedOrganizations(
+            @AuthMember LoginMember loginMember
+    ) {
+        List<Organization> participatingOrganizations = organizationService.getParticipatingOrganizations(loginMember);
+
+        List<OrganizationResponse> organizationResponses = participatingOrganizations.stream()
+                .map(OrganizationResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(organizationResponses);
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberResponse.java
@@ -1,7 +1,6 @@
 package com.ahmadda.presentation.dto;
 
 import com.ahmadda.domain.OrganizationMember;
-import com.ahmadda.domain.Role;
 
 public record OrganizationMemberResponse(
         Long organizationMemberId,
@@ -13,7 +12,7 @@ public record OrganizationMemberResponse(
         return new OrganizationMemberResponse(
                 organizationMember.getId(),
                 organizationMember.getNickname(),
-                organizationMember.getRole() == Role.ADMIN
+                organizationMember.isAdmin()
         );
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberResponse.java
@@ -1,16 +1,19 @@
 package com.ahmadda.presentation.dto;
 
 import com.ahmadda.domain.OrganizationMember;
+import com.ahmadda.domain.Role;
 
 public record OrganizationMemberResponse(
         Long organizationMemberId,
-        String nickname
+        String nickname,
+        boolean isAdmin
 ) {
 
     public static OrganizationMemberResponse from(final OrganizationMember organizationMember) {
         return new OrganizationMemberResponse(
                 organizationMember.getId(),
-                organizationMember.getNickname()
+                organizationMember.getNickname(),
+                organizationMember.getRole() == Role.ADMIN
         );
     }
 }

--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="false">
+    <springProfile name="local">
+        <include resource="logger/logback-spring-local.xml"/>
+    </springProfile>
+    <springProfile name="dev">
+        <include resource="logger/logback-spring-dev.xml"/>
+    </springProfile>
+    <springProfile name="prod">
+        <include resource="logger/logback-spring-prod.xml"/>
+    </springProfile>
+</configuration>

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -27,7 +27,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -367,17 +366,17 @@ class OrganizationServiceTest {
     @Test
     void 사용자가_가입한_조직을_조회할_수_있다() {
         //given
-        Organization organization1 = createAndSaveOrganization("우테코");
-        Organization organization2 = createAndSaveOrganization("아맞다");
-        Organization organization3 = createAndSaveOrganization("서프의 조직");
-        Organization organization4 = createAndSaveOrganization("프론트 조직");
+        var organization1 = createAndSaveOrganization("우테코");
+        var organization2 = createAndSaveOrganization("아맞다");
+        var organization3 = createAndSaveOrganization("서프의 조직");
+        var organization4 = createAndSaveOrganization("프론트 조직");
         var member = memberRepository.save(Member.create("user1", "user1@test.com", "testPicture"));
         createAndSaveOrganizationMember("surf", member, organization1, Role.USER);
         createAndSaveOrganizationMember("surf", member, organization2, Role.ADMIN);
         createAndSaveOrganizationMember("surf", member, organization3, Role.USER);
 
         //when
-        List<Organization> participatingOrganizations =
+        var participatingOrganizations =
                 sut.getParticipatingOrganizations(new LoginMember(member.getId()));
 
         //then

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -57,8 +58,7 @@ class OrganizationServiceTest {
     @Test
     void 조직을_ID로_조회한다() {
         // given
-        var organization = createOrganization("Org", "Desc", "img.png");
-        organizationRepository.save(organization);
+        var organization = createAndSaveOrganization("Org");
 
         // when
         var found = sut.getOrganizationById(organization.getId());
@@ -288,8 +288,7 @@ class OrganizationServiceTest {
     @Test
     void 조직의_관리자는_조직을_수정할_수_있다() {
         //given
-        var organization = createOrganization("Org", "Desc", "img.png");
-        organizationRepository.save(organization);
+        var organization = createAndSaveOrganization("Org");
         var member = memberRepository.save(Member.create("user1", "user1@test.com", "testPicture"));
         var organizationMember = createAndSaveOrganizationMember("surf", member, organization, Role.ADMIN);
         var request = new OrganizationUpdateRequest("새 이름", "새 설명");
@@ -314,8 +313,7 @@ class OrganizationServiceTest {
     @Test
     void 썸네일이_null이어도_조직_수정이_가능하다() {
         //given
-        var organization = createOrganization("Org", "Desc", "img.png");
-        organizationRepository.save(organization);
+        var organization = createAndSaveOrganization("Org");
         var member = memberRepository.save(Member.create("user1", "user1@test.com", "testPicture"));
         var organizationMember = createAndSaveOrganizationMember("surf", member, organization, Role.ADMIN);
         var request = new OrganizationUpdateRequest("새 이름", "새 설명");
@@ -351,8 +349,7 @@ class OrganizationServiceTest {
     @Test
     void 조직원이_없다면_조직을_수정할때_예외가_발생한다() {
         // given
-        var organization = createOrganization("Org", "Desc", "img.png");
-        organizationRepository.save(organization);
+        var organization = createAndSaveOrganization("Org");
         var request = new OrganizationUpdateRequest("새 이름", "새 설명");
         var member = memberRepository.save(Member.create("user1", "user1@test.com", "testPicture"));
 
@@ -365,6 +362,45 @@ class OrganizationServiceTest {
         ))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 조직원입니다.");
+    }
+
+    @Test
+    void 사용자가_가입한_조직을_조회할_수_있다() {
+        //given
+        Organization organization1 = createAndSaveOrganization("우테코");
+        Organization organization2 = createAndSaveOrganization("아맞다");
+        Organization organization3 = createAndSaveOrganization("서프의 조직");
+        Organization organization4 = createAndSaveOrganization("프론트 조직");
+        var member = memberRepository.save(Member.create("user1", "user1@test.com", "testPicture"));
+        createAndSaveOrganizationMember("surf", member, organization1, Role.USER);
+        createAndSaveOrganizationMember("surf", member, organization2, Role.ADMIN);
+        createAndSaveOrganizationMember("surf", member, organization3, Role.USER);
+
+        //when
+        List<Organization> participatingOrganizations =
+                sut.getParticipatingOrganizations(new LoginMember(member.getId()));
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(participatingOrganizations)
+                    .hasSize(3);
+            softly.assertThat(participatingOrganizations)
+                    .extracting("name")
+                    .contains("우테코", "아맞다", "서프의 조직");
+        });
+    }
+
+    @Test
+    void 사용자가_가입한_조직을_조회할때_사용자가_없다면_예외가_발생한다() {
+        //when //then
+        assertThatThrownBy(() -> sut.getParticipatingOrganizations(new LoginMember(999L)))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 회원입니다");
+    }
+
+    private Organization createAndSaveOrganization(String name) {
+        var organization = createOrganization(name, "Desc", "img.png");
+        return organizationRepository.save(organization);
     }
 
     private Organization createOrganization(String name, String description, String imageUrl) {


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #534 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- 내가 가입한 조직 조회 api를 구현했습니다.
- 내 조직원 프로필 조회시 이제 어드민 유무도 반환되게 변경해주었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 로그인한 사용자가 참여 중인 조직 목록을 조회하는 API가 추가되었습니다.
  - 조직 구성원 정보 응답에 관리자 여부(isAdmin) 필드가 포함되어, 구성원이 관리자 권한을 보유했는지 확인할 수 있습니다.
- 문서
  - 새 조직 목록 조회 API 및 리스트 응답 스키마가 OpenAPI 문서에 추가되었습니다.
- 테스트
  - 조직 참여 목록 조회 및 예외 상황에 대한 테스트가 보강되었으며, 테스트 데이터 생성이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->