### PR TITLE
[BE] 알림 리다이렉트 경로에 조직 ID 반영

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/EventEmailPayload.java
+++ b/server/src/main/java/com/ahmadda/domain/EventEmailPayload.java
@@ -28,6 +28,8 @@ public record EventEmailPayload(
                 event.getRegistrationEnd(),
                 event.getEventStart(),
                 event.getEventEnd(),
+                event.getOrganization()
+                        .getId(),
                 event.getId()
         );
 
@@ -57,6 +59,7 @@ public record EventEmailPayload(
             Object registrationEnd,
             Object eventStart,
             Object eventEnd,
+            Long organizationId,
             Long eventId
     ) {
 
@@ -70,6 +73,7 @@ public record EventEmailPayload(
             Assert.notNull(registrationEnd, "신청 종료 시간은 null일 수 없습니다.");
             Assert.notNull(eventStart, "이벤트 시작 시간은 null일 수 없습니다.");
             Assert.notNull(eventEnd, "이벤트 종료 시간은 null일 수 없습니다.");
+            Assert.notNull(organizationId, "조직 ID는 null일 수 없습니다.");
             Assert.notNull(eventId, "이벤트 ID는 null일 수 없습니다.");
         }
     }

--- a/server/src/main/java/com/ahmadda/domain/PushNotificationPayload.java
+++ b/server/src/main/java/com/ahmadda/domain/PushNotificationPayload.java
@@ -5,12 +5,14 @@ import com.ahmadda.domain.util.Assert;
 public record PushNotificationPayload(
         String title,
         String body,
+        Long organizationId,
         Long eventId
 ) {
 
     public PushNotificationPayload {
         Assert.notBlank(title, "푸시 제목은 공백일 수 없습니다.");
         Assert.notBlank(body, "푸시 본문은 공백일 수 없습니다.");
+        Assert.notNull(organizationId, "조직 ID는 null일 수 없습니다.");
         Assert.notNull(eventId, "이벤트 ID는 null일 수 없습니다.");
     }
 
@@ -18,6 +20,8 @@ public record PushNotificationPayload(
         return new PushNotificationPayload(
                 event.getTitle(),
                 content,
+                event.getOrganization()
+                        .getId(),
                 event.getId()
         );
     }

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
@@ -74,7 +74,10 @@ public class SmtpEmailNotifier implements EmailNotifier {
         model.put("registrationEnd", body.registrationEnd());
         model.put("eventStart", body.eventStart());
         model.put("eventEnd", body.eventEnd());
-        model.put("redirectUrl", notificationProperties.getRedirectUrlPrefix() + body.eventId());
+        model.put(
+                "redirectUrl",
+                notificationProperties.getRedirectUrlPrefix() + body.organizationId() + "/event/" + body.eventId()
+        );
 
         return model;
     }

--- a/server/src/main/java/com/ahmadda/infra/notification/push/FcmPushNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/FcmPushNotifier.java
@@ -33,49 +33,13 @@ public class FcmPushNotifier implements PushNotifier {
             return;
         }
         List<String> registrationTokens = getRegistrationTokens(recipients);
-        if (registrationTokens.isEmpty()) {
-            return;
-        }
-
-        MulticastMessage message = createMulticastMessage(registrationTokens, pushNotificationPayload);
-        try {
-            // TODO. 추후 한번에 500개 이상의 토큰을 처리한다면 배치 처리를 고려해야 함
-            BatchResponse batchResponse = FirebaseMessaging.getInstance()
-                    .sendEachForMulticast(message);
-
-            fcmPushErrorHandler.handleFailures(batchResponse, registrationTokens);
-        } catch (FirebaseMessagingException e) {
-            log.error("fcmMulticastPushError: {}", e.getMessage(), e);
-        }
+        sendMulticast(pushNotificationPayload, registrationTokens);
     }
 
     @Override
     public void sendPush(final OrganizationMember recipient, final PushNotificationPayload pushNotificationPayload) {
         List<String> registrationTokens = getRegistrationTokens(recipient);
-        if (registrationTokens.isEmpty()) {
-            return;
-        }
-
-        MulticastMessage message = createMulticastMessage(registrationTokens, pushNotificationPayload);
-        try {
-            // TODO. 추후 한번에 500개 이상의 토큰을 처리한다면 배치 처리를 고려해야 함
-            BatchResponse batchResponse = FirebaseMessaging.getInstance()
-                    .sendEachForMulticast(message);
-
-            fcmPushErrorHandler.handleFailures(batchResponse, registrationTokens);
-        } catch (FirebaseMessagingException e) {
-            log.error("fcmMulticastPushError: {}", e.getMessage(), e);
-        }
-    }
-
-    private List<String> getRegistrationTokens(final OrganizationMember recipient) {
-        long memberId = recipient.getMember()
-                .getId();
-
-        return fcmRegistrationTokenRepository.findAllByMemberId(memberId)
-                .stream()
-                .map(FcmRegistrationToken::getRegistrationToken)
-                .toList();
+        sendMulticast(pushNotificationPayload, registrationTokens);
     }
 
     private List<String> getRegistrationTokens(final List<OrganizationMember> recipients) {
@@ -85,6 +49,16 @@ public class FcmPushNotifier implements PushNotifier {
                 .toList();
 
         return fcmRegistrationTokenRepository.findAllByMemberIdIn(memberIds)
+                .stream()
+                .map(FcmRegistrationToken::getRegistrationToken)
+                .toList();
+    }
+
+    private List<String> getRegistrationTokens(final OrganizationMember recipient) {
+        long memberId = recipient.getMember()
+                .getId();
+
+        return fcmRegistrationTokenRepository.findAllByMemberId(memberId)
                 .stream()
                 .map(FcmRegistrationToken::getRegistrationToken)
                 .toList();
@@ -100,7 +74,30 @@ public class FcmPushNotifier implements PushNotifier {
                         .setTitle(payload.title())
                         .setBody(payload.body())
                         .build())
-                .putData("redirectUrl", notificationProperties.getRedirectUrlPrefix() + payload.eventId())
+                .putData(
+                        "redirectUrl",
+                        notificationProperties.getRedirectUrlPrefix() + payload.organizationId() + "/event/" + payload.eventId()
+                )
                 .build();
+    }
+
+    private void sendMulticast(
+            final PushNotificationPayload pushNotificationPayload,
+            final List<String> registrationTokens
+    ) {
+        if (registrationTokens.isEmpty()) {
+            return;
+        }
+
+        MulticastMessage message = createMulticastMessage(registrationTokens, pushNotificationPayload);
+        try {
+            // TODO. 추후 한번에 500개 이상의 토큰을 처리한다면 배치 처리를 고려해야 함
+            BatchResponse batchResponse = FirebaseMessaging.getInstance()
+                    .sendEachForMulticast(message);
+
+            fcmPushErrorHandler.handleFailures(batchResponse, registrationTokens);
+        } catch (FirebaseMessagingException e) {
+            log.error("fcmMulticastPushError: {}", e.getMessage(), e);
+        }
     }
 }

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -48,7 +48,7 @@ cors:
     - http://local.ahmadda.com:5173
 
 notification:
