### PR TITLE
[BE] 현재 로그인한 사용자의 특정 이벤트에 대한 알림 수신 거부 여부 기능 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
@@ -60,6 +60,21 @@ public class EventNotificationOptOutService {
         optOutRepository.delete(optOut);
     }
 
+    public OrganizationMemberWithOptStatus getMemberWithOptStatus(final Long eventId, final LoginMember loginMember) {
+        Event event = getEvent(eventId);
+        OrganizationMember organizationMember = getOrganizationMember(
+                event.getOrganization()
+                        .getId(),
+                loginMember.memberId()
+        );
+
+        return OrganizationMemberWithOptStatus.createWithOptOutStatus(
+                organizationMember,
+                event,
+                optOutRepository
+        );
+    }
+
     public List<GuestWithOptStatus> mapGuests(final List<Guest> guests) {
         return guests.stream()
                 .map(guest -> {
@@ -98,6 +113,6 @@ public class EventNotificationOptOutService {
 
     private OrganizationMember getOrganizationMember(final Long organizationId, final Long memberId) {
         return organizationMemberRepository.findByOrganizationIdAndMemberId(organizationId, memberId)
-                .orElseThrow(() -> new NotFoundException("해당 조직의 구성원이 아닙니다."));
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 조직원입니다."));
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/EventNotificationOptOutController.java
+++ b/server/src/main/java/com/ahmadda/presentation/EventNotificationOptOutController.java
@@ -2,16 +2,20 @@ package com.ahmadda.presentation;
 
 import com.ahmadda.application.EventNotificationOptOutService;
 import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.domain.OrganizationMemberWithOptStatus;
+import com.ahmadda.presentation.dto.OptOutStatusResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,15 +49,34 @@ public class EventNotificationOptOutController {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    content = @Content(examples = @ExampleObject(value = """
-                            {
-                              "type": "about:blank",
-                              "title": "Not Found",
-                              "status": 404,
-                              "detail": "존재하지 않는 이벤트입니다.",
-                              "instance": "/api/events/{eventId}/notification/opt-out"
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 조직원",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 조직원입니다.",
+                                                      "instance": "/api/events/{eventId}/notification/opt-out"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 이벤트",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 이벤트입니다",
+                                                      "instance": "/api/events/{eventId}/notification/opt-out"
+                                                    }
+                                                    """
+                                    ),
                             }
-                            """))
+                    )
             ),
             @ApiResponse(
                     responseCode = "422",
@@ -98,6 +121,37 @@ public class EventNotificationOptOutController {
                             """))
             ),
             @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 조직원",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 조직원입니다.",
+                                                      "instance": "/api/events/{eventId}/notification/opt-out"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 이벤트",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 이벤트입니다",
+                                                      "instance": "/api/events/{eventId}/notification/opt-out"
+                                                    }
+                                                    """
+                                    ),
+                            }
+                    )
+            ),
+            @ApiResponse(
                     responseCode = "422",
                     content = @Content(examples = @ExampleObject(value = """
                             {
@@ -119,5 +173,75 @@ public class EventNotificationOptOutController {
 
         return ResponseEntity.noContent()
                 .build();
+    }
+
+    @Operation(
+            summary = "이벤트 알림 수신 거부 여부 조회",
+            description = "현재 로그인한 사용자가 해당 이벤트에 대해 알림 수신 거부 상태인지 여부를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = OptOutStatusResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(examples = @ExampleObject(value = """
+                            {
+                              "type": "about:blank",
+                              "title": "Unauthorized",
+                              "status": 401,
+                              "detail": "유효하지 않은 인증 정보입니다.",
+                              "instance": "/api/events/{eventId}/notification/opt-out"
+                            }
+                            """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 조직원",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 조직원입니다.",
+                                                      "instance": "/api/events/{eventId}/notification/opt-out"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 이벤트",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 이벤트입니다",
+                                                      "instance": "/api/events/{eventId}/notification/opt-out"
+                                                    }
+                                                    """
+                                    ),
+                            }
+                    )
+            )
+    })
+    @GetMapping("/{eventId}/notification/opt-out")
+    public ResponseEntity<OptOutStatusResponse> getOptOutStatus(
+            @PathVariable final Long eventId,
+            @AuthMember final LoginMember loginMember
+    ) {
+        OrganizationMemberWithOptStatus organizationMemberWithOptStatus =
+                optOutService.getMemberWithOptStatus(eventId, loginMember);
+
+        OptOutStatusResponse response = OptOutStatusResponse.from(organizationMemberWithOptStatus);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/OptOutStatusResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OptOutStatusResponse.java
@@ -1,0 +1,10 @@
+package com.ahmadda.presentation.dto;
+
+import com.ahmadda.domain.OrganizationMemberWithOptStatus;
+
+public record OptOutStatusResponse(boolean optedOut) {
+
+    public static OptOutStatusResponse from(final OrganizationMemberWithOptStatus organizationMemberWithOptStatus) {
+        return new OptOutStatusResponse(organizationMemberWithOptStatus.isOptedOut());
+    }
+}

--- a/server/src/test/java/com/ahmadda/application/EventNotificationOptOutServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationOptOutServiceTest.java
@@ -106,7 +106,7 @@ class EventNotificationOptOutServiceTest {
         // when // then
         assertThatThrownBy(() -> sut.optOut(event.getId(), loginMember))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("해당 조직의 구성원이 아닙니다.");
+                .hasMessage("존재하지 않는 조직원입니다.");
     }
 
     @Test
@@ -171,7 +171,7 @@ class EventNotificationOptOutServiceTest {
         // when // then
         assertThatThrownBy(() -> sut.cancelOptOut(event.getId(), loginMember))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("해당 조직의 구성원이 아닙니다.");
+                .hasMessage("존재하지 않는 조직원입니다.");
     }
 
     @Test
@@ -188,6 +188,60 @@ class EventNotificationOptOutServiceTest {
         assertThatThrownBy(() -> sut.cancelOptOut(event.getId(), loginMember))
                 .isInstanceOf(BusinessFlowViolatedException.class)
                 .hasMessage("수신 거부 설정이 존재하지 않습니다.");
+    }
+
+    @Test
+    void 특정_이벤트에_대한_수신_거부_여부_정보를_조회할_수_있다() {
+        // given
+        var organization = createOrganization();
+
+        var organizer = createOrganizationMember("주최자", createMember("host", "host@mail.com"), organization);
+        var member = createMember("user", "user@mail.com");
+        var orgMember = createOrganizationMember("닉네임", member, organization);
+
+        var event = createEvent(organizer, organization);
+        var loginMember = new LoginMember(member.getId());
+
+        optOutRepository.save(EventNotificationOptOut.create(orgMember, event));
+
+        // when
+        var result = sut.getMemberWithOptStatus(event.getId(), loginMember);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getOrganizationMember())
+                    .isEqualTo(orgMember);
+            softly.assertThat(result.isOptedOut())
+                    .isTrue();
+        });
+    }
+
+    @Test
+    void 수신_거부_여부_정보를_조회시_존재하지_않는_이벤트이면_예외가_발생한다() {
+        // given
+        var member = createMember("user", "user@mail.com");
+        var loginMember = new LoginMember(member.getId());
+
+        // when // then
+        assertThatThrownBy(() -> sut.getMemberWithOptStatus(Long.MAX_VALUE, loginMember))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 이벤트입니다.");
+    }
+
+    @Test
+    void 수신_거부_여부_정보를_조회시_조직의_구성원이_아니면_예외가_발생한다() {
+        // given
+        var org = createOrganization();
+        var event = createEvent(
+                createOrganizationMember("닉네임", createMember("user", "user@mail.com"), org),
+                org
+        );
+        var loginMember = new LoginMember(Long.MAX_VALUE);
+
+        // when // then
+        assertThatThrownBy(() -> sut.getMemberWithOptStatus(event.getId(), loginMember))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 조직원입니다.");
     }
 
     @Test


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #541

