### PR TITLE
[BE] JPA Nplus1 Detector 버전 마이그레이션 (3.0.0 → 3.1.0)

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,27 +31,27 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'
-
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-metrics:3.4.0'
-    implementation 'ca.pjer:logback-awslogs-appender:1.6.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'com.github.joon6093:jpa-nplus1-detector:3.0.1'
+    implementation 'org.flywaydb:flyway-core'
+    runtimeOnly 'org.flywaydb:flyway-mysql'
+    implementation 'com.github.joon6093.jpa-nplus1-detector:detector-core:3.1.0'
 
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'
     implementation 'com.google.firebase:firebase-admin:9.5.0'
+
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-metrics:3.4.0'
+    implementation 'ca.pjer:logback-awslogs-appender:1.6.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    implementation 'org.flywaydb:flyway-core'
-    runtimeOnly 'org.flywaydb:flyway-mysql'
+    testImplementation 'com.github.joon6093.jpa-nplus1-detector:detector-test:3.1.0'
 }
 
 tasks.named('test') {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'com.github.joon6093:jpa-nplus1-detector:3.0.0'
+    implementation 'com.github.joon6093:jpa-nplus1-detector:3.0.1'
 
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'

--- a/server/src/test/java/com/ahmadda/annotation/IntegrationTest.java
+++ b/server/src/test/java/com/ahmadda/annotation/IntegrationTest.java
@@ -1,16 +1,16 @@
 package com.ahmadda.annotation;
 
 import io.jeyong.detector.annotation.NPlusOneTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
-
+import io.jeyong.detector.annotation.NPlusOneTest.Mode;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -18,7 +18,7 @@ import java.lang.annotation.Target;
 @Transactional
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles(profiles = "test")
-@NPlusOneTest(NPlusOneTest.Mode.LOGGING)
+@NPlusOneTest(Mode.LOGGING)
 public @interface IntegrationTest {
 
 }

--- a/server/src/test/java/com/ahmadda/annotation/IntegrationTest.java
+++ b/server/src/test/java/com/ahmadda/annotation/IntegrationTest.java
@@ -1,7 +1,7 @@
 package com.ahmadda.annotation;
 
-import io.jeyong.detector.annotation.NPlusOneTest;
-import io.jeyong.detector.annotation.NPlusOneTest.Mode;
+import io.jeyong.nplus1detector.test.annotation.NPlusOneTest;
+import io.jeyong.nplus1detector.test.annotation.NPlusOneTest.Mode;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #654

## ✨ 작업 내용

- JPA NPlus1 Detector 라이브러리 버전 마이그레이션 (3.0.0 → 3.0.1)  
  - 참고 PR: https://github.com/joon6093/jpa-nplus1-detector/pull/18

## 🙏 기타 참고 사항

- 기존 3.0.0 버전에서는 `@SpringBootTest`, `@DataJpaTest` 등 **Spring 통합 테스트 환경**에서  
  테스트 메서드 실행 이후 발생한 N+1 예외가 **JUnit 쪽으로 전파되지 않아 테스트가 실패하지 않고 넘어가는** 문제가 있었습니다 ㅠㅠㅠㅠ 넘 슬펐슴다
- 3.0.1에서는 이를 해결하기 위해 JUnit 5 Extension 방식(`@ExtendWith`)을 제거하고,  
  Spring의 `TestExecutionListener` 기반으로 예외 전파 방식이 바뀌었습니다~~
- `mode = EXCEPTION` 설정만 해두면, 아래 사진 처럼 예외도 잘 터지고 디버깅도 쉬워졌습니다! 추후에 N+1 쿼리를 잡을때 사용해보죠~~
<img width="2140" height="830" alt="image" src="https://github.com/user-attachments/assets/1cf70829-8d72-4d77-a681-6ca0036de96a" />

### TMI

`TestExecutionListener`가 생소하다면, 아래 클래스를 함께 참고하면 학습에 도움이 될 수 있습니다!!

- `TestExecutionListener`: Spring 테스트 생명주기 내에서 테스트 실행 전후의 커스텀 로직을 삽입할 수 있는 인터페이스입니다.
- `TransactionalTestExecutionListener`: 테스트 메서드 단위로 트랜잭션을 시작하고, 자동 롤백을 처리하는 역할을 수행합니다.

자세한 내용은 [관련 공식 문서(https://docs.spring.io/spring-framework/reference/testing/testcontext-framework.html)에서 확인할 수 있습니다!!!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신뢰성/유지보수
  - 런타임/빌드 종속성을 정리 및 업데이트했습니다: Flyway 마이그레이션, JPA N+1 검출기 업그레이드, AWS S3/메트릭스 스타터 및 Logback AWS 로깅 추가, OpenAPI UI 재추가, 기존 JWT 라이브러리 제거. 애플리케이션 동작에는 영향이 없습니다.
- 테스트
  - 통합 테스트의 어노테이션 참조를 단순화하고 임포트를 정리해 가독성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->