### PR TITLE
[FE] 이벤트 수정하기 버튼 disabled 문제 해결

### DIFF
--- a/client/src/features/Event/New/utils/validateEventForm.ts
+++ b/client/src/features/Event/New/utils/validateEventForm.ts
@@ -10,14 +10,15 @@ export const validateEventForm = (
 
   const startStr = (formData.eventStart ?? '').toString().trim();
   const endStr = (formData.eventEnd ?? '').toString().trim();
-  const bothDateEmpty = !startStr && !endStr;
+  const bothDateFilled = Boolean(startStr && endStr);
 
-  (Object.keys(FIELD_CONFIG) as Array<keyof BasicEventFormFields>).forEach((key) => {
-    if ((key === 'eventStart' || key === 'eventEnd') && bothDateEmpty) return;
+  (Object.keys(FIELD_CONFIG) as (keyof typeof FIELD_CONFIG)[]).forEach((key) => {
+    if ((key === 'eventStart' || key === 'eventEnd' || key === 'registrationEnd') && bothDateFilled)
+      return;
 
     const msg = getErrorMessage(
       key as keyof CreateEventAPIRequest,
-      String(formData[key] ?? ''),
+      String(formData[key] ?? '').trim(),
       formData
     );
     if (msg) newErrors[key] = msg;


### PR DESCRIPTION
## 관련 이슈

close #615 

## ✨ 작업 내용

- 수정 페이지 진입 시 이벤트 수정 버튼이 간헐적으로 disabled 되던 문제를 수정했습니다.
- 기간 입력을 하나로 합쳤지만 검증은 eventStart/eventEnd를 각각 필수로 체크해 중간 상태에서 잔여 에러가 남던 이슈였습니다.
- validateEventForm에서 두 값이 모두 비어있을 때는 검증을 스킵하도록 변경 → 잔여 에러 제거


## 🙏 기타 참고 사항

https://github.com/user-attachments/assets/16812727-89d8-4d2f-a792-b55024e7177a


### 일부 코드 설명
```tsx
// 둘 다 비어있을 땐 초기 상태로 간주 → 개별 required 에러 미생성
if ((key === 'eventStart' || key === 'eventEnd') && bothDateEmpty) return;

const msg = getErrorMessage(
      key as keyof CreateEventAPIRequest,
      // getErrorMessage가 string을 기대하므로 안전하게 문자열로 변환
      String(formData[key] ?? ''),
      formData
    );

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 검증 대상을 설정된 필드(FIELD_CONFIG)로 제한해 불필요한 오류 경고를 줄였습니다.
  * 시작/종료 일시가 모두 채워진 경우 관련 날짜 필드 검증을 건너뛰어 중복 오류를 방지합니다.
  * 값 추출 및 타입 처리를 개선해 문자열·숫자 입력에 대한 오류 메시지의 정확성과 일관성을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->