### PR TITLE
[BE] SMTP 메일 발송 timeout 오류 해결

### DIFF
--- a/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
@@ -36,6 +36,7 @@ public class SmtpEmailNotifier implements EmailNotifier {
         recipientEmails.forEach(recipientEmail -> {
             MimeMessage mimeMessage = createMimeMessage(recipientEmail, subject, text);
 
+            // TODO: 추후 지수 백오프를 이용한 재시도 로직 구현
             javaMailSender.send(mimeMessage);
         });
     }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -29,9 +29,11 @@ spring:
       mail:
         smtp:
           auth: true
-          timeout: 1000
           starttls:
             enable: true
+          connectiontimeout: 5000
+          timeout: 10000
+          writetimeout: 5000
 
 oauth:
   google:


### PR DESCRIPTION
## 관련 이슈

close #636

## ✨ 작업 내용

- JavaMailSenderImpl에 다음 timeout 설정 값 추가:
  - `mail.smtp.connectiontimeout = 5000`
  - `mail.smtp.timeout = 10000`
  - `mail.smtp.writetimeout = 5000`

## 🔍 작업 배경 및 설정 이유

근본적인 배경은 **론칭데이 당시 발생했던 SMTP timeout 오류를 해결**하기 위함입니다! 
그리고 추가적인 배경은 [JavaMail 공식 문서](https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html)에 따르면  
`mail.smtp.connectiontimeout`, `mail.smtp.timeout`, `mail.smtp.writetimeout`의 **기본값은 모두 무한대(infinite)**이며,  
명시하지 않으면 **지연되거나 응답 없는 SMTP 서버로 인해 쓰레드가 무기한 대기**하게 됩니다.

따라서 **명시적으로 timeout 값을 지정**하는 것이 안정성 측면에서 필요하다고 판단했습니다!!

### 설정 값에 대한 근거

- `connectiontimeout: 5000`  
  SMTP 서버와 연결 시 5초 이내로 실패를 감지하여 빠른 장애 전파 유도  
- `timeout: 10000`  
  Gmail SMTP의 응답 지연 가능성(특히 비동기 대량 전송 시)을 고려해 10초까지 유예  
- `writetimeout: 5000`  
  메시지 전송(write) 지연은 드물지만 예외 상황을 대비해 최소한의 대기 시간 설정

또한 현재 시스템은 **BCC 방식으로 10명~100명 이상의 수신자에게 한 번에 메일을 전송**하는 구조이기 때문에,  
응답이 지연될 가능성을 고려해 **읽기 타임아웃(timeout)은 조금 더 여유 있게(10초)** 설정했습니다.

우선 보수적이면서도 빠르게 실패할 수 있는 균형값으로 설정했는데, 추후에 운영하면서 계속 조정해보죠~ 
아무래도 Gmail이라는 거대한 비관리 의존성이라 관련 자료도 거의 없고 명확하게 설정하기 어렵더라고요 허허

###  후속 계획

이 설정 이후에도 `SocketTimeoutException: Read timed out` 예외가 지속된다면,  
오류 원인을 좀 더 정밀하게 분석한 후,  
**지수 백오프(Exponential Backoff) 기반의 재시도 로직**을 도입할 예정입니다.  
오류를 발견하고 함께 대응 로직을 구현해보는 것도 좋은 경험이 될 것 같네요 😎

### TMI: 왜 `com.sun.mail.smtp`인가요?

저도 이번에 공부하면서 알게 된 사실인데, JavaMail API는 표준 인터페이스인 `javax.mail.*`을 제공하지만  
**실제 구현체는 Sun에서 제공하는 `com.sun.mail.smtp.SMTPTransport`**입니다.

Spring Boot의 `JavaMailSenderImpl`도 내부적으로 이 구현체를 사용하고 있으며,  
`spring.mail.properties.mail.smtp.*`로 설정한 값들은  
결국 이 클래스에 전달되어  
**Socket 연결, 읽기/쓰기 타임아웃, 인증 방식, STARTTLS 등 주요 동작을 제어**합니다~~

즉, 우리가 설정한 timeout 값은 **JavaMail의 SMTPTransport 내부에서 `Socket.setSoTimeout(...)` 등으로 직접 반영**되는 구조더라고요.

### 마무리

아마 방학 중에 이제 개인적으로 PR을 올리지는 않을 것 같네요~~
지금까지 방학기간에 했던 작업들은 전부 레벨 4 시작 전에 귀찮을 수 있는 작업들을 마무리해두고 싶어서 했던거라..
약간의 열정페이.. ㅋㅋㅋ

이번 주 토요일, 레전드 게더에서 **레전드 리팩토링 데이** 재밌게 해보죠~~
