### PR TITLE
[FE] 조직 이미지 크기 최대 10MB로 제한

### DIFF
--- a/client/src/features/Organization/New/constants/errorMessages.ts
+++ b/client/src/features/Organization/New/constants/errorMessages.ts
@@ -1,4 +1,5 @@
 export const ERROR_MESSAGES = {
   REQUIRED: (label: string) => `${label}을(를) 입력해 주세요.`,
   MAX_LENGTH: (label: string, max: number) => `${label}은(는) ${max}자 이하로 입력해 주세요.`,
+  MAX_FILE_SIZE_MB: (label: string, mb: number) => `${label}은(는) ${mb}MB까지 업로드할 수 있어요.`,
 };

--- a/client/src/features/Organization/New/constants/validationRules.ts
+++ b/client/src/features/Organization/New/constants/validationRules.ts
@@ -2,3 +2,8 @@ export const MAX_LENGTH = {
   NAME: 30,
   DESCRIPTION: 30,
 } as const;
+
+export const IMAGE = {
+  MAX_MB: 10,
+  MAX_BYTES: 10 * 1024 * 1024,
+} as const;

--- a/client/src/features/Organization/New/utils/getOrgErrorMessage.ts
+++ b/client/src/features/Organization/New/utils/getOrgErrorMessage.ts
@@ -1,4 +1,5 @@
 import { ERROR_MESSAGES } from '../constants/errorMessages';
+import { IMAGE } from '../constants/validationRules';
 
 import { ORG_VALIDATION_RULES, OrgFormFields } from './validationRules';
 import { isEmpty } from './validators';
@@ -17,6 +18,12 @@ export const getOrgErrorMessage = (
     const v = value.trim();
     if (v.length > rule.maxLength) {
       return ERROR_MESSAGES.MAX_LENGTH(rule.label, rule.maxLength);
+    }
+  }
+
+  if (rule.maxBytes && value instanceof File) {
+    if (value.size > rule.maxBytes) {
+      return ERROR_MESSAGES.MAX_FILE_SIZE_MB(rule.label, IMAGE.MAX_MB);
     }
   }
 

--- a/client/src/features/Organization/New/utils/validationRules.ts
+++ b/client/src/features/Organization/New/utils/validationRules.ts
@@ -1,4 +1,4 @@
-import { MAX_LENGTH } from '../constants/validationRules';
+import { IMAGE, MAX_LENGTH } from '../constants/validationRules';
 
 export type OrgFormFields = {
   name: string;
@@ -10,6 +10,7 @@ type ValidationRule = {
   label: string;
   required?: boolean;
   maxLength?: number;
+  maxBytes?: number;
 };
 
 export const ORG_VALIDATION_RULES: Record<keyof OrgFormFields, ValidationRule> = {
@@ -26,5 +27,6 @@ export const ORG_VALIDATION_RULES: Record<keyof OrgFormFields, ValidationRule> =
   thumbnail: {
     label: '조직 이미지',
     required: true,
+    maxBytes: IMAGE.MAX_BYTES,
   },
 };


### PR DESCRIPTION
## 관련 이슈

close #648 

## ✨ 작업 내용

- 조직 생성 시 최대 첨부 가능한 이미지 크기를 10MB로 제한하였습니다.
- 10MB를 초과하는 경우 에러 메시지를 띄웁니다.

## 🙏 기타 참고 사항

- 10MB를 넘는 이미지가 별로 없어서 테스트 편의상 제한을 4MB로 낮춰 검증했습니다. (영상 테스트 이미지는 4.4MB)

https://github.com/user-attachments/assets/cc5139f6-7f69-4821-9867-46ba017d1570



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 조직 생성 화면의 썸네일 업로드에 용량 제한을 추가했습니다. 이제 최대 10MB까지 업로드할 수 있습니다.
  - 용량을 초과한 파일을 선택하면, 최대 업로드 가능 용량을 명확히 안내하는 메시지가 즉시 표시됩니다.
  - 파일 크기 기반 유효성 검사를 강화하여 업로드 오류를 사전에 방지합니다.
  - 사용자 안내 문구를 현지화하여 이해하기 쉬운 오류 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->