### PR TITLE
[BE] 요청 속도 제한 필터 구조 개선 및 책임 분리 

### DIFF
--- a/server/src/main/java/com/ahmadda/presentation/filter/SlidingWindowRateLimitFilter.java
+++ b/server/src/main/java/com/ahmadda/presentation/filter/SlidingWindowRateLimitFilter.java
@@ -69,7 +69,7 @@ public class SlidingWindowRateLimitFilter extends OncePerRequestFilter {
                         removeExpiredTimestamps(timestamps, now);
 
                         if (timestamps.size() >= MAX_REQUESTS) {
-                            long retryAfterSeconds = calculateRetryAfterSeconds(timestamps, now);
+                            long retryAfterSeconds = calculateRetryAfterSeconds(timestamps, now, id);
 
                             return new RateLimitResult(timestamps, true, retryAfterSeconds);
                         }
@@ -120,8 +120,13 @@ public class SlidingWindowRateLimitFilter extends OncePerRequestFilter {
      * @param now        현재 시각 (System.nanoTime() 기준)
      * @return 다음 요청이 허용되기까지 남은 시간 (초). 최소 1초 이상으로 보정됨.
      */
-    private long calculateRetryAfterSeconds(final Deque<Long> timestamps, final long now) {
+    private long calculateRetryAfterSeconds(final Deque<Long> timestamps, final long now, final Long memberId) {
         if (timestamps.isEmpty()) {
+            log.warn(
+                    "SlidingWindowRateLimitFilterError: reRetryAfterSeconds를 계산할 때 timestamps가 비어있습니다. 발생시간={}, memberId={}",
+                    now,
+                    memberId
+            );
             return 1;
         }
 

--- a/server/src/main/java/com/ahmadda/presentation/filter/ratelimit/RateLimitExceededHandler.java
+++ b/server/src/main/java/com/ahmadda/presentation/filter/ratelimit/RateLimitExceededHandler.java
@@ -1,0 +1,40 @@
+package com.ahmadda.presentation.filter.ratelimit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimitExceededHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public void handle(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final long retryAfterSeconds
+    ) throws IOException {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.TOO_MANY_REQUESTS);
+        problemDetail.setTitle("Too Many Requests");
+        problemDetail.setDetail("요청이 너무 많습니다. " + retryAfterSeconds + "초 후 다시 시도해 주세요.");
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
+
+        response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfterSeconds));
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(problemDetail));
+    }
+}

