### PR TITLE
[BE] Sliding Window 기반 요청 속도 제한 필터 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/presentation/filter/SlidingWindowRateLimitFilter.java
+++ b/server/src/main/java/com/ahmadda/presentation/filter/SlidingWindowRateLimitFilter.java
@@ -1,0 +1,110 @@
+package com.ahmadda.presentation.filter;
+
+import com.ahmadda.infra.login.jwt.JwtProvider;
+import com.ahmadda.presentation.header.HeaderProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 2)
+@RequiredArgsConstructor
+public class SlidingWindowRateLimitFilter extends OncePerRequestFilter {
+
+    private static final long WINDOW_MILLIS = 60_000;
+    private static final int MAX_REQUESTS = 100;
+
+    private final HeaderProvider headerProvider;
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    private final Map<Long, Deque<Long>> requestLogs = new ConcurrentHashMap<>();
+
+    @Override
+    protected void doFilterInternal(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        Long memberId = extractMemberIdSafely(authorizationHeader);
+
+        if (memberId == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        long now = Instant.now()
+                .toEpochMilli();
+        Deque<Long> timestamps = requestLogs.computeIfAbsent(memberId, id -> new ConcurrentLinkedDeque<>());
+
+        if (isRateLimited(timestamps, now)) {
+            respondTooManyRequests(request, response);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isRateLimited(final Deque<Long> timestamps, final long now) {
+        synchronized (timestamps) {
+            while (!timestamps.isEmpty() && timestamps.peekFirst() < now - WINDOW_MILLIS) {
+                timestamps.pollFirst();
+            }
+
+            if (timestamps.size() >= MAX_REQUESTS) {
+                return true;
+            }
+
+            timestamps.addLast(now);
+            return false;
+        }
+    }
+
+    private void respondTooManyRequests(
+            final HttpServletRequest request,
+            final HttpServletResponse response
+    ) throws IOException {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.TOO_MANY_REQUESTS);
+        problemDetail.setTitle("Too Many Requests");
+        problemDetail.setDetail("요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.");
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
+
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(problemDetail));
+    }
+
+    private Long extractMemberIdSafely(final String authorizationHeader) {
+        try {
+            String accessToken = headerProvider.extractAccessToken(authorizationHeader);
+
+            return jwtProvider.parseAccessPayload(accessToken)
+                    .getMemberId();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
close #598

## ✨ 작업 내용

- JWT에서 memberId를 추출하여 사용자 식별
- Sliding Window Counter 알고리즘을 사용한 요청 속도 제한 구현
- 사용자 요청 로그를 인메모리에 저장 및 관리 (ConcurrentHashMap<Long, Deque<Long>>)
- 요청 허용 여부 판단 후 429 응답 처리 (application/problem+json 형식의 ProblemDetail 반환)
- JWT가 없거나 유효하지 않은 요청은 제한 대상에서 제외하여, 비회원/외부 요청은 차단하지 않음

---

## 🔒 제한 정책

| 항목          | 값                        |
|---------------|-----------------------------|
| 제한 기준     | 60초 동안 100개의 요청 허용 |
| 초과 시 응답  | HTTP 429 Too Many Requests + ProblemDetail JSON 응답 |

```json
{
  "type": "about:blank",
  "title": "Too Many Requests",
  "status": 429,
  "detail": "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.",
  "instance": "/api/..."
}
```

---

## 🚫 타 알고리즘과의 비교 및 배제 이유

| 알고리즘            | 배제 이유 |
|---------------------|----------|
| **Fixed Window Counter** | 경계 시점에 요청이 몰릴 경우(burst) 제어 불가능. 예: 59초에 100건, 61초에 다시 100건 허용됨 |
| **Sliding Window Log**   | 높은 정확도는 보장되나, 요청마다 타임스탬프를 저장해야 하므로 메모리 비용 과다 발생 |
| **Leaky Bucket**         | 요청을 고정 속도로 처리하지만, 실제로 초당 몇 건을 허용했는지 명확히 계산하거나 보장하긴 어려움 |
| **Token Bucket**         | burst 허용 특성이 있어, 고른 요청 간격을 요구하는 우리 서비스 특성과 맞지 않음 |

---

## 🙏 기타 참고 사항

- 론칭데이 전까지 구현 완료가 필요하여, 외부 라이브러리 없이 직접 Sliding Window Counter 알고리즘을 구현했습니다!!! 고생했습니다 서프!! @abc5259 
- `synchronized`와 `ReentrantLock` 중 무엇을 사용할지 고민했으나, 요청이 적을 때는 `isRateLimited` 메서드의 연산 비용이 작아 락 경합이 거의 발생하지 않을 것으로 보았고, 요청이 많은 경우 `ReentrantLock` 사용 시 오히려 CPU 코어 간 컨텍스트 스위칭 및 경합이 더 심해질 수 있다고 판단했습니다.  
  - 따라서 `synchronized`는 JVM이 관리하는 blocking 방식으로, 간단한 임계 구역 보호에는 오히려 비용이 적고 안정적이라 판단하여 최종 선택하게 되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 사용자별 슬라이딩 윈도우 속도 제한을 도입했습니다(기본 창 60초, 최대 100요청).
  * 초과 시 HTTP 429를 반환하고 응답은 application/problem+json 형식으로 한국어 상세 메시지와 요청 URI를 포함합니다.
  * 멤버 식별 정보를 추출하지 못한 요청은 속도 제한 없이 기존대로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->