### PR TITLE
[FE] 이벤트 제목 입력 시 시간에도 에러 메시지 뜨는 문제

### DIFF
--- a/client/src/features/Event/New/hooks/useBasicEventForm.ts
+++ b/client/src/features/Event/New/hooks/useBasicEventForm.ts
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState } from 'react';
 
 import { BasicEventFormFields, CreateEventAPIRequest } from '../../types/Event';
 import { FIELD_CONFIG } from '../constants/formFieldConfig';
+import { computeEverNonEmpty, isProvided } from '../utils/fieldPresence';
 import { validateEventForm } from '../utils/validateEventForm';
 
 const makeInitialForm = (initialData?: Partial<CreateEventAPIRequest>): BasicEventFormFields => ({
@@ -14,20 +15,6 @@ const makeInitialForm = (initialData?: Partial<CreateEventAPIRequest>): BasicEve
   maxCapacity: 10,
   ...initialData,
 });
-
-const isProvided = (v: unknown): boolean => {
-  if (v === null || v === undefined) return false;
-  if (typeof v === 'string') return v.trim() !== '';
-  return true;
-};
-
-const computeEverNonEmpty = (form: BasicEventFormFields) => {
-  const map: Partial<Record<keyof BasicEventFormFields, boolean>> = {};
-  (Object.keys(form) as (keyof BasicEventFormFields)[]).forEach((k) => {
-    map[k] = isProvided(form[k]);
-  });
-  return map;
-};
 
 export const useBasicEventForm = (initialData?: Partial<CreateEventAPIRequest>) => {
   const initialForm = makeInitialForm(initialData);

--- a/client/src/features/Event/New/utils/fieldPresence.ts
+++ b/client/src/features/Event/New/utils/fieldPresence.ts
@@ -1,0 +1,13 @@
+export const isProvided = (v: unknown): boolean => {
+  if (v == null) return false;
+  if (typeof v === 'string') return v.trim() !== '';
+  return true;
+};
+
+export const computeEverNonEmpty = <T extends Record<string, unknown>>(form: T) => {
+  const map: Partial<Record<keyof T, boolean>> = {};
+  (Object.keys(form) as Array<keyof T>).forEach((k) => {
+    map[k] = isProvided(form[k]);
+  });
+  return map;
+};


### PR DESCRIPTION
## 관련 이슈

close #575 

## ✨ 작업 내용

이벤트 제목 입력 시 시간에도 에러 메시지 뜨는 문제와 폼 진입 시 모든 필수 필드에 에러 메시지가 뜨는 문제를 해결하였습니다.

### 문제 원인

매 입력마다 `validateEventForm`로 전체 필드를 검증하고 있어서,
아직 건드리지 않은 필수 필드도 빈 값으로 인식하여 현재 입력 중인 필드 외에 다른 필드의 에러 메시지까지 같이 보여졌습니다.

### 해결 방법

`everNonEmptyRef`를 도입해서 한 번도 건드리지 않은 필드에는 에러를 표시하지 않도록 하였습니다.

## 🙏 기타 참고 사항

https://github.com/user-attachments/assets/5be313dc-6e64-48ab-ad73-51fd92f7ca82





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 폼 데이터 불러오기 기능 추가로 외부/기존 값이 즉시 폼에 반영됩니다.
  - 입력 이력 추적 도입으로 한 번이라도 입력된 필드는 이후에도 상태를 인식합니다.

- 버그 수정
  - 오류 메시지 노출 로직 개선: 아직 입력하지 않은(빈 값이며 한 번도 입력된 적 없는) 필드는 경고를 숨깁니다.
  - 입력 변경 시 검증 흐름을 일관화해 잘못된 오류 표시를 감소시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->