### PR TITLE
[FE] 이벤트 기간 선택시 에러 메시지 뜨는 문제 해결

### DIFF
--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -74,8 +74,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
 
   const {
     basicEventForm,
-    handleValueChange,
-    validateField,
+    setField,
     handleChange,
     errors,
     isValid: isBasicFormValid,
@@ -231,19 +230,15 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
       return;
     }
 
-    handleValueChange('eventStart', formatDateForInput(finalStartTime));
-    handleValueChange('eventEnd', formatDateForInput(finalEndTime));
-
     const currentRegistrationEndTime =
       parseInputDate(basicEventForm.registrationEnd) || finalStartTime;
     const newRegistrationEnd = applyTimeToDate(startDate, currentRegistrationEndTime);
     const finalRegistrationEnd =
       newRegistrationEnd.getTime() > finalStartTime.getTime() ? finalStartTime : newRegistrationEnd;
-    handleValueChange('registrationEnd', formatDateForInput(finalRegistrationEnd));
 
-    validateField('eventStart', formatDateForInput(finalStartTime));
-    validateField('eventEnd', formatDateForInput(finalEndTime));
-    validateField('registrationEnd', formatDateForInput(finalRegistrationEnd));
+    setField('eventStart', formatDateForInput(finalStartTime));
+    setField('eventEnd', formatDateForInput(finalEndTime));
+    setField('registrationEnd', formatDateForInput(finalRegistrationEnd));
   };
 
   const handleRegistrationEndSelect = (date: Date, time: TimeValue) => {
@@ -258,8 +253,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
       return;
     }
 