## ✨ 작업 내용

- 현재 로그인한 사용자의 특정 이벤트에 대한 알림 수신 거부 여부를 조회하는 기능을 구현합니다.

## 🙏 기타 참고 사항

- 알림 수신 거부 여부를 이벤트 상세 응답에 포함시킬지, 별도 API로 분리할지 고민했으나, RESTful한 자원 설계 관점에서 별도 API로 분리하는 것이 적절하다고 판단하여 해당 방식으로 구현했습니다 😎

- EventNotificationOptOutService에서는 단순히 boolean을 반환할 수도 있었지만, 확장성과 유지보수성을 고려해 OrganizationMemberWithOptStatus를 반환하도록 했습니다! 이로 인해 추후 클라이언트 요구사항이 변경되더라도 유연하게 대응할 수 있도록 했습니다!! 👍


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 이벤트별 알림 수신 거부 상태 조회 API 추가(GET /api/events/{eventId}/notification/opt-out). 현재 사용자 기준 optedOut(boolean) 반환.
- Documentation
  - Swagger/OpenAPI에 401/404 응답 예시 확장(이벤트 없음/조직원 아님 구분). 신규 조회 API 문서화 및 200 응답 스키마 명시.
- Bug Fixes
  - 오류 메시지 문구를 상황별로 정교화해 일관성 및 가독성 향상.
- Tests
  - 조회 기능의 정상/예외 케이스 테스트 추가 및 메시지 변경 사항 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->