### PR TITLE
[BE] 테스트 환경에서 N+1 Detector 설정 변경

### DIFF
--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -3,6 +3,9 @@
     <springProfile name="local">
         <include resource="logger/logback-spring-local.xml"/>
     </springProfile>
+    <springProfile name="test">
+        <include resource="logger/logback-spring-local.xml"/>
+    </springProfile>
     <springProfile name="dev">
         <include resource="logger/logback-spring-dev.xml"/>
     </springProfile>

--- a/server/src/test/java/com/ahmadda/annotation/IntegrationTest.java
+++ b/server/src/test/java/com/ahmadda/annotation/IntegrationTest.java
@@ -1,9 +1,9 @@
 package com.ahmadda.annotation;
 
+import io.jeyong.detector.annotation.NPlusOneTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -14,9 +14,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Transactional
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles(profiles = "test")
+@NPlusOneTest(NPlusOneTest.Mode.LOGGING)
 public @interface IntegrationTest {
 
 }

--- a/server/src/test/java/com/ahmadda/annotation/IntegrationTest.java
+++ b/server/src/test/java/com/ahmadda/annotation/IntegrationTest.java
@@ -4,6 +4,7 @@ import io.jeyong.detector.annotation.NPlusOneTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -14,6 +15,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
+@Transactional
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles(profiles = "test")
 @NPlusOneTest(NPlusOneTest.Mode.LOGGING)

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -6,10 +6,6 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
-    properties:
-      hibernate:
-        detector:
-          enabled: true
 
   cloud:
     aws:


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #559

## ✨ 작업 내용

- 테스트 환경에서 N+1 감지를 위한 `@NPlusOneTest` 어노테이션을 적용했습니다~!

## 🙏 기타 참고 사항

- @NPlusOneTest는 로깅 모드와 예외 모드가 있는데, 현재는 N+1 쿼리를 잡아야 하는 상황은 아니므로 로깅 모드로 설정했씁니다!

### 실행 로그
<img width="2130" height="840" alt="image" src="https://github.com/user-attachments/assets/bf9a4b46-026d-408c-be75-a78b82e03ac0" />

### 로깅 모드
<img width="2044" height="776" alt="image" src="https://github.com/user-attachments/assets/33f8fa57-3294-429d-94b1-13f307544816" />

### 예외 모드
<img width="2134" height="758" alt="image" src="https://github.com/user-attachments/assets/0d4abc65-99a8-458e-816b-6c576527aa09" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **테스트**
  - @IntegrationTest로 실행되는 테스트에 N+1 쿼리 로깅을 활성화하여 성능 문제를 빠르게 파악하고 회귀를 예방할 수 있습니다.

- **작업**
  - 테스트 환경에 로컬과 동일한 로깅 프로필을 추가해 로그 가시성과 일관성을 개선했습니다.
  - 테스트 설정에서 중복된 JPA 감지 옵션을 제거하여 구성 단순화 및 유지보수성을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->