### PR TITLE
[BE] SemVer에서 HeadVer로 변경

### DIFF
--- a/.github/workflows/be-dev-deploy-closed-prs.yml
+++ b/.github/workflows/be-dev-deploy-closed-prs.yml
@@ -1,4 +1,4 @@
-name: Dev Deploy Closed Prs
+name: BE Dev Deploy Closed Prs
 
 on:
   push:

--- a/.github/workflows/be-prod-deploy-hotfix.yml
+++ b/.github/workflows/be-prod-deploy-hotfix.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'server/**'
 
+permissions: write-all
+
 jobs:
   setup:
     if: startsWith(github.event.head_commit.message, 'hotfix')
@@ -29,9 +31,7 @@ jobs:
           git fetch --tags
 
           latest_be_tag=$(git tag -l 'be-*' | sort -V | tail -n 1)
-          echo "latest_be_tag=$latest_be_tag"
 
-          # Extract head, yearweek, build
           base=$(echo "$latest_be_tag" | sed 's/^be-//')
           head=$(echo "$base" | cut -d'.' -f1 | sed 's/v//')
           yearweek=$(echo "$base" | cut -d'.' -f2)

--- a/.github/workflows/be-prod-deploy-hotfix.yml
+++ b/.github/workflows/be-prod-deploy-hotfix.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
 
     outputs:
-      image-tag: ${{ steps.extract.outputs.version }}
+      image-tag: ${{ steps.calc.outputs.version }}
 
     steps:
       - name: Checkout repository
@@ -23,36 +23,29 @@ jobs:
           submodules: recursive
           token: ${{ secrets.BE_SUBMODULE_TOKEN }}
 
-      - name: Get latest v{head}.{yearweek} tag
-        id: base
+      - name: Fetch latest be- tag
+        id: latest
         run: |
           git fetch --tags
 
-          latest_tag=$(git tag -l 'v*.*' | sort -V | tail -n 1)
-          echo "latest_tag=$latest_tag"
-          
-          head=$(echo "$latest_tag" | cut -d'.' -f1 | sed 's/v//')
-          yearweek=$(echo "$latest_tag" | cut -d'.' -f2)
+          latest_be_tag=$(git tag -l 'be-*' | sort -V | tail -n 1)
+          echo "latest_be_tag=$latest_be_tag"
+
+          # Extract head, yearweek, build
+          base=$(echo "$latest_be_tag" | sed 's/^be-//')
+          head=$(echo "$base" | cut -d'.' -f1 | sed 's/v//')
+          yearweek=$(echo "$base" | cut -d'.' -f2)
+          last_build=$(echo "$base" | cut -d'.' -f3)
 
           echo "head=$head" >> $GITHUB_OUTPUT
           echo "yearweek=$yearweek" >> $GITHUB_OUTPUT
-          echo "base_tag=$latest_tag" >> $GITHUB_OUTPUT
+          echo "last_build=$last_build" >> $GITHUB_OUTPUT
 
-      - name: Determine next build number
-        id: extract
+      - name: Calculate next build version
+        id: calc
         run: |
-          prefix="be-v${{ steps.base.outputs.head }}.${{ steps.base.outputs.yearweek }}"
-
-          latest_hotfix=$(git tag -l "${prefix}.*" | sort -V | tail -n 1)
-
-          if [ -z "$latest_hotfix" ]; then
-            build=2
-          else
-            last_build=$(echo "$latest_hotfix" | awk -F. '{print $3}')
-            build=$((last_build + 1))
-          fi
-
-          version="${prefix}.${build}"
+          next_build=$(( ${{ steps.latest.outputs.last_build }} + 1 ))
+          version="be-v${{ steps.latest.outputs.head }}.${{ steps.latest.outputs.yearweek }}.${next_build}"
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "Using version: $version"
 
@@ -83,12 +76,13 @@ jobs:
           context: ./server
           file: ./server/Dockerfile
           push: true
-          tags: amadda/ahmadda_server:${{ steps.extract.outputs.version }}
+          tags: amadda/ahmadda_server:${{ steps.calc.outputs.version }}
 
-      - name: Create and push tag
+      - name: Create and push Git tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git tag "${{ steps.extract.outputs.version }}"
-          git push origin "${{ steps.extract.outputs.version }}"
+          tag="${{ steps.calc.outputs.version }}"
+          git tag "$tag"
+          git push origin "$tag"

