### PR TITLE
[BE] SMTP 발송량 제한 초과 오류 해결

### DIFF
--- a/server/src/main/java/com/ahmadda/infra/config/AsyncConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package com.ahmadda.infra.config;
 
 import com.ahmadda.infra.logger.AsyncTraceLoggingDecorator;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -13,6 +14,7 @@ import java.util.concurrent.Executor;
 public class AsyncConfig implements AsyncConfigurer {
 
     // TODO. 추후 ThreadPoolTaskExecutor의 thread 설정 변경 및 graceful shutdown 고려 필요
+    @Bean
     @Override
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();

--- a/server/src/main/java/com/ahmadda/infra/config/AsyncConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/config/AsyncConfig.java
@@ -20,7 +20,6 @@ public class AsyncConfig implements AsyncConfigurer {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setThreadNamePrefix("async-");
         executor.setTaskDecorator(new AsyncTraceLoggingDecorator());
-        executor.initialize();
 
         return executor;
     }

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
@@ -30,14 +30,15 @@ public class SmtpEmailNotifier implements EmailNotifier {
     @Override
     public void sendEmails(final List<OrganizationMember> recipients, final EventEmailPayload eventEmailPayload) {
         List<String> recipientEmails = getRecipientEmails(recipients);
+        if (recipientEmails.isEmpty()) {
+            return;
+        }
+
         String subject = createSubject(eventEmailPayload.subject());
         String text = createText(eventEmailPayload.body());
-        // TODO. 추후 BCC 방식으로 묶어서 전송 고려
-        recipientEmails.forEach(recipientEmail -> {
-            MimeMessage mimeMessage = createMimeMessage(recipientEmail, subject, text);
-
-            javaMailSender.send(mimeMessage);
-        });
+    
+        MimeMessage mimeMessage = createMimeMessageWithBcc(recipientEmails, subject, text);
+        javaMailSender.send(mimeMessage);
     }
 
     private List<String> getRecipientEmails(List<OrganizationMember> recipients) {
@@ -79,13 +80,18 @@ public class SmtpEmailNotifier implements EmailNotifier {
         return model;
     }
 
-    private MimeMessage createMimeMessage(final String recipientEmail, final String subject, final String text) {
+    private MimeMessage createMimeMessageWithBcc(
+            final List<String> bccRecipients,
+            final String subject,
+            final String text
+    ) {
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-        MimeMessageHelper helper;
         try {
-            helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
 
-            helper.setTo(recipientEmail);
+            helper.setTo("amadda.team@gmail.com");
+            // TODO. 추후 BCC 수신자가 100명 이상일 경우, 배치 처리 고려
+            helper.setBcc(bccRecipients.toArray(String[]::new));
             helper.setSubject(subject);
             helper.setText(text, true);
         } catch (MessagingException e) {

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
       mail:
         smtp:
           auth: true
-          timeout: 1000
+          timeout: 10000
           starttls:
             enable: true
 

--- a/server/src/test/java/com/ahmadda/learning/AwsS3ImageUploaderTest.java
+++ b/server/src/test/java/com/ahmadda/learning/AwsS3ImageUploaderTest.java
@@ -1,26 +1,24 @@
 package com.ahmadda.learning;
 
+import com.ahmadda.annotation.IntegrationTest;
 import com.ahmadda.domain.ImageFile;
 import com.ahmadda.infra.image.AwsS3ImageUploader;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Disabled
+@IntegrationTest
 @TestPropertySource(properties = {
         "aws.s3.mock=false",
         "aws.s3.region=${aws.dev.s3.region}",
         "aws.s3.bucket=${aws.dev.s3.bucket}",
         "aws.s3.folder=${aws.dev.s3.folder}"
 })
-@Transactional
-@Disabled
 public class AwsS3ImageUploaderTest {
 
     @Autowired

--- a/server/src/test/java/com/ahmadda/learning/SlackAlarmTest.java
+++ b/server/src/test/java/com/ahmadda/learning/SlackAlarmTest.java
@@ -1,20 +1,18 @@
 package com.ahmadda.learning;
 
 
+import com.ahmadda.annotation.IntegrationTest;
 import com.ahmadda.application.dto.MemberCreateAlarmPayload;
 import com.ahmadda.domain.Member;
 import com.ahmadda.infra.alarm.slack.SlackAlarm;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@TestPropertySource(properties = "slack.mock=false")
-@Transactional
 @Disabled
+@IntegrationTest
+@TestPropertySource(properties = "slack.mock=false")
 class SlackAlarmTest {
 
     @Autowired

--- a/server/src/test/java/com/ahmadda/learning/notification/FcmPushNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/notification/FcmPushNotifierTest.java
@@ -1,5 +1,6 @@
 package com.ahmadda.learning.notification;
 
+import com.ahmadda.annotation.IntegrationTest;
 import com.ahmadda.domain.Member;
 import com.ahmadda.domain.MemberRepository;
 import com.ahmadda.domain.Organization;
@@ -12,17 +13,14 @@ import com.ahmadda.infra.notification.push.FcmRegistrationTokenRepository;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@TestPropertySource(properties = "push.mock=false")
-@Transactional
 @Disabled
+@IntegrationTest
+@TestPropertySource(properties = "push.mock=false")
 class FcmPushNotifierTest {
 
     @Autowired

--- a/server/src/test/java/com/ahmadda/learning/notification/SmtpEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/notification/SmtpEmailNotifierTest.java
@@ -1,5 +1,6 @@
 package com.ahmadda.learning.notification;
 
+import com.ahmadda.annotation.IntegrationTest;
 import com.ahmadda.domain.EmailNotifier;
 import com.ahmadda.domain.EventEmailPayload;
 import com.ahmadda.domain.Member;
@@ -9,14 +10,13 @@ import com.ahmadda.domain.Role;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Disabled
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@IntegrationTest
 @TestPropertySource(properties = "mail.mock=false")
 class SmtpEmailNotifierTest {
 

--- a/server/src/test/java/com/ahmadda/learning/notification/SmtpEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/notification/SmtpEmailNotifierTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Disabled
@@ -60,5 +61,50 @@ class SmtpEmailNotifierTest {
 
         // when // then
         smtpEmailNotifier.sendEmails(List.of(organizationMember), emailPayload);
+    }
+
+    @Test
+    void BCC_수신자가_100명_이상이면_예외가_발생한다() {
+        // given
+        var organizationName = "테스트 조직";
+        var eventTitle = "테스트 이벤트";
+        var organizerNickname = "주최자";
+
+        var organization = Organization.create(organizationName, "설명", "logo.png");
+
+        var recipients = new ArrayList<OrganizationMember>();
+        for (int i = 0; i < 100; i++) {
+            var email = "dummy" + i + "@example.com";
+            var dummyMember = Member.create("유저" + i, email, "profile.png");
+            var orgMember = OrganizationMember.create("닉네임" + i, dummyMember, organization, Role.USER);
+            recipients.add(orgMember);
+        }
+
+        var emailPayload = new EventEmailPayload(
+                new EventEmailPayload.Subject(
+                        organizationName,
+                        organizerNickname,
+                        eventTitle
+                ),
+                new EventEmailPayload.Body(
+                        "100명 이상의 수신자에게 발송되는 테스트 메일입니다.",
+                        organizationName,
+                        eventTitle,
+                        organizerNickname,
+                        "루터회관",
+                        LocalDateTime.now()
+                                .plusDays(1),
+                        LocalDateTime.now()
+                                .plusDays(2),
+                        LocalDateTime.now()
+                                .plusDays(3),
+                        LocalDateTime.now()
+                                .plusDays(4),
+                        1L
+                )
+        );
+
+        // when
+        smtpEmailNotifier.sendEmails(recipients, emailPayload);
     }
 }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #635

## ✨ 작업 내용

데모데이 당일, SMTP 발송량이 하루 500건을 초과하면서 아래와 같은 오류가 발생했습니다:
```
MailSendException: Failed messages: SMTPSendFailedException: 550-5.4.5 Daily user sending limit exceeded
```


이를 빠르게 해결하기 위해 **BCC 방식**을 도입해 임시 대응했습니다.

BCC 방식은 수신자를 숨긴 채 한 번에 여러 명에게 메일을 보내는 방식으로, 아래와 같이 실제 BCC 발송이 된 것을 확인할 수 있습니다:

<img width="1598" height="810" alt="image" src="https://github.com/user-attachments/assets/e6d01da8-d036-41bf-bf4a-14f0bcc02a60" />

다만, 지메일에서 지원하는 BCC 방식에도 **100명 이상 수신 시 오류가 발생**하며 다음과 같은 예외가 발생합니다:


```
SMTPAddressFailedException: 452 4.5.3 Your message has too many recipients
```


따라서 향후 100명이 넘는 경우에는 배치 처리로 분할 발송하는 로직을 도입해도 좋을 것 같습니다.

또한 BCC 방식은 발송 시간이 오래 걸려  다음과 같은 Read timed out 예외도 발생했습니다:

```
MessagingException: java.net.SocketTimeoutException: Read timed out
```


이 문제는 **메일 읽기 응답 대기 시간을 10초로 연장**하여 해결했습니다. time out에 대한 자세한 내용은 [또 다른 이슈](https://github.com/woowacourse-teams/2025-ah-madda/issues/636) 에서 더 자세히 다뤄보겠습니다!! 

## 🙏 기타 참고 사항

- 지메일 발송 제한 관련 공식 문서는 [여기](https://support.google.com/a/answer/166852)에서 확인하실 수 있습니다. 저도 해당 문서를 참고해서 구현했습니다~!! 👍
- 현재는 BCC 방식으로 임시 대응 중이며, **하루 500건 제한은 그대로 유효**합니다 ㅠㅠ
- 추후 SMTP 발송량을 모니터링하거나 사전 경고를 받을 수 있는 체계를 도입해도 좋겠습니다!! 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - 이메일 발송을 수신자별 개별 전송에서 단일 BCC 전송으로 변경하여 개인정보 보호와 전송 안정성 개선
  - 수신자가 없을 때 발송을 건너뛰어 불필요한 시도 방지
  - SMTP 타임아웃을 1초에서 10초로 늘려 타임아웃 실패 감소

- Tests
  - 메일/푸시/슬랙 테스트를 IntegrationTest 기반으로 전환 및 일부 테스트는 기본 비실행으로 변경
  - BCC 100명 이상 예외 시나리오 테스트 추가

- Chores
  - 비동기 실행기 구성 관련 안정성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->