### PR TITLE
[BE] 필수질문에 대한 답변이 빈 문자열 값으로 와도 예외 처리되게 변경

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/Guest.java
+++ b/server/src/main/java/com/ahmadda/domain/Guest.java
@@ -69,16 +69,17 @@ public class Guest extends BaseEntity {
     }
 
     public void submitAnswers(final Map<Question, String> questionAnswers) {
-        validateRequiredQuestions(questionAnswers.keySet());
+        validateRequiredQuestions(questionAnswers);
 
         addAnswers(questionAnswers);
     }
 
-    private void validateRequiredQuestions(final Set<Question> answeredQuestions) {
+    private void validateRequiredQuestions(final Map<Question, String> questionAnswers) {
         Set<Question> requiredQuestions = event.getRequiredQuestions();
 
         for (Question required : requiredQuestions) {
-            if (!answeredQuestions.contains(required)) {
+            String answer = questionAnswers.get(required);
+            if (answer == null || answer.isBlank()) {
                 throw new BusinessRuleViolatedException("필수 질문에 대한 답변이 누락되었습니다.");
             }
         }

--- a/server/src/test/java/com/ahmadda/domain/GuestTest.java
+++ b/server/src/test/java/com/ahmadda/domain/GuestTest.java
@@ -4,6 +4,8 @@ import com.ahmadda.domain.exception.BusinessRuleViolatedException;
 import com.ahmadda.domain.exception.UnauthorizedOperationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -204,6 +206,27 @@ class GuestTest {
 
         var answers = Map.of(
                 question2, "답변2"
+        );
+
+        // when // then
+        assertThatThrownBy(() -> guest.submitAnswers(answers))
+                .isInstanceOf(BusinessRuleViolatedException.class)
+                .hasMessageContaining("필수 질문에 대한 답변이 누락되었습니다");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void 필수_질문에_대한_답변이_빈_문자열값_이라면_예외가_발생한다(String answer) {
+        // given
+        var now = LocalDateTime.now();
+
+        var question = Question.create("필수 질문1", true, 0);
+        var event = createEvent("이벤트", participant, now, question);
+
+        var guest = Guest.create(event, otherParticipant, now);
+
+        var answers = Map.of(
+                question, answer
         );
 
         // when // then


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #554 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

이벤트의 필수 질문에 답변이 누락시 이벤트에 참여되는 버그를 고쳤습니다.

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
버그가 생긴 이유는 프론트에서 답변이 누락됐을 경우 해당 값 자체를 넘겨주지 않는다고 판단하고 개발했는데, 요청 로그를 보니 필수답변이 누락된 경우에 answer값을 빈 문자열로 주고 있었습니다. 그래서 빈 문자열인 경우에 예외처리를 해주었습니다.
<img width="317" height="134" alt="스크린샷 2025-08-19 오전 1 22 43" src="https://github.com/user-attachments/assets/420b6c6d-61fd-48bb-bd4d-cf8d7a989b9c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 필수 질문 검증이 강화되어, 공백·빈 문자열 답변도 누락으로 처리됩니다.
- 버그 수정
  - 필수 질문에 키만 존재하고 답변이 비어있는 경우도 올바르게 오류가 표시되어 제출이 차단됩니다. 오류 메시지는 기존과 동일합니다.
- 테스트
  - 필수 질문에 대한 빈/공백 답변 검증을 위한 파라미터화 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->