--- a/server/src/main/java/com/ahmadda/presentation/filter/ratelimit/SlidingWindowRateLimitFilter.java
+++ b/server/src/main/java/com/ahmadda/presentation/filter/ratelimit/SlidingWindowRateLimitFilter.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class SlidingWindowRateLimitFilter extends OncePerRequestFilter {
 
-    private static final long WINDOW_NANOS = TimeUnit.MILLISECONDS.toNanos(60_000);
+    private static final long WINDOW_NANOS = TimeUnit.SECONDS.toNanos(60);
     private static final int MAX_REQUESTS = 100;
 
     private final HeaderProvider headerProvider;

--- a/server/src/main/java/com/ahmadda/presentation/filter/ratelimit/SlidingWindowRateLimitFilter.java
+++ b/server/src/main/java/com/ahmadda/presentation/filter/ratelimit/SlidingWindowRateLimitFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
@@ -22,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+@Getter
 @Slf4j
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE + 2)
@@ -89,6 +91,7 @@ public class SlidingWindowRateLimitFilter extends OncePerRequestFilter {
         requestLogs.entrySet()
                 .removeIf(entry -> {
                     Deque<Long> timestamps = entry.getValue();
+
                     synchronized (timestamps) {
                         removeExpiredTimestamps(timestamps, now);
 

--- a/server/src/test/java/com/ahmadda/presentation/filter/ratelimit/RateLimitExceededHandlerTest.java
+++ b/server/src/test/java/com/ahmadda/presentation/filter/ratelimit/RateLimitExceededHandlerTest.java
@@ -1,0 +1,54 @@
+package com.ahmadda.presentation.filter.ratelimit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class RateLimitExceededHandlerTest {
+
+    RateLimitExceededHandler handler;
+    MockHttpServletRequest request;
+    MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        var objectMapper = new ObjectMapper();
+        handler = new RateLimitExceededHandler(objectMapper);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    void 응답에_429_상태코드와_RetryAfter헤더_그리고_ProblemDetail본문이_포함된다() throws Exception {
+        // given
+        request.setRequestURI("/api/test");
+
+        // when
+        handler.handle(request, response, 42);
+
+        // then
+        var body = response.getContentAsString();
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.getStatus())
+                    .isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+            softly.assertThat(response.getHeader(HttpHeaders.RETRY_AFTER))
+                    .isEqualTo("42");
+            softly.assertThat(response.getContentType())
+                    .isEqualTo("application/problem+json;charset=UTF-8");
+
+            softly.assertThat(body)
+                    .contains("Too Many Requests");
+            softly.assertThat(body)
+                    .contains("요청이 너무 많습니다");
+            softly.assertThat(body)
+                    .contains("/api/test");
+        });
+    }
+}

--- a/server/src/test/java/com/ahmadda/presentation/filter/ratelimit/SlidingWindowRateLimitFilterTest.java
+++ b/server/src/test/java/com/ahmadda/presentation/filter/ratelimit/SlidingWindowRateLimitFilterTest.java
@@ -1,0 +1,88 @@
+package com.ahmadda.presentation.filter.ratelimit;
+
+import com.ahmadda.infra.login.jwt.JwtProvider;
+import com.ahmadda.infra.login.jwt.dto.JwtMemberPayload;
+import com.ahmadda.presentation.header.HeaderProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class SlidingWindowRateLimitFilterTest {
+
+    SlidingWindowRateLimitFilter filter;
+    JwtProvider jwtProvider;
+    HeaderProvider headerProvider;
+    RateLimitExceededHandler rateLimitExceededHandler;
+
+    MockHttpServletRequest request;
+    MockHttpServletResponse response;
+    FilterChain chain;
+
+    @BeforeEach
+    void setUp() {
+        jwtProvider = mock(JwtProvider.class);
+        headerProvider = mock(HeaderProvider.class);
+        rateLimitExceededHandler = spy(new RateLimitExceededHandler(new ObjectMapper()));
+
+        filter = new SlidingWindowRateLimitFilter(headerProvider, jwtProvider, rateLimitExceededHandler);
+
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        chain = mock(FilterChain.class);
+    }
+
+    @Test
+    void 비회원요청은_제한없이_통과된다() throws Exception {
+        // given
+        request.removeHeader(HttpHeaders.AUTHORIZATION);
+
+        // when
+        filter.doFilterInternal(request, response, chain);
+
+        // then
+        verify(chain).doFilter(request, response);
+        verifyNoInteractions(rateLimitExceededHandler);
+    }
+
+    @Test
+    void 요청횟수_초과시_핸들러가_호출된다() throws Exception {
+        // given
+        var memberId = 1L;
+        var token = "token";
+        var bearerToken = "Bearer " + token;
+
+        request.addHeader(HttpHeaders.AUTHORIZATION, bearerToken);
+        request.setRequestURI("/api/test");
+
+        var payload = mock(JwtMemberPayload.class);
+        when(payload.getMemberId()).thenReturn(memberId);
+        when(headerProvider.extractAccessToken(bearerToken)).thenReturn(token);
+        when(jwtProvider.parseAccessPayload(token)).thenReturn(payload);
+
+        for (int i = 0; i < 100; i++) {
+            filter.doFilterInternal(request, response, chain);
+        }
+
+        // when
+        filter.doFilterInternal(request, response, chain);
+
+        // then
+        verify(rateLimitExceededHandler).handle(
+                eq(request),
+                eq(response),
+                anyLong()
+        );
+    }
+}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #633

## ✨ 작업 내용

- 기존 `SlidingWindowRateLimitFilter`의 복잡한 책임을 분리하여 SRP 준수
  - 요청 제한 응답 생성을 `RateLimitExceededHandler`로 분리
  - 응답 본문을 `ProblemDetail`로 통일해 클라이언트 응답 포맷 명확화
- 시스템 시계(`System.currentTimeMillis`) 의존을 제거하고 `System.nanoTime()` 기반으로 변경
  - 시스템 시간 변경(수동/자동)에 의한 오작동 방지
- stale request 로그를 제거하는 스케줄러(`@Scheduled`) 도입
- 내부 클래스 `RateLimitResult`로 연산 결과 명시화
- 테스트 코드 전면 개선 및 추가

## 🙏 기타 참고 사항

### 1. 기존 requestLogs에서의 Race Condition 예방 및 해결 방식

- 다음 시나리오에서 동기화 문제가 발생할 수 있음:
  - 스레드 A가 `computeIfAbsent`로 Deque를 생성한 직후 아직 `addLast(now)` 이전
  - 스케줄러 스레드 B가 해당 Deque가 비어있다고 판단하고 `requestLogs.remove()` 호출
  - 스레드 A는 여전히 그 Deque를 참조 중이며 `.addLast(now)` 수행 → 로그는 저장되지만 `requestLogs`에는 없음
  - 결과적으로 다음 요청 시 `computeIfAbsent`가 다시 실행되며 Deque 재생성 → 이전 요청 로그 유실

→ 해당 문제는 실제로 다음과 같이 해결함:

- 요청 처리 측에서 Deque 생성을 requestLogs.compute(memberId, ...) 내에서 처리
- 즉, requestLogs는 “생성 + 만료 로그 정리 + 새 로그 기록”이 항상 원자적으로 수행되기에, 스레드 간 경합이 발생해도 로그 유실 없이 일관성이 보장됨

#### 추가 설명: ConcurrentHashMap + synchronized(timestamps)의 조합이 필요한 이유

- ConcurrentHashMap은 맵 자체의 key 단위 접근에 대한 동시성은 보장하지만, value 객체 내부의 상태 변화까지는 보호하지 않음
  - 예를 들어, Deque<Long>의 addLast(now), removeFirst(), isEmpty() 등은 멀티스레드에서 안전하지 않음
- 따라서 value인 timestamps에 대한 조작은 반드시 synchronized(timestamps)로 감싸서 보호해야 함

#### 추가 설명: `ConcurrentLinkedDeque`가 아닌 `synchronized`를 사용한 이유

- `SlidingWindowRateLimitFilter`는 **특정 key(memberId)에 요청이 집중되는 상황**을 처리하기 위한 구조
- 이 경우 `ConcurrentLinkedDeque`는 non-blocking 구조이므로, **다수의 스레드가 동시에 동일한 Deque에 접근하면 빈번한 CAS(Compare-And-Swap) 충돌**이 발생
- 이러한 충돌은 오히려 성능 저하를 유발하며, 동시에 컨텍스트 스위칭 비용 또한 증가
- 반면, `synchronized`는 **블로킹 방식으로 하나의 스레드만 접근하도록 제어**하므로, 충돌이 발생하지 않으며 **안정적인 처리 흐름과 낮은 CPU 소모**라는 이점
- 또한, 대부분의 요청은 다양한 memberId에 대해 분산되기 때문에 key 단위의 락 경합 자체도 낮은 편이며, **경합이 발생할 때만 명시적으로 순차 처리를 유도하는 것이 더 유리한 전략**이라고 판단

#### 2. 현재 requestLogs에서의 Race Condition 문제
- 다음 시나리오에서 동기화 문제가 발생할 수 있음:
  - 스레드 A: compute 실행, 이미 존재하는 Deque를 참조 → 아직 addLast(now) 호출 전.
  - 스레드 B: removeIf 실행 → 같은 key에 대한 entry를 집음.
  - Deque가 비어있다고 판단되면 해당 entry를 삭제해버림.
  - 스레드 A: 여전히 참조 중인 Deque에 addLast(now) 수행.
  - 하지만 Map에서는 이미 삭제된 상태 → 로그가 유실됨.

→ 즉, 초기 생성 시점은 안전하지만, 기존 Deque를 참조한 상태에서 removeIf가 개입하면 로그가 유실

#### 고려했던 동기화 대안: `synchronized(memberId)` 기반 락

- `Long`은 불변 객체이지만, new Long(1)과 같이 생성 시 객체 주소가 다를 수 있음
- 예: 아래와 같은 코드에서는 `==` 비교가 false가 됨
  ```java
  Long id1 = new Long(1);
  Long id2 = new Long(1);
  System.out.println(id1 == id2); // false
  ```
- `synchronized(id1)`과 `synchronized(id2)`는 동등한 값이어도 **서로 다른 락을 잡음**
- 즉, 같은 memberId라도 다른 Long 인스턴스가 전달될 경우 락이 분리됨 → 동기화가 무의미해짐

→ 해당 이유로 `memberId` 자체를 락으로 사용하는 방식은 제외

🚨 해당 케이스는 생성과 로그 기록을 원자적으로 처리하는 경우와 비교했을 때 발생 가능성이 매우 낮고, 실제로 발생하더라도 치명적인 문제가 아니라고 판단하여 우선은 배제했습니다. 다만, 혹시 synchronized(memberId) 외에 더 나은 방법이 있다면 공유 부탁드립니다..!

### 3. 리팩토링 내성을 위한 테스트 개선

기존에는 `SlidingWindowRateLimitFilter`가 직접 응답 객체에 상태 코드, 헤더, 메시지 등 모든 RateLimit 응답을 구성했기 때문에, 테스트에서도 다음과 같은 복잡한 설정이 필요했음:

- `MockHttpServletResponse`에서 상태 코드, 응답 본문, 헤더 등을 직접 꺼내 검증
- `PrintWriter` 등을 목(mock)으로 설정해 JSON 직렬화까지 테스트
- 응답 포맷 변경 시 테스트가 깨지는 등 **리팩토링 내성이 매우 낮은 구조**

→ 이를 해결하기 위해 **SRP(단일 책임 원칙)**에 따라 응답 처리 책임을 `RateLimitExceededHandler` 클래스로 분리함

→ 이후 `SlidingWindowRateLimitFilterTest`에서는 다음 한 줄로 충분히 테스트가 가능해짐:

```java
verify(rateLimitExceededHandler).handle(eq(request), eq(response), anyLong());
```

#### 개선 효과

- **응답 형식 변경에 영향을 받지 않음**  
  예: 메시지를 "요청이 너무 많습니다" → "잠시 후 다시 시도해주세요"로 바꿔도 테스트 유지

- **테스트 유지보수 비용 감소**  
  MockWriter, ObjectMapper 설정 등 불필요한 코드 제거

- **의미 있는 동작 단위에 집중**  
  응답 구현 세부가 아닌 **"핸들러가 호출되었는가?"** 라는 비즈니스 의미에 집중

- **RateLimitExceededHandler 단위 테스트를 별도로 구성 가능**  
  JSON 직렬화, 헤더, 상태코드 등에 대한 검증은 `RateLimitExceededHandlerTest`에 위임

→ 전체적으로 **책임을 명확히 나누고**, **행위 기반 테스트로 전환**하여  
리팩토링에 강하고 유지보수성 높은 구조로 전환함



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - JWT 인증 사용자에 대해 슬라이딩 윈도우 방식의 요청 제한(60초당 100회) 도입. 한도를 초과하면 429(Too Many Requests)와 Retry-After 헤더, 한글 메시지의 문제 상세 JSON을 반환.
- 리팩터
  - 초과 응답 처리를 전담 핸들러로 분리해 일관된 오류 응답 제공.
  - 주기적 정리로 불필요한 요청 기록을 제거해 메모리 사용 개선.
- 테스트
  - 429 응답 상태/헤더/본문 형식 검증 테스트 추가.
  - 비인증 요청 통과, 한도 초과 차단, 기록 정리 동작을 검증하는 단위 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->