### PR TITLE
[BE] 과거 이벤트 조회 api 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -192,7 +192,7 @@ public class EventService {
 
     private void validateOrganizationAccess(final Long organizationId, final Long memberId) {
         if (!organizationMemberRepository.existsByOrganizationIdAndMemberId(organizationId, memberId)) {
-            throw new ForbiddenException("조직에 소속되지 않아 권한이 없습니다.");
+            throw new ForbiddenException("이벤트 스페이스에 소속되지 않아 권한이 없습니다.");
         }
     }
 

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -284,4 +284,14 @@ public class EventService {
         ReminderHistory reminderHistory = reminder.remind(recipients, event, content);
         reminderHistoryRepository.save(reminderHistory);
     }
+
+    public List<Event> getActiveEvents(final Long organizationId, final LoginMember loginMember) {
+        Organization organization = getOrganization(organizationId);
+
+        if (!organizationMemberRepository.existsByOrganizationIdAndMemberId(organizationId, loginMember.memberId())) {
+            throw new ForbiddenException("조직에 참여하지 않아 권한이 없습니다.");
+        }
+
+        return organization.getActiveEvents(LocalDateTime.now());
+    }
 }

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -151,6 +151,16 @@ public class EventService {
         return event.isOrganizer(member);
     }
 
+    public List<Event> getPastEvent(
+            final Long organizationId,
+            final LoginMember loginMember,
+            final LocalDateTime compareDateTime
+    ) {
+        validateOrganizationAccess(organizationId, loginMember.memberId());
+
+        return eventRepository.findAllByEventOperationPeriodEventPeriodEndBefore(compareDateTime);
+    }
+
     private Member getMember(final Long loginMember) {
         return memberRepository.findById(loginMember)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));

--- a/server/src/main/java/com/ahmadda/application/OrganizationService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationService.java
@@ -3,10 +3,8 @@ package com.ahmadda.application;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.OrganizationCreateRequest;
 import com.ahmadda.application.dto.OrganizationUpdateRequest;
-import com.ahmadda.common.exception.ForbiddenException;
 import com.ahmadda.common.exception.NotFoundException;
 import com.ahmadda.common.exception.UnprocessableEntityException;
-import com.ahmadda.domain.event.Event;
 import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.member.MemberRepository;
 import com.ahmadda.domain.organization.InviteCode;
@@ -26,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -71,30 +68,6 @@ public class OrganizationService {
 
     public Organization getOrganizationById(final Long organizationId) {
         return getOrganization(organizationId);
-    }
-
-    public List<Event> getOrganizationEvents(final Long organizationId, final LoginMember loginMember) {
-        Organization organization = getOrganizationById(organizationId);
-
-        if (!organizationMemberRepository.existsByOrganizationIdAndMemberId(organizationId, loginMember.memberId())) {
-            throw new ForbiddenException("조직에 참여하지 않아 권한이 없습니다.");
-        }
-
-        return organization.getActiveEvents(LocalDateTime.now());
-    }
-
-    //TODO 07.25 이후 리팩터링 및 제거하기
-    @Transactional
-    @Deprecated
-    public Organization alwaysGetWoowacourse() {
-        Optional<Organization> organization = organizationRepository.findByName(WOOWACOURSE_NAME);
-
-        return organization.orElseGet(() -> organizationRepository.save(
-                Organization.create(
-                        WOOWACOURSE_NAME,
-                        "우아한테크코스입니다",
-                        imageUrl
-                )));
     }
 
     @Transactional

--- a/server/src/main/java/com/ahmadda/domain/event/EventRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventRepository.java
@@ -15,6 +15,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
             final LocalDateTime to
     );
 
