### PR TITLE
[FE] 모든 navigate 점검 및 수정

### DIFF
--- a/client/src/__test__/MyEventPage.test.tsx
+++ b/client/src/__test__/MyEventPage.test.tsx
@@ -34,8 +34,8 @@ describe('MyEventPage 테스트', () => {
 
       render(
         <RouterWithQueryClient
-          initialRoute="/event/my"
-          routes={[{ path: '/event/my', element: <MyEventPage /> }]}
+          initialRoute="/1/event/my"
+          routes={[{ path: '/:organizationId/event/my', element: <MyEventPage /> }]}
         />
       );
 
@@ -59,8 +59,8 @@ describe('MyEventPage 테스트', () => {
 
       render(
         <RouterWithQueryClient
-          initialRoute="/event/my"
-          routes={[{ path: '/event/my', element: <MyEventPage /> }]}
+          initialRoute="/1/event/my"
+          routes={[{ path: '/:organizationId/event/my', element: <MyEventPage /> }]}
         />
       );
 
@@ -90,8 +90,8 @@ describe('MyEventPage 테스트', () => {
 
       render(
         <RouterWithQueryClient
-          initialRoute="/event/my"
-          routes={[{ path: '/event/my', element: <MyEventPage /> }]}
+          initialRoute="/1/event/my"
+          routes={[{ path: '/:organizationId/event/my', element: <MyEventPage /> }]}
         />
       );
 

--- a/client/src/__test__/OverviewPage.test.tsx
+++ b/client/src/__test__/OverviewPage.test.tsx
@@ -18,8 +18,8 @@ const mockFetcher = vi.mocked(fetcher);
 const renderOverviewPage = () => {
   render(
     <RouterWithQueryClient
-      initialRoute="/event?organizationId=1"
-      routes={[{ path: '/event', element: <OverviewPage /> }]}
+      initialRoute="/1/event"
+      routes={[{ path: '/:organizationId/event', element: <OverviewPage /> }]}
     />
   );
 };

--- a/client/src/__test__/customRender.tsx
+++ b/client/src/__test__/customRender.tsx
@@ -34,7 +34,6 @@ export const RouterWithQueryClient = ({
       <QueryClientProviderWrapper queryClient={queryClient}>
         <MemoryRouter initialEntries={[initialRoute]}>
           <ToastProvider>
-            ev
             <Routes>
               {routes.map((route, index) => (
                 <Route key={index} path={route.path} element={route.element} />

--- a/client/src/features/Error/pages/ErrorPage.tsx
+++ b/client/src/features/Error/pages/ErrorPage.tsx
@@ -22,7 +22,7 @@ export const ErrorPage = () => {
             <Icon
               name="logo"
               size={55}
-              onClick={() => navigate('/event')}
+              onClick={() => navigate(`/`)}
               css={css`
                 cursor: pointer;
               `}

--- a/client/src/features/Event/Detail/components/info/EventHeader.tsx
+++ b/client/src/features/Event/Detail/components/info/EventHeader.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { useEventNotificationToggle } from '@/api/mutations/useEventNotificationToggle';
 import { Badge } from '@/shared/components/Badge';
@@ -28,6 +28,7 @@ export const EventHeader = ({
   registrationEnd,
 }: EventHeaderProps) => {
   const navigate = useNavigate();
+  const { organizationId } = useParams();
   const status = badgeText(registrationEnd);
 
   const { optOut, optIn, isLoading, data } = useEventNotificationToggle(eventId);
@@ -65,7 +66,7 @@ export const EventHeader = ({
         <Button
           color="secondary"
           variant="outline"
-          onClick={() => navigate(`/event/edit/${eventId}`)}
+          onClick={() => navigate(`/${organizationId}/event/edit/${eventId}`)}
         >
           수정
         </Button>

--- a/client/src/features/Event/Detail/pages/EventDetailPage.tsx
+++ b/client/src/features/Event/Detail/pages/EventDetailPage.tsx
@@ -20,8 +20,6 @@ import { EventDetailContainer } from '../containers/EventDetailContainer';
 export const EventDetailPage = () => {
   const navigate = useNavigate();
   const { eventId, organizationId } = useParams();
-  console.log('organizationId', organizationId);
-  console.log('eventId', eventId);
   const [
     { data: event },
     { data: guestStatus, isError: guestStatusError, error: guestStatusErrorData },

--- a/client/src/features/Event/Detail/pages/EventDetailPage.tsx
+++ b/client/src/features/Event/Detail/pages/EventDetailPage.tsx
@@ -19,7 +19,9 @@ import { EventDetailContainer } from '../containers/EventDetailContainer';
 
 export const EventDetailPage = () => {
   const navigate = useNavigate();
-  const { eventId } = useParams();
+  const { eventId, organizationId } = useParams();
+  console.log('organizationId', organizationId);
+  console.log('eventId', eventId);
   const [
     { data: event },
     { data: guestStatus, isError: guestStatusError, error: guestStatusErrorData },
@@ -58,14 +60,14 @@ export const EventDetailPage = () => {
             <Icon
               name="logo"
               size={55}
-              onClick={() => navigate('/event')}
+              onClick={() => navigate(`/${organizationId}/event`)}
               css={css`
                 cursor: pointer;
               `}
             />
           }
           right={
-            <Button size="sm" onClick={() => navigate('/event/my')}>
+            <Button size="sm" onClick={() => navigate(`/${organizationId}/event/my`)}>
               내 이벤트
             </Button>
           }

--- a/client/src/features/Event/Manage/pages/EventManagePage.tsx
+++ b/client/src/features/Event/Manage/pages/EventManagePage.tsx
@@ -28,12 +28,11 @@ import { EventManageContainer } from '../containers/EventManageContainer';
 
 export const EventManagePage = () => {
   const navigate = useNavigate();
-  const { eventId: eventIdParam } = useParams();
+  const { eventId: eventIdParam, organizationId } = useParams();
   const eventId = Number(eventIdParam);
   const { success, error } = useToast();
   const { isOpen, open, close } = useModal();
   const { data: event, refetch } = useQuery(eventQueryOptions.detail(eventId));
-
   const [{ data: profile }, { data: statistics = [] }] = useSuspenseQueries({
     queries: [profileQueryOptions.profile(), eventQueryOptions.statistic(eventId)],
   });
@@ -74,7 +73,7 @@ export const EventManagePage = () => {
               />
             }
             right={
-              <Button size="sm" onClick={() => navigate('/event/my')}>
+              <Button size="sm" onClick={() => navigate(`/${organizationId}/event/my`)}>
                 내 이벤트
               </Button>
             }

--- a/client/src/features/Event/Manage/pages/EventManagePage.tsx
+++ b/client/src/features/Event/Manage/pages/EventManagePage.tsx
@@ -66,7 +66,7 @@ export const EventManagePage = () => {
               <Icon
                 name="logo"
                 size={55}
-                onClick={() => navigate('/event')}
+                onClick={() => navigate(`/${organizationId}/event`)}
                 css={css`
                   cursor: pointer;
                 `}

--- a/client/src/features/Event/My/components/EventTabs.tsx
+++ b/client/src/features/Event/My/components/EventTabs.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
 
 import { myQueryOptions } from '@/api/queries/my';
 import { Flex } from '@/shared/components/Flex';
@@ -13,13 +14,14 @@ import { EventSection } from './EventSection';
 import { EventTabsList } from './EventTabsList';
 
 export const EventTabs = () => {
-  // E.TODO: organizationMemberId를 실제로 가져오는 로직 필요
-  const organizationMemberId = 1; // 임시 값
+  const { organizationId } = useParams();
 
-  const { data: hostEvents = [] } = useQuery(myQueryOptions.event.hostEvents(organizationMemberId));
+  const { data: hostEvents = [] } = useQuery(
+    myQueryOptions.event.hostEvents(Number(organizationId))
+  );
 
   const { data: participateEvents = [] } = useQuery(
-    myQueryOptions.event.participateEvents(organizationMemberId)
+    myQueryOptions.event.participateEvents(Number(organizationId))
   );
 
   const groupedHostEvents = groupEventsByDate(hostEvents);

--- a/client/src/features/Event/My/components/Info.tsx
+++ b/client/src/features/Event/My/components/Info.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
@@ -7,7 +7,7 @@ import { Text } from '@/shared/components/Text';
 
 export const Info = () => {
   const navigate = useNavigate();
-
+  const { organizationId } = useParams();
   return (
     <Flex
       dir="row"
@@ -33,7 +33,7 @@ export const Info = () => {
           내가 주최하고, 참여한 이벤트를 확인해보세요.
         </Text>
       </Flex>
-      <Button size="md" variant="outline" onClick={() => navigate('/event/new')}>
+      <Button size="md" variant="outline" onClick={() => navigate(`/${organizationId}/event/new`)}>
         + 이벤트 만들기
       </Button>
     </Flex>

--- a/client/src/features/Event/My/pages/MyEventPage.tsx
+++ b/client/src/features/Event/My/pages/MyEventPage.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button } from '@/shared/components/Button';
 import { Header } from '@/shared/components/Header';
@@ -12,7 +12,7 @@ import { MyEventContainer } from '../containers/MyEventContainer';
 
 export const MyEventPage = () => {
   const navigate = useNavigate();
-
+  const { organizationId } = useParams();
   return (
     <PageLayout
       header={
@@ -28,7 +28,7 @@ export const MyEventPage = () => {
             />
           }
           right={
-            <Button size="sm" onClick={() => navigate('/event/my')}>
+            <Button size="sm" onClick={() => navigate(`/${organizationId}/event/my`)}>
               내 이벤트
             </Button>
           }

--- a/client/src/features/Event/My/pages/MyEventPage.tsx
+++ b/client/src/features/Event/My/pages/MyEventPage.tsx
@@ -21,7 +21,7 @@ export const MyEventPage = () => {
             <Icon
               name="logo"
               size={55}
-              onClick={() => navigate('/event')}
+              onClick={() => navigate(`/${organizationId}/event`)}
               css={css`
                 cursor: pointer;
               `}

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -41,8 +41,6 @@ import { MyPastEventModal } from './MyPastEventModal';
 import { QuestionForm } from './QuestionForm';
 import { TemplateDropdown } from './TemplateDropdown';
 
-const ORGANIZATION_ID = 1; // 임시
-
 type EventCreateFormProps = {
   isEdit: boolean;
   eventId?: number;
@@ -52,7 +50,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
   const navigate = useNavigate();
   const { organizationId } = useParams();
   const { success, error } = useToast();
-  const { mutate: addEvent } = useAddEvent(ORGANIZATION_ID);
+  const { mutate: addEvent } = useAddEvent(Number(organizationId));
   const { mutate: updateEvent } = useUpdateEvent();
   const { mutate: addTemplate } = useAddTemplate();
 

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import { css } from '@emotion/react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { HttpError } from '@/api/fetcher';
 import { useAddTemplate } from '@/api/mutations/useAddTemplate';
@@ -50,6 +50,7 @@ type EventCreateFormProps = {
 
 export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
   const navigate = useNavigate();
+  const { organizationId } = useParams();
   const { success, error } = useToast();
   const { mutate: addEvent } = useAddEvent(ORGANIZATION_ID);
   const { mutate: updateEvent } = useUpdateEvent();
@@ -93,6 +94,9 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
 
   const isFormReady = isBasicFormValid && isQuestionValid;
 
+  console.log('isFormReady', isFormReady);
+  console.log('isBasicFormValid', isBasicFormValid);
+  console.log('isQuestionValid', isQuestionValid);
   const handleTemplateSelected = (
     templateDetail: Pick<TemplateDetailAPIResponse, 'description'>
   ) => {
@@ -158,7 +162,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
         clear();
         trackCreateEvent();
         success('😁 이벤트가 성공적으로 생성되었습니다!');
-        navigate(`/event/${eventId}`);
+        navigate(`/${organizationId}/event/${eventId}`);
       },
       onError: handleError,
     });
@@ -171,7 +175,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
         onSuccess: () => {
           clear();
           success('😁 이벤트가 성공적으로 수정되었습니다!');
-          navigate(`/event/${eventId}`);
+          navigate(`/${organizationId}/event/${eventId}`);
         },
         onError: handleError,
       }

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -94,9 +94,6 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
 
   const isFormReady = isBasicFormValid && isQuestionValid;
 
-  console.log('isFormReady', isFormReady);
-  console.log('isBasicFormValid', isBasicFormValid);
-  console.log('isQuestionValid', isQuestionValid);
   const handleTemplateSelected = (
     templateDetail: Pick<TemplateDetailAPIResponse, 'description'>
   ) => {

--- a/client/src/features/Event/New/pages/NewEventPage.tsx
+++ b/client/src/features/Event/New/pages/NewEventPage.tsx
@@ -11,7 +11,7 @@ import { EventCreateForm } from '../components/EventCreateForm';
 
 export const NewEventPage = () => {
   const navigate = useNavigate();
-  const { eventId } = useParams();
+  const { eventId, organizationId } = useParams();
   const isEdit = !!eventId;
 
   return (
@@ -29,7 +29,7 @@ export const NewEventPage = () => {
             />
           }
           right={
-            <Button size="sm" onClick={() => navigate('/event/my')}>
+            <Button size="sm" onClick={() => navigate(`/${organizationId}/event/my`)}>
               내 이벤트
             </Button>
           }

--- a/client/src/features/Event/New/pages/NewEventPage.tsx
+++ b/client/src/features/Event/New/pages/NewEventPage.tsx
@@ -22,7 +22,7 @@ export const NewEventPage = () => {
             <Icon
               name="logo"
               size={55}
-              onClick={() => navigate('/event')}
+              onClick={() => navigate(`/${organizationId}/event`)}
               css={css`
                 cursor: pointer;
               `}

--- a/client/src/features/Event/Overview/components/ActionButtons.tsx
+++ b/client/src/features/Event/Overview/components/ActionButtons.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
@@ -9,14 +9,14 @@ type ActionButtonsProps = {
 };
 export const ActionButtons = ({ onIssueInviteCode }: ActionButtonsProps) => {
   const navigate = useNavigate();
-
+  const { organizationId } = useParams();
   return (
     <>
       <DesktopButtonContainer>
         <Button size="md" iconName="share" onClick={onIssueInviteCode}>
           조직 초대
         </Button>
-        <Button size="md" iconName="plus" onClick={() => navigate('/event/new')}>
+        <Button size="md" iconName="plus" onClick={() => navigate(`/${organizationId}/event/new`)}>
           이벤트 생성
         </Button>
       </DesktopButtonContainer>

--- a/client/src/features/Event/Overview/pages/OverviewPage.tsx
+++ b/client/src/features/Event/Overview/pages/OverviewPage.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { organizationQueryOptions } from '@/api/queries/organization';
 import { Button } from '@/shared/components/Button';
@@ -13,10 +13,7 @@ import { OrganizationInfo } from '../components/OrganizationInfo';
 
 export const OverviewPage = () => {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-
-  const orgIdParam = searchParams.get('organizationId');
-  const organizationId = orgIdParam ? Number(orgIdParam) : undefined;
+  const { organizationId } = useParams();
 
   const { data: organizationData } = useQuery({
     ...organizationQueryOptions.organizations(String(organizationId ?? '')),
@@ -24,12 +21,12 @@ export const OverviewPage = () => {
   });
 
   const { data: eventData } = useQuery({
-    ...organizationQueryOptions.event(organizationId as number),
+    ...organizationQueryOptions.event(Number(organizationId)),
     enabled: !!organizationId,
   });
 
-  const goMyEvents = () => navigate(`/event/my?organizationId=${organizationId ?? ''}`);
-  const goHome = () => navigate(`/event?organizationId=${organizationId ?? ''}`);
+  const goMyEvents = () => navigate(`/${organizationId}/event/my`);
+  const goHome = () => navigate(`/${organizationId}/event`);
 
   // S.TODO 로딩 처리
 

--- a/client/src/features/Event/components/EventCard/EventCard.tsx
+++ b/client/src/features/Event/components/EventCard/EventCard.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Badge } from '@/shared/components/Badge';
 import { Flex } from '@/shared/components/Flex';
@@ -37,7 +37,7 @@ export const EventCard = ({
   cardType = 'default',
 }: EventCardProps) => {
   const navigate = useNavigate();
-
+  const { organizationId } = useParams();
   const { isUnlimited, progressValue, progressMax } = calculateCapacityStatus(
     maxCapacity,
     currentGuestCount
@@ -47,9 +47,9 @@ export const EventCard = ({
     trackClickEventCard(title);
 
     if (cardType === 'host') {
-      navigate(`/event/manage/${eventId}`);
+      navigate(`/${organizationId}/event/manage/${eventId}`);
     } else {
-      navigate(`/event/${eventId}`);
+      navigate(`/${organizationId}/event/${eventId}`);
     }
   };
 

--- a/client/src/features/Home/components/Info.tsx
+++ b/client/src/features/Home/components/Info.tsx
@@ -1,10 +1,8 @@
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { isAuthenticated } from '@/api/auth';
-import { organizationQueryOptions } from '@/api/queries/organization';
 import Ahmadda from '@/assets/icon/ahmadda.webp';
 import Point from '@/assets/icon/point.webp';
 import { Button } from '@/shared/components/Button';
@@ -22,12 +20,6 @@ export const Info = () => {
   const { isOpen, open, close } = useModal();
   const navigate = useNavigate();
 
-  //E.TODO 추후 organizationId 받아오기
-  const { data: profileData } = useQuery({
-    ...organizationQueryOptions.profile(1),
-    enabled: isAuthenticated(),
-  });
-
   const handelGuideOpenClick = () => {
     if (!isAuthenticated()) {
       error(`로그인이 필요한 서비스입니다.\n먼저 로그인해 주세요.`, {
@@ -39,10 +31,7 @@ export const Info = () => {
   };
 
   const handleEnterClick = () => {
-    if (profileData?.nickname) {
-      navigate('/organization');
-      return;
-    }
+    navigate(`/organization`);
   };
 
   return (

--- a/client/src/features/Home/page/HomePage.tsx
+++ b/client/src/features/Home/page/HomePage.tsx
@@ -44,7 +44,7 @@ export const HomePage = () => {
               <Icon
                 name="logo"
                 size={55}
-                onClick={() => navigate('/event')}
+                onClick={() => navigate(`/`)}
                 css={css`
                   cursor: pointer;
                 `}

--- a/client/src/features/Invite/component/InviteModal.tsx
+++ b/client/src/features/Invite/component/InviteModal.tsx
@@ -52,7 +52,10 @@ export const InviteModal = () => {
           </Flex>
 
           <Flex dir="column" alignItems="center">
-            <OrganizationInfo name={organizationData?.name ?? ''} />
+            <OrganizationInfo
+              name={organizationData?.name ?? ''}
+              imageUrl={organizationData?.imageUrl ?? ''}
+            />
             <Input
               autoFocus
               id="nickname"

--- a/client/src/features/Invite/hooks/useInviteOrganizationProcess.tsx
+++ b/client/src/features/Invite/hooks/useInviteOrganizationProcess.tsx
@@ -44,7 +44,7 @@ export const useInviteOrganizationProcess = () => {
         onSuccess: () => {
           success('조직 참가가 완료되었습니다!');
           close();
-          navigate(`/event?organizationId=${organizationData?.organizationId}`);
+          navigate(`/${organizationData?.organizationId}/event`);
         },
         onError: (err) => {
           error(err.message, { duration: 3000 });

--- a/client/src/features/Invite/hooks/useInviteOrganizationProcess.tsx
+++ b/client/src/features/Invite/hooks/useInviteOrganizationProcess.tsx
@@ -49,7 +49,7 @@ export const useInviteOrganizationProcess = () => {
         onError: (err) => {
           error(err.message, { duration: 3000 });
           if (err.message === '이미 참여한 조직입니다.') {
-            navigate(`/event?organizationId=${organizationData?.organizationId}`);
+            navigate(`/${organizationData?.organizationId}/event`);
             return;
           }
           navigate('/');

--- a/client/src/features/Organization/New/components/OrganizationCreateForm.tsx
+++ b/client/src/features/Organization/New/components/OrganizationCreateForm.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
 import { Input } from '@/shared/components/Input';
 import { Text } from '@/shared/components/Text';
+import { Textarea } from '@/shared/components/Textarea';
 import { useModal } from '@/shared/hooks/useModal';
 
 import { MAX_LENGTH } from '../constants/validationRules';
@@ -153,11 +154,9 @@ export const OrganizationCreateForm = () => {
           </Flex>
 
           <Flex dir="column" gap="12px">
-            <label htmlFor="orgName">
-              <Text type="Heading" weight="medium">
-                조직 이름
-              </Text>
-            </label>
+            <Text as="label" htmlFor="orgName" type="Heading" weight="medium">
+              조직 이름
+            </Text>
             <Input
               id="orgName"
               name="name"
@@ -172,21 +171,17 @@ export const OrganizationCreateForm = () => {
           </Flex>
 
           <Flex dir="column" gap="12px">
-            <label htmlFor="orgDescription">
-              <Text type="Heading" weight="medium">
-                한 줄 소개
-              </Text>
-            </label>
-            <Input
+            <Text as="label" htmlFor="orgDescription" type="Heading" weight="medium">
+              한 줄 소개
+            </Text>
+            <Textarea
               id="orgDescription"
               name="description"
               placeholder="조직을 소개해주세요."
               value={form.description}
               onChange={handleChange}
               errorMessage={errors.description}
-              showCounter
               maxLength={MAX_LENGTH.DESCRIPTION}
-              isRequired
             />
           </Flex>
 

--- a/client/src/features/Organization/New/components/OrganizationCreateForm.tsx
+++ b/client/src/features/Organization/New/components/OrganizationCreateForm.tsx
@@ -12,7 +12,6 @@ import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
 import { Input } from '@/shared/components/Input';
 import { Text } from '@/shared/components/Text';
-import { Textarea } from '@/shared/components/Textarea';
 import { useModal } from '@/shared/hooks/useModal';
 
 import { MAX_LENGTH } from '../constants/validationRules';
@@ -92,7 +91,7 @@ export const OrganizationCreateForm = () => {
 
   const isSubmitting = isEdit ? isPatching : isCreating;
 
-  const onSubmit = (e: React.FormEvent) => {
+  const handleEditButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     if (!isValid()) return;
 
@@ -110,7 +109,7 @@ export const OrganizationCreateForm = () => {
         },
         {
           onSuccess: () => {
-            navigate(`/event?organizationId=${organizationId}`);
+            navigate(`/${organizationId}/event`);
           },
         }
       );
@@ -127,7 +126,7 @@ export const OrganizationCreateForm = () => {
   };
 
   return (
-    <form onSubmit={onSubmit}>
+    <>
       <Flex dir="column" padding="60px 0" gap="40px">
         <Flex padding="40px 0">
           <Text as="h1" type="Display" weight="bold">
@@ -174,18 +173,26 @@ export const OrganizationCreateForm = () => {
             <Text as="label" htmlFor="orgDescription" type="Heading" weight="medium">
               한 줄 소개
             </Text>
-            <Textarea
+            <Input
               id="orgDescription"
               name="description"
               placeholder="조직을 소개해주세요."
               value={form.description}
               onChange={handleChange}
               errorMessage={errors.description}
+              showCounter
               maxLength={MAX_LENGTH.DESCRIPTION}
+              isRequired
             />
           </Flex>
 
-          <Button type="submit" color="primary" size="full" disabled={!isValid() || isSubmitting}>
+          <Button
+            type="submit"
+            color="primary"
+            size="full"
+            disabled={!isValid() || isSubmitting}
+            onClick={handleEditButtonClick}
+          >
             {isEdit ? '조직 수정하기' : '조직 생성하기'}
           </Button>
         </Flex>
@@ -201,6 +208,6 @@ export const OrganizationCreateForm = () => {
           onConfirm={handleConfirmNickname}
         />
       )}
-    </form>
+    </>
   );
 };

--- a/client/src/features/Organization/New/pages/NewOrganizationPage.tsx
+++ b/client/src/features/Organization/New/pages/NewOrganizationPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
@@ -10,14 +10,20 @@ import { OrganizationCreateForm } from '../components/OrganizationCreateForm';
 
 export const NewOrganizationPage = () => {
   const navigate = useNavigate();
-
+  const { organizationId } = useParams();
   return (
     <PageLayout
       header={
         <Header
-          left={<IconButton name="logo" size={55} onClick={() => navigate('/event')} />}
+          left={
+            <IconButton
+              name="logo"
+              size={55}
+              onClick={() => navigate(`/${organizationId}/event`)}
+            />
+          }
           right={
-            <Button size="sm" onClick={() => navigate('/event/my')}>
+            <Button size="sm" onClick={() => navigate(`/${organizationId}/event/my`)}>
               내 이벤트
             </Button>
           }

--- a/client/src/features/Organization/Select/pages/SelectOrganizationPage.tsx
+++ b/client/src/features/Organization/Select/pages/SelectOrganizationPage.tsx
@@ -1,11 +1,8 @@
-import { Suspense } from 'react';
-
 import { css } from '@emotion/react';
 import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { organizationQueryOptions } from '@/api/queries/organization';
-import { ErrorPage } from '@/features/Error/pages/ErrorPage';
 import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
 import { Header } from '@/shared/components/Header';
@@ -50,9 +47,7 @@ export const OrganizationSelectPage = () => {
         />
       }
     >
-      <Suspense fallback={<ErrorPage />}>
-        <OrganizationSelectBody />
-      </Suspense>
+      <OrganizationSelectBody />
     </PageLayout>
   );
 };
@@ -79,7 +74,7 @@ const OrganizationSelectBody = () => {
     isAdmin: profileQueries[idx]?.data?.isAdmin ?? org.isAdmin,
   }));
 
-  const handleJoin = (orgId: number) => navigate(`/event?organizationId=${orgId}`);
+  const handleJoin = (orgId: number) => navigate(`/${orgId}/event`);
   const handleEdit = (orgId: number) => navigate(`/organization/edit/${orgId}`);
 
   return (

--- a/client/src/features/Organization/Select/pages/SelectOrganizationPage.tsx
+++ b/client/src/features/Organization/Select/pages/SelectOrganizationPage.tsx
@@ -24,7 +24,6 @@ const MOBILE_ROW_HEIGHT = 250;
 
 export const OrganizationSelectPage = () => {
   const navigate = useNavigate();
-
   return (
     <PageLayout
       header={
@@ -33,7 +32,7 @@ export const OrganizationSelectPage = () => {
             <Icon
               name="logo"
               size={55}
-              onClick={() => navigate('/event')}
+              onClick={() => navigate(`/`)}
               css={css`
                 cursor: pointer;
               `}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -31,11 +31,9 @@ if (GA_ID) {
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <ClientQueryProvider>
-      <ThemeProvider theme={theme}>
-        <RouterProvider router={router} />
-      </ThemeProvider>
-    </ClientQueryProvider>
-  </React.StrictMode>
+  <ClientQueryProvider>
+    <ThemeProvider theme={theme}>
+      <RouterProvider router={router} />
+    </ThemeProvider>
+  </ClientQueryProvider>
 );

--- a/client/src/router/route.tsx
+++ b/client/src/router/route.tsx
@@ -34,7 +34,7 @@ export const router = createBrowserRouter(
           Component: AuthCallback,
         },
         {
-          path: '/event',
+          path: '/:organizationId/event',
           Component: ProtectRoute,
           children: [
             {


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #612 

## ✨ 작업 내용

- 모든 navigate를 점검하였습니다!
- useParams를 덕지덕지 붙여놨는데, 추후 수정을 꼭 약속드립니다..!!
- route에서 /event 주소를 /organizationId/event로 바꾸었습니다!
- 서버 선생님들이 로그인 api를 자꾸 두번치는 것이 문제라고 말씀해주셔서 저희의 StrictMode를 꺼두었습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 이벤트 관련 경로가 조직 단위로 변경되어 /:organizationId/event 아래에서 모든 이벤트 페이지를 이용할 수 있습니다. 여러 컴포넌트의 내비게이션이 조직 컨텍스트를 반영하도록 업데이트되었습니다.
- Refactor
  - 조직 선택 페이지의 Suspense 기반 로딩/에러 경계 제거로 로딩 처리 방식이 변경되었습니다.
  - 최상위 StrictMode 제거.
- Chores
  - 홈/에러 페이지 로고 및 진입 버튼 경로 조정(루트 및 /organization 고정).
- Tests
  - 테스트 라우팅을 쿼리에서 경로 기반 organizationId로 전환 및 불필요 텍스트 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->