### PR TITLE
[BE] 개발 환경을 위한 토큰 만료기한 변경

### DIFF
--- a/.github/workflows/be-dev-deploy-closed-prs.yml
+++ b/.github/workflows/be-dev-deploy-closed-prs.yml
@@ -1,13 +1,11 @@
 name: BE Dev Deploy Closed Prs
 
 on:
-  pull_request:
+  push:
+    branches:
+      - be/dev
     paths:
       - 'server/**'
-    types:
-      - opened
-      - synchronize
-      - reopened
 
 jobs:
   setup:

--- a/.github/workflows/be-dev-deploy-closed-prs.yml
+++ b/.github/workflows/be-dev-deploy-closed-prs.yml
@@ -1,11 +1,13 @@
 name: BE Dev Deploy Closed Prs
 
 on:
-  push:
-    branches:
-      - be/dev
+  pull_request:
     paths:
       - 'server/**'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   setup:

--- a/server/src/main/java/com/ahmadda/presentation/cookie/config/RefreshTokenCookieProperties.java
+++ b/server/src/main/java/com/ahmadda/presentation/cookie/config/RefreshTokenCookieProperties.java
@@ -44,10 +44,6 @@ public class RefreshTokenCookieProperties {
             throw new IllegalArgumentException("쿠키 Path가 비어있습니다.");
         }
 
-        if (domain == null || domain.isBlank()) {
-            throw new IllegalArgumentException("쿠키 domain이 비어있습니다.");
-        }
-
         if (sameSite == null || sameSite.isBlank()) {
             throw new IllegalArgumentException("쿠키 SameSite가 비어있습니다.");
         }

--- a/server/src/main/java/com/ahmadda/presentation/cookie/config/RefreshTokenCookieProperties.java
+++ b/server/src/main/java/com/ahmadda/presentation/cookie/config/RefreshTokenCookieProperties.java
@@ -44,6 +44,10 @@ public class RefreshTokenCookieProperties {
             throw new IllegalArgumentException("쿠키 Path가 비어있습니다.");
         }
 
+        if (domain == null || domain.isBlank()) {
+            throw new IllegalArgumentException("쿠키 Domain이 비어있습니다.");
+        }
+
         if (sameSite == null || sameSite.isBlank()) {
             throw new IllegalArgumentException("쿠키 SameSite가 비어있습니다.");
         }

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -32,8 +32,8 @@ jwt:
 cookie:
   refresh-token:
     path: /
-    domain: ahmadda.com
-    same-site: Strict
+    domain: .ahmadda.com
+    same-site: None
     secure: true
     http-only: true
     ttl: 14d

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -33,7 +33,7 @@ cookie:
   refresh-token:
     path: /
     domain: ahmadda.com
-    same-site: None
+    same-site: Strict
     secure: true
     http-only: true
     ttl: 14d

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -32,7 +32,7 @@ jwt:
 cookie:
   refresh-token:
     path: /
-    domain: ~
+    domain: .ahmadda.com
     same-site: None
     secure: true
     http-only: true

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -31,12 +31,12 @@ jwt:
 
 cookie:
   refresh-token:
-    path: ${cookie.dev.refresh-token.path}
-    domain: ${cookie.dev.refresh-token.domain}
-    same-site: ${cookie.dev.refresh-token.same-site}
-    secure: ${cookie.dev.refresh-token.secure}
-    http-only: ${cookie.dev.refresh-token.http-only}
-    ttl: ${cookie.dev.refresh-token.ttl}
+    path: /
+    domain: ~
+    same-site: None
+    secure: true
+    http-only: true
+    ttl: 14d
 
 cors:
   allowed-origins:

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -32,8 +32,8 @@ jwt:
 cookie:
   refresh-token:
     path: /
-    domain: ahmadda.com
-    same-site: Strict
+    domain: localhost
+    same-site: None
     secure: true
     http-only: true
     ttl: 14d

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -32,7 +32,7 @@ jwt:
 cookie:
   refresh-token:
     path: /
-    domain: .ahmadda.com
+    domain: localhost
     same-site: None
     secure: true
     http-only: true

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -32,7 +32,7 @@ jwt:
 cookie:
   refresh-token:
     path: /
-    domain: localhost
+    domain: ahmadda.com
     same-site: None
     secure: true
     http-only: true

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -32,8 +32,8 @@ jwt:
 cookie:
   refresh-token:
     path: /
-    domain: localhost
-    same-site: None
+    domain: ahmadda.com
+    same-site: Strict
     secure: true
     http-only: true
     ttl: 14d

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -28,7 +28,7 @@ jwt:
 cookie:
   refresh-token:
     path: /
-    domain: ~
+    domain: localhost
     same-site: None
     secure: true
     http-only: true

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -27,12 +27,12 @@ jwt:
 
 cookie:
   refresh-token:
-    path: ${cookie.local.refresh-token.path}
-    domain: ${cookie.local.refresh-token.domain}
-    same-site: ${cookie.local.refresh-token.same-site}
-    secure: ${cookie.local.refresh-token.secure}
-    http-only: ${cookie.local.refresh-token.http-only}
-    ttl: ${cookie.local.refresh-token.ttl}
+    path: /
+    domain: ~
+    same-site: None
+    secure: true
+    http-only: true
+    ttl: 14d
 
 cors:
   allowed-origins:

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -28,12 +28,12 @@ jwt:
 
 cookie:
   refresh-token:
-    path: ${cookie.prod.refresh-token.path}
-    domain: ${cookie.prod.refresh-token.domain}
-    same-site: ${cookie.prod.refresh-token.same-site}
-    secure: ${cookie.prod.refresh-token.secure}
-    http-only: ${cookie.prod.refresh-token.http-only}
-    ttl: ${cookie.prod.refresh-token.ttl}
+    path: /
+    domain: ahmadda.com
+    same-site: Strict
+    secure: true
+    http-only: true
+    ttl: 14d
 
 cors:
   allowed-origins:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
       - security/db.yml
       - security/slack.yml
       - security/aws.yml
-      - security/cookie.yml
 
   application:
     name: ah-madda

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -20,12 +20,12 @@ jwt:
 
 cookie:
   refresh-token:
-    path: ${cookie.local.refresh-token.path}
-    domain: ${cookie.local.refresh-token.domain}
-    same-site: ${cookie.local.refresh-token.same-site}
-    secure: ${cookie.local.refresh-token.secure}
-    http-only: ${cookie.local.refresh-token.http-only}
-    ttl: ${cookie.local.refresh-token.ttl}
+    path: /
+    domain: ~
+    same-site: None
+    secure: true
+    http-only: true
+    ttl: 14d
 
 cors:
   allowed-origins:

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -21,7 +21,7 @@ jwt:
 cookie:
   refresh-token:
     path: /
-    domain: ~
+    domain: localhost
     same-site: None
     secure: true
     http-only: true


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

#610

## ✨ 작업 내용
- 액세스 토큰 기한을 연장했습니다.

## 🙏 기타 참고 사항
- 제발.. ㅎ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새 기능
  - 환경별(개발/로컬/프로드/테스트) 리프레시 토큰 쿠키 설정을 명시값으로 정비: path '/', 지정 도메인, SameSite, Secure, HttpOnly, TTL 14일.
- 버그 수정
  - 쿠키 도메인 누락 검증 메시지의 표기 통일(문구 가독성 개선).
- 문서/설정
  - 불필요한 cookie.yml import 제거로 설정 로딩 단순화.
- 테스트
  - 테스트 환경 쿠키 설정을 실제 동작과 일치하도록 업데이트.
- 기타 작업
  - 보안 리소스 서브모듈 참조 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->