-    handleValueChange('registrationEnd', formatDateForInput(finalTime));
-    validateField('registrationEnd', formatDateForInput(finalTime));
+    setField('registrationEnd', formatDateForInput(finalTime));
   };
 
   return (
@@ -340,10 +334,8 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
                 errorMessage={errors.eventStart || errors.eventEnd}
                 isRequired
                 onClear={() => {
-                  handleValueChange('eventStart', '');
-                  handleValueChange('eventEnd', '');
-                  validateField('eventStart', '');
-                  validateField('eventEnd', '');
+                  setField('eventStart', '');
+                  setField('eventEnd', '');
                 }}
                 css={css`
                   cursor: pointer;
@@ -396,8 +388,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
                 errorMessage={errors.registrationEnd}
                 isRequired
                 onClear={() => {
-                  handleValueChange('registrationEnd', '');
-                  validateField('registrationEnd', '');
+                  setField('registrationEnd', '');
                 }}
                 css={css`
                   cursor: pointer;
@@ -474,8 +465,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
               }
               onClose={capacityModalClose}
               onSubmit={(value) => {
-                handleValueChange('maxCapacity', value);
-                validateField('maxCapacity', value.toString());
+                setField('maxCapacity', value.toString());
               }}
             />
           </Flex>

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -74,7 +74,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
 
   const {
     basicEventForm,
-    setField,
+    patchAndValidate,
     handleChange,
     errors,
     isValid: isBasicFormValid,
@@ -236,9 +236,11 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
     const finalRegistrationEnd =
       newRegistrationEnd.getTime() > finalStartTime.getTime() ? finalStartTime : newRegistrationEnd;
 
-    setField('eventStart', formatDateForInput(finalStartTime));
-    setField('eventEnd', formatDateForInput(finalEndTime));
-    setField('registrationEnd', formatDateForInput(finalRegistrationEnd));
+    patchAndValidate({
+      eventStart: formatDateForInput(finalStartTime),
+      eventEnd: formatDateForInput(finalEndTime),
+      registrationEnd: formatDateForInput(finalRegistrationEnd),
+    });
   };
 
   const handleRegistrationEndSelect = (date: Date, time: TimeValue) => {
@@ -253,7 +255,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
       return;
     }
 
-    setField('registrationEnd', formatDateForInput(finalTime));
+    patchAndValidate({ registrationEnd: formatDateForInput(finalTime) });
   };
 
   return (
@@ -334,8 +336,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
                 errorMessage={errors.eventStart || errors.eventEnd}
                 isRequired
                 onClear={() => {
-                  setField('eventStart', '');
-                  setField('eventEnd', '');
+                  patchAndValidate({ eventStart: '', eventEnd: '' });
                 }}
                 css={css`
                   cursor: pointer;
@@ -388,7 +389,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
                 errorMessage={errors.registrationEnd}
                 isRequired
                 onClear={() => {
-                  setField('registrationEnd', '');
+                  patchAndValidate({ registrationEnd: '' });
                 }}
                 css={css`
                   cursor: pointer;
@@ -465,7 +466,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
               }
               onClose={capacityModalClose}
               onSubmit={(value) => {
-                setField('maxCapacity', value.toString());
+                patchAndValidate({ maxCapacity: value });
               }}
             />
           </Flex>

--- a/client/src/features/Event/New/hooks/useBasicEventForm.ts
+++ b/client/src/features/Event/New/hooks/useBasicEventForm.ts
@@ -18,17 +18,16 @@ export const useBasicEventForm = (initialData?: Partial<CreateEventAPIRequest>) 
 
   const [errors, setErrors] = useState<Record<string, string>>({});
 
-  const handleValueChange = (key: keyof BasicEventFormFields, value: string | number) => {
-    setBasicEventForm((prev) => ({
-      ...prev,
-      [key]: value,
-    }));
+  const patchAndValidate = (patch: Partial<BasicEventFormFields>) => {
+    setBasicEventForm((prev) => {
+      const next = { ...prev, ...patch };
+      setErrors(validateEventForm(next));
+      return next;
+    });
   };
 
-  const validateField = (key: keyof BasicEventFormFields, value: string | number) => {
-    const updated = { ...basicEventForm, [key]: value };
-    const validation = validateEventForm(updated);
-    setErrors(validation);
+  const setField = (key: keyof BasicEventFormFields, value: string | number) => {
+    patchAndValidate({ [key]: value } as Partial<BasicEventFormFields>);
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -36,8 +35,7 @@ export const useBasicEventForm = (initialData?: Partial<CreateEventAPIRequest>) 
     const parsedValue = type === 'number' ? Number(value) : value;
     const key = name as keyof BasicEventFormFields;
 
-    handleValueChange(key, parsedValue);
-    validateField(key, parsedValue);
+    patchAndValidate({ [key]: parsedValue } as Partial<BasicEventFormFields>);
   };
 
   const isValid = useMemo(() => {
@@ -57,18 +55,12 @@ export const useBasicEventForm = (initialData?: Partial<CreateEventAPIRequest>) 
   }, [basicEventForm, errors]);
 
   const loadFormData = (data: Partial<CreateEventAPIRequest>) => {
-    setBasicEventForm((prev) => {
-      const merged = { ...prev, ...data } as BasicEventFormFields;
-      const validation = validateEventForm(merged);
-      setErrors(validation);
-      return merged;
-    });
+    patchAndValidate(data as Partial<BasicEventFormFields>);
   };
 
   return {
     basicEventForm,
-    handleValueChange,
-    validateField,
+    setField,
     handleChange,
     isValid,
     errors,

--- a/client/src/features/Event/New/hooks/useBasicEventForm.ts
+++ b/client/src/features/Event/New/hooks/useBasicEventForm.ts
@@ -26,10 +26,6 @@ export const useBasicEventForm = (initialData?: Partial<CreateEventAPIRequest>) 
     });
   };
 
-  const setField = (key: keyof BasicEventFormFields, value: string | number) => {
-    patchAndValidate({ [key]: value } as Partial<BasicEventFormFields>);
-  };
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value, type } = e.target;
     const parsedValue = type === 'number' ? Number(value) : value;
@@ -60,7 +56,7 @@ export const useBasicEventForm = (initialData?: Partial<CreateEventAPIRequest>) 
 
   return {
     basicEventForm,
-    setField,
+    patchAndValidate,
     handleChange,
     isValid,
     errors,


### PR DESCRIPTION
## 관련 이슈

close #573 

## ✨ 작업 내용

- 이벤트 시작·종료를 하나의 날짜 범위 입력으로 합치면서, 입력 직후 유효성 에러가 잠시 남아있다가 새로고침/다른 필드 변경 시에 사라지는 현상이 발생해 해결했습니다.
- 기존 구조는 값 변경(`handleValueChange`) 과 검증(`validateField`) 이 분리되어 서로 다른 렌더 사이클에서 실행될 수 있었는데, 이 과정에서 에러 잔상이 발생했던 것으로 추정되어 `patchAndValidate`를 만들어 값 변경과 유효성 검사를 한꺼번에 수행하도록 수정했습니다.
- 외부에서도 `handleValueChange`와 `validateField`를 둘 다 호츌할 필요 없이, `patchAndValidate` 하나만 호출하면 되도록 변경되었습니다.

## 🙏 기타 참고 사항

[ 문제 상황 ]

https://github.com/user-attachments/assets/ee58e2c9-2e05-4cbb-a396-5007ad8e1d65

[ 해결 후 ]

https://github.com/user-attachments/assets/eacf5a27-fbe7-4dd1-b9d7-c14981fbd645
