### PR TITLE
[BE] 메인화면 이벤트 정보에 현재 멤버가 참여중인지 포함하는 필드 추가

### DIFF
--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -14,6 +14,7 @@ import com.ahmadda.presentation.dto.EventLoadResponse;
 import com.ahmadda.presentation.dto.EventResponse;
 import com.ahmadda.presentation.dto.EventTitleResponse;
 import com.ahmadda.presentation.dto.EventUpdateResponse;
+import com.ahmadda.presentation.dto.MainEventResponse;
 import com.ahmadda.presentation.dto.OrganizerStatusResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -55,7 +56,7 @@ public class OrganizationEventController {
             @ApiResponse(
                     responseCode = "200",
                     content = @Content(
-                            array = @ArraySchema(schema = @Schema(implementation = EventResponse.class))
+                            array = @ArraySchema(schema = @Schema(implementation = MainEventResponse.class))
                     )
             ),
             @ApiResponse(
@@ -108,14 +109,14 @@ public class OrganizationEventController {
             )
     })
     @GetMapping("/{organizationId}/events")
-    public ResponseEntity<List<EventResponse>> getOrganizationEvents(
+    public ResponseEntity<List<MainEventResponse>> getOrganizationEvents(
             @PathVariable final Long organizationId,
             @AuthMember final LoginMember loginMember
     ) {
         List<Event> organizationEvents = organizationService.getOrganizationEvents(organizationId, loginMember);
 
-        List<EventResponse> eventResponses = organizationEvents.stream()
-                .map(EventResponse::from)
+        List<MainEventResponse> eventResponses = organizationEvents.stream()
+                .map(event -> MainEventResponse.from(event, loginMember))
                 .toList();
 
         return ResponseEntity.ok(eventResponses);

--- a/server/src/main/java/com/ahmadda/presentation/dto/MainEventResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/MainEventResponse.java
@@ -1,0 +1,48 @@
+package com.ahmadda.presentation.dto;
+
+import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.domain.event.Event;
+
+import java.time.LocalDateTime;
+
+public record MainEventResponse(
+        Long eventId,
+        String title,
+        String description,
+        LocalDateTime eventStart,
+        LocalDateTime eventEnd,
+        int currentGuestCount,
+        int maxCapacity,
+        String place,
+        LocalDateTime registrationStart,
+        LocalDateTime registrationEnd,
+        String organizerName,
+        boolean isGuest
+) {
+
+    public static MainEventResponse from(final Event event, final LoginMember loginMember) {
+        boolean isGuest = event.getGuests()
+                .stream()
+                .anyMatch(guest -> guest.getOrganizationMember()
+                        .getMember()
+                        .getId()
+                        .equals(loginMember.memberId()));
+
+        return new MainEventResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getDescription(),
+                event.getEventStart(),
+                event.getEventEnd(),
+                event.getGuests()
+                        .size(),
+                event.getMaxCapacity(),
+                event.getPlace(),
+                event.getRegistrationStart(),
+                event.getRegistrationEnd(),
+                event.getOrganizer()
+                        .getNickname(),
+                isGuest
+        );
+    }
+}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #664 

## ✨ 작업 내용

- 전체 이벤트 목록에 isGuest 필드를 추가하여 반환하도록 하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 조직 이벤트 목록에 표시 정보가 확대되었습니다: 제목, 기간, 장소, 정원과 현재 참여자 수, 등록 시작/마감, 주최자명을 한눈에 확인할 수 있습니다.
  - 로그인한 사용자의 참석 여부(게스트 여부)가 목록에서 바로 표시되어 참여 상태를 즉시 파악할 수 있습니다.
  - 개선된 응답 구조로 목록 로딩 시 더 풍부한 이벤트 요약 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->