-  redirect-url-prefix: http://localhost:5173/event/
+  redirect-url-prefix: https://staging.ahmadda.com/
 
 aws:
   s3:

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -40,7 +40,7 @@ cors:
     - http://127.0.0.1:5173
 
 notification:
-  redirect-url-prefix: http://localhost:5173/event/
+  redirect-url-prefix: http://localhost:5173/
 
 mail:
   mock: true

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -43,7 +43,7 @@ cors:
     - https://prod.ahmadda.com
 
 notification:
-  redirect-url-prefix: https://ahmadda.com/event/
+  redirect-url-prefix: https://ahmadda.com/
 
 aws:
   s3:

--- a/server/src/test/java/com/ahmadda/learning/notification/FcmPushNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/notification/FcmPushNotifierTest.java
@@ -53,6 +53,7 @@ class FcmPushNotifierTest {
         var payload = new PushNotificationPayload(
                 "테스트 알림 제목",
                 "이것은 테스트 메시지입니다.",
+                1L,
                 1L
         );
 
@@ -80,6 +81,7 @@ class FcmPushNotifierTest {
         var payload = new PushNotificationPayload(
                 "테스트 알림 제목",
                 "이것은 테스트 메시지입니다.",
+                1L,
                 1L
         );
 

--- a/server/src/test/java/com/ahmadda/learning/notification/SmtpEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/notification/SmtpEmailNotifierTest.java
@@ -54,6 +54,7 @@ class SmtpEmailNotifierTest {
                                 .plusDays(3),
                         LocalDateTime.now()
                                 .plusDays(4),
+                        1L,
                         1L
                 )
         );

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -33,7 +33,7 @@ cors:
     - http://127.0.0.1:5173
 
 notification:
-  redirect-url-prefix: http://localhost:5173/event/
+  redirect-url-prefix: http://localhost:5173/
 
 mail:
   mock: true


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 알림 리다이렉트 경로에 조직 ID 반영 -->

## 관련 이슈

close #641

## ✨ 작업 내용

- 기존 알림 클릭 시 리다이렉트 경로가 `/event/{eventId}` 형태로 구성되어 있어, 실제 경로가 존재하지 않아 오류가 발생했습니다.
- 이를 해결하기 위해 경로를 `/{organizationId}/event/{eventId}` 형태로 변경했습니다.
- 이메일 알림과 푸시 알림 모두 해당 경로를 적용하도록 수정했습니다.
  - `EventEmailPayload`, `PushNotificationPayload`로 추상화된 구조 덕분에 간단하게 변경할 수 있었습니다 🙌

## 🙏 기타 참고 사항

- `FcmPushNotifier`에 있던 FCM 멀티캐스트 전송 로직을 공통 메서드로 분리하여 중복을 제거했습니다!
  - 그때 투투씨가 작업을 안하신거.. 😭