--- a/.github/workflows/be-prod-deploy-hotfix.yml
+++ b/.github/workflows/be-prod-deploy-hotfix.yml
@@ -1,0 +1,94 @@
+name: BE Prod Deploy On Hotfix
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'server/**'
+
+jobs:
+  setup:
+    if: startsWith(github.event.head_commit.message, 'hotfix')
+    runs-on: ubuntu-22.04-arm
+
+    outputs:
+      image-tag: ${{ steps.extract.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.BE_SUBMODULE_TOKEN }}
+
+      - name: Get latest v{head}.{yearweek} tag
+        id: base
+        run: |
+          git fetch --tags
+
+          latest_tag=$(git tag -l 'v*.*' | sort -V | tail -n 1)
+          echo "latest_tag=$latest_tag"
+          
+          head=$(echo "$latest_tag" | cut -d'.' -f1 | sed 's/v//')
+          yearweek=$(echo "$latest_tag" | cut -d'.' -f2)
+
+          echo "head=$head" >> $GITHUB_OUTPUT
+          echo "yearweek=$yearweek" >> $GITHUB_OUTPUT
+          echo "base_tag=$latest_tag" >> $GITHUB_OUTPUT
+
+      - name: Determine next build number
+        id: extract
+        run: |
+          prefix="be-v${{ steps.base.outputs.head }}.${{ steps.base.outputs.yearweek }}"
+
+          latest_hotfix=$(git tag -l "${prefix}.*" | sort -V | tail -n 1)
+
+          if [ -z "$latest_hotfix" ]; then
+            build=2
+          else
+            last_build=$(echo "$latest_hotfix" | awk -F. '{print $3}')
+            build=$((last_build + 1))
+          fi
+
+          version="${prefix}.${build}"
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "Using version: $version"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Run tests
+        working-directory: ./server
+        run: |
+          chmod +x ./gradlew
+          ./gradlew test
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.PROD_DOCKERHUB_DEPLOY_USERNAME }}
+          password: ${{ secrets.PROD_DOCKERHUB_DEPLOY_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./server
+          file: ./server/Dockerfile
+          push: true
+          tags: amadda/ahmadda_server:${{ steps.extract.outputs.version }}
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag "${{ steps.extract.outputs.version }}"
+          git push origin "${{ steps.extract.outputs.version }}"

--- a/.github/workflows/be-prod-deploy-on-release.yml
+++ b/.github/workflows/be-prod-deploy-on-release.yml
@@ -1,19 +1,11 @@
-name: Prod Deploy On Release
+name: BE Prod Deploy On Release
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'server/**'
   release:
     types: [published]
 
 jobs:
   setup:
-    if: |
-      startsWith(github.event.head_commit.message, 'hotfix') ||
-      github.event_name == 'release'
     runs-on: ubuntu-22.04-arm
 
     outputs:
@@ -29,10 +21,10 @@ jobs:
       - name: Fetch latest tag
         id: extract
         run: |
-            git fetch --tags
-            LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-            IMAGE_TAG="${LATEST_TAG}-${{ github.run_id }}"
-            echo "version=$IMAGE_TAG" >> $GITHUB_OUTPUT
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          IMAGE_TAG="${LATEST_TAG}.1"
+          echo "version=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/be-prod-deploy-on-release.yml
+++ b/.github/workflows/be-prod-deploy-on-release.yml
@@ -18,13 +18,12 @@ jobs:
           submodules: recursive
           token: ${{ secrets.BE_SUBMODULE_TOKEN }}
 
-      - name: Fetch latest tag
+      - name: Fetch latest BE tag
         id: extract
         run: |
           git fetch --tags
-          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-          IMAGE_TAG="${LATEST_TAG}.1"
-          echo "version=$IMAGE_TAG" >> $GITHUB_OUTPUT
+          LATEST_BE_TAG=$(git tag -l 'be-v*.*.*' | sort -V | tail -n 1)
+          echo "version=$LATEST_BE_TAG" >> $GITHUB_OUTPUT
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/be-prod-rollback-on-manual.yml
+++ b/.github/workflows/be-prod-rollback-on-manual.yml
@@ -1,4 +1,4 @@
-name: Prod Rollback On Manual
+name: BE Prod Rollback On Manual
 
 on:
   workflow_dispatch:

--- a/.github/workflows/be-validation-opened-prs.yml
+++ b/.github/workflows/be-validation-opened-prs.yml
@@ -1,4 +1,4 @@
-name: Validation Opened PRs
+name: BE Validation Opened PRs
 
 on:
   pull_request:

--- a/.github/workflows/tag-headver-on-merged-release.yml
+++ b/.github/workflows/tag-headver-on-merged-release.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Extract head version from branch name
         id: head
@@ -34,10 +36,20 @@ jobs:
 
       - name: Create and push HeadVer tag
         run: |
-          tag="v${{ steps.head.outputs.head }}.${{ steps.yearweek.outputs.yearweek }}"
+          head=${{ steps.head.outputs.head }}
+          yearweek=${{ steps.yearweek.outputs.yearweek }}
+
+          base_tag="v${head}.${yearweek}"
+          be_tag="be-${base_tag}.1"
+          fe_tag="fe-${base_tag}.1"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git tag "$tag"
-          git push origin "$tag"
+          git tag "$base_tag"
+          git tag "$be_tag"
+          git tag "$fe_tag"
+
+          git push origin "$base_tag" "$be_tag" "$fe_tag"
+
+          echo "Tagged: $base_tag, $be_tag, $fe_tag"

--- a/.github/workflows/tag-headver-on-merged-release.yml
+++ b/.github/workflows/tag-headver-on-merged-release.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+permissions: write-all
+
 jobs:
   tag-headver:
     if: >

--- a/.github/workflows/tag-headver-on-merged-release.yml
+++ b/.github/workflows/tag-headver-on-merged-release.yml
@@ -1,0 +1,43 @@
+name: Tag HeadVer on Merged Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  tag-headver:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract head version from branch name
+        id: head
+        run: |
+          head_branch="${{ github.event.pull_request.head.ref }}"
+          head_version="${head_branch##release/v}"
+          echo "head=$head_version" >> $GITHUB_OUTPUT
+
+      - name: Calculate yearweek (ISO-8601)
+        id: yearweek
+        run: |
+          year=$(date -u +%y)
+          week=$(date -u +%V)
+          yearweek="${year}$(printf '%02d' $week)"
+          echo "yearweek=$yearweek" >> $GITHUB_OUTPUT
+
+      - name: Create and push HeadVer tag
+        run: |
+          tag="v${{ steps.head.outputs.head }}.${{ steps.yearweek.outputs.yearweek }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag "$tag"
+          git push origin "$tag"


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- [BE] SemVer에서 HeadVer로 변경 -->

## 관련 이슈

close #607

## ✨ 작업 내용

HeadVer 버전 관리 체계를 도입함에 따라 기존 SemVer 기반 워크플로우 및 태깅 방식을 아래와 같이 전환하였습니다.

### 1. HeadVer 형식 도입
- 기존 `x.y.z` 형태의 SemVer 대신 `{head}.{yearweek}.{build}` 형식을 사용하는 **HeadVer 전략**을 도입했습니다.
  - `head`: 수동으로 관리되는 주 버전 (ex. 1)
  - `yearweek`: ISO-8601 기준 연도 주차 (ex. 2534)
  - `build`: 빌드 순번, release는 `.1`부터, hotfix는 `.2`부터 시작

### 2. 릴리즈 워크플로우 수정
- `.github/workflows/prod-deploy-on-release.yml` → `be-prod-deploy-on-release.yml`로 이름 변경
- 불필요한 push 조건 제거, `release.published` 이벤트만 대응
- 가장 최신 `be-v{head}.{yearweek}.{build}` 태그를 찾아 해당 이미지로 배포

### 3. 핫픽스 워크플로우 신규 도입
- `.github/workflows/be-prod-deploy-hotfix.yml` 추가
- `main` 브랜치에 push되며 커밋 메시지가 `hotfix`로 시작할 경우 실행
- 최신 태그(`be-v{head}.{yearweek}.{build}`)를 기준으로 태그를 자동 생성
- Docker 이미지에도 동일한 태그를 부여하여 일관된 배포 관리 가능

### 4. 릴리즈 브랜치 자동 태그 워크플로우 추가
- `.github/workflows/tag-headver-on-merged-release.yml` 추가
- `release/v{head}` 브랜치에서 `main`으로 PR 머지될 때
  - 다음 세 가지 태그를 **동시에 같은 커밋에 자동 생성**
    - `v{head}.{yearweek}`: 공식 릴리즈용
    - `be-v{head}.{yearweek}.1`: 백엔드 배포 기준 태그
    - `fe-v{head}.{yearweek}.1`: 프론트엔드 배포 기준 태그

### 5. 기타 리팩토링
- 명확한 역할 분리를 위해 워크플로우 파일명을 다음과 같이 일괄 변경
  - `dev-deploy-closed-prs.yml` → `be-dev-deploy-closed-prs.yml`
  - `prod-rollback-on-manual.yml` → `be-prod-rollback-on-manual.yml`
  - `validation-opened-prs.yml` → `be-validation-opened-prs.yml`

## 🙏 기타 참고 사항

- HeadVer 도입은 https://github.com/line/headver 를 기반으로 적용하였습니다.
- 기존 SemVer 대비, 날짜 기반의 자동 증가 및 역할별 버전 명시(`be-`, `fe-`)로 인해 릴리즈/배포 관리가 훨씬 명확해집니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 핫픽스 커밋을 감지해 자동으로 빌드·테스트·이미지 배포·버전 태깅하는 프로덕션 핫픽스 배포 파이프라인을 추가했습니다.
  * 릴리스 브랜치 병합 시 헤드 버전 기준의 표준 태그 세트를 자동 생성·푸시합니다.

* **변경/관리**
  * 프로덕션 배포 트리거를 릴리스 공개 이벤트로 단순화해 처리 흐름을 명확히 했습니다.
  * 여러 배포·검증·롤백 워크플로의 표시명을 BE 접두사로 통일했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->