+    List<Event> findAllByEventOperationPeriodEventPeriodEndBefore(final LocalDateTime now);
+
     List<Event> findAllByEventOperationPeriodEventPeriodStartBetween(
             final LocalDateTime from,
             final LocalDateTime to

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -4,8 +4,8 @@ import com.ahmadda.application.OrganizationService;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.OrganizationCreateRequest;
 import com.ahmadda.application.dto.OrganizationUpdateRequest;
-import com.ahmadda.domain.organization.OrganizationImageFile;
 import com.ahmadda.domain.organization.Organization;
+import com.ahmadda.domain.organization.OrganizationImageFile;
 import com.ahmadda.domain.organization.OrganizationMember;
 import com.ahmadda.presentation.dto.OrganizationCreateResponse;
 import com.ahmadda.presentation.dto.OrganizationParticipateRequest;
@@ -154,25 +154,6 @@ public class OrganizationController {
     @GetMapping("/{organizationId}")
     public ResponseEntity<OrganizationResponse> readOrganization(@PathVariable final Long organizationId) {
         Organization organization = organizationService.getOrganizationById(organizationId);
-        OrganizationResponse organizationResponse = OrganizationResponse.from(organization);
-
-        return ResponseEntity.ok(organizationResponse);
-    }
-
-    //TODO 07.25 이후 리팩터링 및 제거하기
-    @Deprecated
-    @Operation(summary = "우아코스 조직 정보 조회 (임시)", description = "항상 우아코스 조직 정보를 반환하는 임시 API입니다. 추후 제거될 예정입니다.")
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    content = @Content(
-                            schema = @Schema(implementation = OrganizationResponse.class)
-                    )
-            )
-    })
-    @GetMapping("/woowacourse")
-    public ResponseEntity<OrganizationResponse> getOrganization() {
-        Organization organization = organizationService.alwaysGetWoowacourse();
         OrganizationResponse organizationResponse = OrganizationResponse.from(organization);
 
         return ResponseEntity.ok(organizationResponse);

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -122,6 +122,77 @@ public class OrganizationEventController {
         return ResponseEntity.ok(eventResponses);
     }
 
+    @Operation(summary = "메인 화면의 과거에 열렸던 이벤트 목록 조회", description = "조직의 과거의 이벤트 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = MainEventResponse.class))
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보 입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events/past"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Forbidden",
+                                              "status": 403,
+                                              "detail": "조직에 소속되지 않은 회원입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events/past"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Not Found",
+                                              "status": 404,
+                                              "detail": "존재하지 않은 조직원 정보입니다.",
+                                              "instance": "/api/organizations/{organizationId}/events/past"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @GetMapping("/{organizationId}/events/past")
+    public ResponseEntity<List<MainEventResponse>> getPastEvents(
+            @PathVariable final Long organizationId,
+            @AuthMember final LoginMember loginMember
+    ) {
+        List<Event> organizationEvents = eventService.getPastEvent(organizationId, loginMember, LocalDateTime.now());
+
+        List<MainEventResponse> eventResponses = organizationEvents.stream()
+                .map(event -> MainEventResponse.from(event, loginMember))
+                .toList();
+
+        return ResponseEntity.ok(eventResponses);
+    }
+
     @Operation(summary = "이벤트 생성", description = "조직 ID에 속한 이벤트를 생성합니다. 해당 조직 ID에 속한 조직원만 이벤트를 생성할 수 있습니다.")
     @ApiResponses(value = {
             @ApiResponse(

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -113,7 +113,7 @@ public class OrganizationEventController {
             @PathVariable final Long organizationId,
             @AuthMember final LoginMember loginMember
     ) {
-        List<Event> organizationEvents = organizationService.getOrganizationEvents(organizationId, loginMember);
+        List<Event> organizationEvents = eventService.getActiveEvents(organizationId, loginMember);
 
         List<MainEventResponse> eventResponses = organizationEvents.stream()
                 .map(event -> MainEventResponse.from(event, loginMember))
@@ -122,7 +122,7 @@ public class OrganizationEventController {
         return ResponseEntity.ok(eventResponses);
     }
 
-    @Operation(summary = "메인 화면의 과거에 열렸던 이벤트 목록 조회", description = "조직의 과거의 이벤트 목록을 조회합니다.")
+    @Operation(summary = "과거에 열렸던 이벤트 목록 조회", description = "조직의 과거의 이벤트 목록을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
@@ -156,22 +156,6 @@ public class OrganizationEventController {
                                               "title": "Forbidden",
                                               "status": 403,
                                               "detail": "이벤트 스페이스에 소속되지 않은 회원입니다.",
-                                              "instance": "/api/organizations/{organizationId}/events/past"
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    content = @Content(
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "type": "about:blank",
-                                              "title": "Not Found",
-                                              "status": 404,
-                                              "detail": "존재하지 않은 조직원 정보입니다.",
                                               "instance": "/api/organizations/{organizationId}/events/past"
                                             }
                                             """

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -155,7 +155,7 @@ public class OrganizationEventController {
                                               "type": "about:blank",
                                               "title": "Forbidden",
                                               "status": 403,
-                                              "detail": "조직에 소속되지 않은 회원입니다.",
+                                              "detail": "이벤트 스페이스에 소속되지 않은 회원입니다.",
                                               "instance": "/api/organizations/{organizationId}/events/past"
                                             }
                                             """
@@ -577,7 +577,7 @@ public class OrganizationEventController {
                                               "type": "about:blank",
                                               "title": "Forbidden",
                                               "status": 403,
-                                              "detail": "조직에 소속되지 않은 회원입니다.",
+                                              "detail": "이벤트 스페이스에 소속되지 않은 회원입니다.",
                                               "instance": "/api/organizations/events/{eventId}/registration/close"
                                             }
                                             """

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -562,7 +562,7 @@ public class OrganizationEventController {
                                               "title": "Forbidden",
                                               "status": 403,
                                               "detail": "이벤트 스페이스에 소속되지 않은 회원입니다.",
-                                              "instance": "/api/organizations/events/{eventId}/registration/close"
+                                              "instance": "/api/organizations/events/{eventId}"
                                             }
                                             """
                             )

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -14,6 +14,7 @@ import com.ahmadda.presentation.dto.EventLoadResponse;
 import com.ahmadda.presentation.dto.EventResponse;
 import com.ahmadda.presentation.dto.EventTitleResponse;
 import com.ahmadda.presentation.dto.EventUpdateResponse;
+import com.ahmadda.presentation.dto.MainEventResponse;
 import com.ahmadda.presentation.dto.OrganizerStatusResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -112,7 +113,7 @@ public class OrganizationEventController {
             @PathVariable final Long organizationId,
             @AuthMember final LoginMember loginMember
     ) {
-        List<Event> organizationEvents = organizationService.getOrganizationEvents(organizationId, loginMember);
+        List<Event> organizationEvents = eventService.getActiveEvents(organizationId, loginMember);
 
         List<MainEventResponse> eventResponses = organizationEvents.stream()
                 .map(event -> MainEventResponse.from(event, loginMember))

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -14,6 +14,7 @@ import com.ahmadda.presentation.dto.EventLoadResponse;
 import com.ahmadda.presentation.dto.EventResponse;
 import com.ahmadda.presentation.dto.EventTitleResponse;
 import com.ahmadda.presentation.dto.EventUpdateResponse;
+import com.ahmadda.presentation.dto.MainEventResponse;
 import com.ahmadda.presentation.dto.OrganizerStatusResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -55,7 +56,7 @@ public class OrganizationEventController {
             @ApiResponse(
                     responseCode = "200",
                     content = @Content(
-                            array = @ArraySchema(schema = @Schema(implementation = EventResponse.class))
+                            array = @ArraySchema(schema = @Schema(implementation = MainEventResponse.class))
                     )
             ),
             @ApiResponse(
@@ -108,14 +109,14 @@ public class OrganizationEventController {
             )
     })
     @GetMapping("/{organizationId}/events")
-    public ResponseEntity<List<EventResponse>> getOrganizationEvents(
+    public ResponseEntity<List<MainEventResponse>> getOrganizationEvents(
             @PathVariable final Long organizationId,
             @AuthMember final LoginMember loginMember
     ) {
         List<Event> organizationEvents = organizationService.getOrganizationEvents(organizationId, loginMember);
 
-        List<EventResponse> eventResponses = organizationEvents.stream()
-                .map(EventResponse::from)
+        List<MainEventResponse> eventResponses = organizationEvents.stream()
+                .map(event -> MainEventResponse.from(event, loginMember))
                 .toList();
 
         return ResponseEntity.ok(eventResponses);

--- a/server/src/main/java/com/ahmadda/presentation/dto/MainEventResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/MainEventResponse.java
@@ -1,0 +1,48 @@
+package com.ahmadda.presentation.dto;
+
+import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.domain.event.Event;
+
+import java.time.LocalDateTime;
+
+public record MainEventResponse(
+        Long eventId,
+        String title,
+        String description,
+        LocalDateTime eventStart,
+        LocalDateTime eventEnd,
+        int currentGuestCount,
+        int maxCapacity,
+        String place,
+        LocalDateTime registrationStart,
+        LocalDateTime registrationEnd,
+        String organizerName,
+        boolean isGuest
+) {
+
+    public static MainEventResponse from(final Event event, final LoginMember loginMember) {
+        boolean isGuest = event.getGuests()
+                .stream()
+                .anyMatch(guest -> guest.getOrganizationMember()
+                        .getMember()
+                        .getId()
+                        .equals(loginMember.memberId()));
+
+        return new MainEventResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getDescription(),
+                event.getEventStart(),
+                event.getEventEnd(),
+                event.getGuests()
+                        .size(),
+                event.getMaxCapacity(),
+                event.getPlace(),
+                event.getRegistrationStart(),
+                event.getRegistrationEnd(),
+                event.getOrganizer()
+                        .getNickname(),
+                isGuest
+        );
+    }
+}

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -808,50 +808,6 @@ class EventServiceTest {
                 .hasMessage("존재하지 않는 회원입니다.");
     }
 
-    private Organization createOrganization() {
-        var organization = Organization.create("우테코", "우테코입니다.", "image");
-
-        return organizationRepository.save(organization);
-    }
-
-    private LoginMember createLoginMember(Member member) {
-        return new LoginMember(member.getId());
-    }
-
-    private Member createMember() {
-        return memberRepository.save(Member.create("name", "ahmadda@ahmadda.com", "testPicture"));
-    }
-
-    private Member createMember(String name, String email) {
-        return memberRepository.save(Member.create(name, email, "testPicture"));
-    }
-
-    private OrganizationMember createOrganizationMember(Organization organization, Member member) {
-        var organizationMember = OrganizationMember.create("surf", member, organization, OrganizationMemberRole.USER);
-
-        return organizationMemberRepository.save(organizationMember);
-    }
-
-    private Event createEvent(final OrganizationMember organizationMember, final Organization organization) {
-        var now = LocalDateTime.now();
-
-        var event = Event.create(
-                "title",
-                "description",
-                "place",
-                organizationMember,
-                organization,
-                EventOperationPeriod.create(
-                        now.plusDays(1), now.plusDays(2),
-                        now.plusDays(3), now.plusDays(4),
-                        now
-                ),
-                10
-        );
-
-        return eventRepository.save(event);
-    }
-
     @Test
     void 과거_이벤트를_조회할_수_있다() {
         // given
@@ -898,11 +854,11 @@ class EventServiceTest {
         // when // then
         assertThatThrownBy(() -> sut.getActiveEvents(999L, loginMember))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 조직 정보입니다.");
+                .hasMessage("존재하지 않은 조직 정보입니다.");
     }
 
     @Test
-    void 과거_이벤트는_조직원이_아니면_조회시_예외가_발생한다() {
+    void 과거_이벤트_조회시_조직에_속하지_않으면_예외가_발생한다() {
         // given
         var member = createMember();
         var organization = createOrganization();
@@ -962,6 +918,50 @@ class EventServiceTest {
         assertThat(events).hasSize(2)
                 .extracting(Event::getTitle)
                 .containsExactlyInAnyOrder("EventA1", "EventA2");
+    }
+
+    private Organization createOrganization() {
+        var organization = Organization.create("우테코", "우테코입니다.", "image");
+
+        return organizationRepository.save(organization);
+    }
+
+    private LoginMember createLoginMember(Member member) {
+        return new LoginMember(member.getId());
+    }
+
+    private Member createMember() {
+        return memberRepository.save(Member.create("name", "ahmadda@ahmadda.com", "testPicture"));
+    }
+
+    private Member createMember(String name, String email) {
+        return memberRepository.save(Member.create(name, email, "testPicture"));
+    }
+
+    private OrganizationMember createOrganizationMember(Organization organization, Member member) {
+        var organizationMember = OrganizationMember.create("surf", member, organization, OrganizationMemberRole.USER);
+
+        return organizationMemberRepository.save(organizationMember);
+    }
+
+    private Event createEvent(final OrganizationMember organizationMember, final Organization organization) {
+        var now = LocalDateTime.now();
+
+        var event = Event.create(
+                "title",
+                "description",
+                "place",
+                organizationMember,
+                organization,
+                EventOperationPeriod.create(
+                        now.plusDays(1), now.plusDays(2),
+                        now.plusDays(3), now.plusDays(4),
+                        now
+                ),
+                10
+        );
+
+        return eventRepository.save(event);
     }
 
     private Organization createOrganization(String name, String description, String imageUrl) {

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -899,7 +899,7 @@ class EventServiceTest {
         //when // then
         assertThatThrownBy(() -> sut.getPastEvent(organization.getId(), loginMember, LocalDateTime.now()))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("조직에 소속되지 않아 권한이 없습니다.");
+                .hasMessage("이벤트 스페이스에 소속되지 않아 권한이 없습니다.");
     }
 
     private Event createEventWithDates(


### PR DESCRIPTION
## 관련 이슈
close #668 

## ✨ 작업 내용
- 과거 이벤트 조회 기능을 구현합니다.

## 참고사항

```
 List<Event> findAllByEventOperationPeriodRegistrationEventPeriodEndBetween(
            final LocalDateTime from,
            final LocalDateTime to
    );

```

위 방식(원래 있던 쿼리)를 사용하려고했으나, LocalDateTime.MIN ~ LocalDateTIme.now()
좀 더 이해하기 쉽게 아래 방식을 채택했습니다 (메서드명이 좀 길긴하지만요..)
```
List<Event> findAllByEventOperationPeriodEventPeriodEndBefore(final LocalDateTime now);

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새 기능
  - 과거 이벤트 조회 엔드포인트 추가: GET /{organizationId}/events/past — 종료된 이벤트 목록 반환(이벤트 스페이스 소속 회원만 접근).
- 변경 사항
  - 전체 이벤트 응답 포맷 통합: MainEventResponse로 전환(제목, 기간, 장소, 정원/참여자 수, 주최자, 게스트 여부 등).
  - 권한 오류 문구 일부 수정: 이벤트 스페이스 관련 표현으로 통일.
- 제거
  - 단일 기본 조직 제공 엔드포인트 및 관련 서비스 메서드 삭제.
- 문서
  - OpenAPI 스키마 및 응답 예시 업데이트.
- 테스트
  - 과거/활성 이벤트 조회 및 권한 검증 단위 테스트 추가·정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->