### PR TITLE
[BE] 이벤트 신청 마감 리마인드 시점을 30분 전으로 변경

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationScheduler.java
@@ -25,7 +25,8 @@ public class EventNotificationScheduler {
 
     // TODO. 추후 5분이라는 시간을 보장하도록 구현
     private static final Duration SCHEDULER_SCAN_WINDOW = Duration.ofMinutes(5);
-    private static final Duration START_REMINDER_LEAD_TIME = Duration.ofHours(24);
+    private static final Duration REGISTRATION_CLOSING_REMINDER_LEAD_TIME = Duration.ofMinutes(30);
+    private static final Duration EVENT_START_REMINDER_LEAD_TIME = Duration.ofHours(24);
 
     private final EventRepository eventRepository;
     private final EventNotificationOptOutRepository eventNotificationOptOutRepository;
@@ -35,8 +36,9 @@ public class EventNotificationScheduler {
     // TODO. 추후 중복 알람을 방지하도록 구현
     @Scheduled(fixedRate = 180_000)
     @Transactional
-    public void notifyRegistrationClosingEvents() {
-        LocalDateTime windowStart = LocalDateTime.now();
+    public void notifyRegistrationClosingIn30Minutes() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime windowStart = now.plus(REGISTRATION_CLOSING_REMINDER_LEAD_TIME);
         LocalDateTime windowEnd = windowStart.plus(SCHEDULER_SCAN_WINDOW);
 
         List<Event> upcomingEvents =
@@ -57,7 +59,7 @@ public class EventNotificationScheduler {
     @Transactional
     public void notifyEventStartIn24Hours() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime windowStart = now.plus(START_REMINDER_LEAD_TIME);
+        LocalDateTime windowStart = now.plus(EVENT_START_REMINDER_LEAD_TIME);
         LocalDateTime windowEnd = windowStart.plus(SCHEDULER_SCAN_WINDOW);
 
         List<Event> startingEvents =

--- a/server/src/test/java/com/ahmadda/application/EventNotificationSchedulerTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventNotificationSchedulerTest.java
@@ -16,8 +16,8 @@ import com.ahmadda.domain.OrganizationMemberRepository;
 import com.ahmadda.domain.OrganizationRepository;
 import com.ahmadda.domain.Reminder;
 import com.ahmadda.domain.ReminderHistoryRepository;
-import com.ahmadda.domain.Role;
 import com.ahmadda.domain.ReminderRecipient;
+import com.ahmadda.domain.Role;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -98,7 +98,7 @@ class EventNotificationSchedulerTest {
         eventNotificationOptOutRepository.save(ng2OptOut);
 
         // when
-        sut.notifyRegistrationClosingEvents();
+        sut.notifyRegistrationClosingIn30Minutes();
 
         // then
         if (expectToSend) {
@@ -131,7 +131,7 @@ class EventNotificationSchedulerTest {
         ));
 
         // when
-        sut.notifyRegistrationClosingEvents();
+        sut.notifyRegistrationClosingIn30Minutes();
 
         // then
         var savedHistories = reminderHistoryRepository.findAll();
@@ -182,7 +182,7 @@ class EventNotificationSchedulerTest {
         saveGuest(event, saveOrganizationMember("게스트2", "g2@email.com", organization));
 
         // when
-        sut.notifyRegistrationClosingEvents();
+        sut.notifyRegistrationClosingIn30Minutes();
 
         // then
         verify(reminder, Mockito.never()).remind(any(), any(), any());


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #565

## ✨ 작업 내용

- 이벤트 신청 마감 리마인드 시간을 기존 설정에서 30분 전으로 조정
- 기존 스케줄링/알림 로직이 정상 동작하는지 확인


## 🙏 기타 참고 사항

- 실제 리프레시 이벤트 진행 시, 리마인드가 1분 전에 도착해 사용자들이 불편을 겪었다는 피드백을 받았습니다 ㅠㅠ
  - 그럴 의도는 전혀 없었는데 슬프네요
- 이에 따라 충분한 여유를 둘 수 있도록 리마인드 시점을 30분 전으로 변경했씁니다!!
