### PR TITLE
[BE] refresh token cookie 값 domain 설정 

### DIFF
--- a/server/src/main/java/com/ahmadda/presentation/cookie/CookieProvider.java
+++ b/server/src/main/java/com/ahmadda/presentation/cookie/CookieProvider.java
@@ -13,12 +13,13 @@ import org.springframework.stereotype.Component;
 public class CookieProvider {
 
     public static final String REFRESH_TOKEN_KEY = "refresh_token";
-    
+
     private final RefreshTokenCookieProperties refreshTokenCookieProperties;
 
     public ResponseCookie createRefreshTokenCookie(final String refreshToken) {
         return ResponseCookie.from(REFRESH_TOKEN_KEY, refreshToken)
                 .maxAge(refreshTokenCookieProperties.getTtl())
+                .domain(refreshTokenCookieProperties.getDomain())
                 .sameSite(refreshTokenCookieProperties.getSameSite())
                 .secure(refreshTokenCookieProperties.isSecure())
                 .httpOnly(refreshTokenCookieProperties.isHttpOnly())
@@ -30,6 +31,7 @@ public class CookieProvider {
     public ResponseCookie createLogoutRefreshTokenCookie() {
         return ResponseCookie.from(REFRESH_TOKEN_KEY, "")
                 .maxAge(0)
+                .domain(refreshTokenCookieProperties.getDomain())
                 .sameSite(refreshTokenCookieProperties.getSameSite())
                 .secure(refreshTokenCookieProperties.isSecure())
                 .httpOnly(refreshTokenCookieProperties.isHttpOnly())

--- a/server/src/main/java/com/ahmadda/presentation/cookie/config/RefreshTokenCookieProperties.java
+++ b/server/src/main/java/com/ahmadda/presentation/cookie/config/RefreshTokenCookieProperties.java
@@ -10,30 +10,48 @@ import java.time.Duration;
 public class RefreshTokenCookieProperties {
 
     private final String path;
+    private final String domain;
     private final String sameSite;
     private final boolean secure;
     private final boolean httpOnly;
     private final Duration ttl;
 
-    public RefreshTokenCookieProperties(String path, String sameSite, boolean secure, boolean httpOnly, Duration ttl) {
-        validateProperties(path, sameSite, ttl);
+    public RefreshTokenCookieProperties(
+            final String path,
+            final String domain,
+            final String sameSite,
+            final boolean secure,
+            final boolean httpOnly,
+            final Duration ttl
+    ) {
+        validateProperties(path, domain, sameSite, ttl);
 
         this.path = path;
+        this.domain = domain;
         this.sameSite = sameSite;
         this.secure = secure;
         this.httpOnly = httpOnly;
         this.ttl = ttl;
     }
 
-    private void validateProperties(final String path,
-                                    final String sameSite,
-                                    final Duration ttl) {
+    private void validateProperties(
+            final String path,
+            final String domain,
+            final String sameSite,
+            final Duration ttl
+    ) {
         if (path == null || path.isBlank()) {
             throw new IllegalArgumentException("쿠키 Path가 비어있습니다.");
         }
+
+        if (domain == null || domain.isBlank()) {
+            throw new IllegalArgumentException("쿠키 domain이 비어있습니다.");
+        }
+
         if (sameSite == null || sameSite.isBlank()) {
             throw new IllegalArgumentException("쿠키 SameSite가 비어있습니다.");
         }
+
         if (ttl == null) {
             throw new IllegalArgumentException("쿠키 만료 시간이 지정되지 않았습니다.");
         }

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -32,6 +32,7 @@ jwt:
 cookie:
   refresh-token:
     path: ${cookie.dev.refresh-token.path}
+    domain: ${cookie.dev.refresh-token.domain}
     same-site: ${cookie.dev.refresh-token.same-site}
     secure: ${cookie.dev.refresh-token.secure}
     http-only: ${cookie.dev.refresh-token.http-only}

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -28,6 +28,7 @@ jwt:
 cookie:
   refresh-token:
     path: ${cookie.local.refresh-token.path}
+    domain: ${cookie.dev.refresh-token.domain}
     same-site: ${cookie.local.refresh-token.same-site}
     secure: ${cookie.local.refresh-token.secure}
     http-only: ${cookie.local.refresh-token.http-only}

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -28,7 +28,7 @@ jwt:
 cookie:
   refresh-token:
     path: ${cookie.local.refresh-token.path}
-    domain: ${cookie.dev.refresh-token.domain}
+    domain: ${cookie.local.refresh-token.domain}
     same-site: ${cookie.local.refresh-token.same-site}
     secure: ${cookie.local.refresh-token.secure}
     http-only: ${cookie.local.refresh-token.http-only}

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -29,6 +29,7 @@ jwt:
 cookie:
   refresh-token:
     path: ${cookie.prod.refresh-token.path}
+    domain: ${cookie.dev.refresh-token.domain}
     same-site: ${cookie.prod.refresh-token.same-site}
     secure: ${cookie.prod.refresh-token.secure}
     http-only: ${cookie.prod.refresh-token.http-only}

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -29,7 +29,7 @@ jwt:
 cookie:
   refresh-token:
     path: ${cookie.prod.refresh-token.path}
-    domain: ${cookie.dev.refresh-token.domain}
+    domain: ${cookie.prod.refresh-token.domain}
     same-site: ${cookie.prod.refresh-token.same-site}
     secure: ${cookie.prod.refresh-token.secure}
     http-only: ${cookie.prod.refresh-token.http-only}

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -25,6 +25,7 @@ jwt:
 cookie:
   refresh-token:
     path: ${cookie.local.refresh-token.path}
+    domain: ${cookie.local.refresh-token.domain}
     same-site: ${cookie.local.refresh-token.same-site}
     secure: ${cookie.local.refresh-token.secure}
     http-only: ${cookie.local.refresh-token.http-only}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #587 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

refresh token이 기존에 domain이 설정되어 있지 않아 domain을 설정해주었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 리프레시 토큰 쿠키에 domain 및 path 속성을 적용해 설정 가능하도록 개선했습니다.
  * 로그아웃 시 리프레시 토큰 쿠키에도 동일한 속성을 적용해 서브도메인 간 동작 일관성을 높였습니다.
* 설정
  * dev/local/prod 환경에 cookie.refresh-token.domain 구성 키를 추가해 도메인을 환경별로 관리할 수 있습니다.
* 잡무
  * 보안 리소스 서브모듈 참조를 최신 커밋으로 갱신했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->