### PR TITLE
[BE] 포키 30분내에 보낼 수 있는 횟수 3번으로 제한

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/notification/Poke.java
+++ b/server/src/main/java/com/ahmadda/domain/notification/Poke.java
@@ -4,22 +4,21 @@ import com.ahmadda.common.exception.UnprocessableEntityException;
 import com.ahmadda.domain.event.Event;
 import com.ahmadda.domain.organization.Organization;
 import com.ahmadda.domain.organization.OrganizationMember;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 //TODO 성능 문제 추후에 고려
 @Service
 @RequiredArgsConstructor
 public class Poke {
 
-    private static final int MAX_SENDABLE_COUNT = 10;
+    private static final int MAX_SENDABLE_COUNT = 3;
     private static final Duration DUPLICATE_POKE_COUNT_MINUTES = Duration.ofMinutes(30L);
     private static final String POKE_MESSAGE_FORMAT = "%s님에게 포키가 왔습니다! 🎉";
 
@@ -140,11 +139,11 @@ public class Poke {
     ) {
         Organization organization = event.getOrganization();
 
-        if (!organization.isExistOrganizationMember(sendOrganizationMember)) {
+        if (!sendOrganizationMember.isBelongTo(organization)) {
             throw new UnprocessableEntityException("포키를 보내려면 해당 조직에 참여하고 있어야 합니다.");
         }
 
-        if (!organization.isExistOrganizationMember(receiveOrganizationMember)) {
+        if (!receiveOrganizationMember.isBelongTo(organization)) {
             throw new UnprocessableEntityException("포키 대상이 해당 조직에 참여하고 있어야 합니다.");
         }
     }

--- a/server/src/test/java/com/ahmadda/domain/notification/PokeTest.java
+++ b/server/src/test/java/com/ahmadda/domain/notification/PokeTest.java
@@ -1,5 +1,10 @@
 package com.ahmadda.domain.notification;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
 import com.ahmadda.annotation.IntegrationTest;
 import com.ahmadda.common.exception.UnprocessableEntityException;
 import com.ahmadda.domain.event.Event;
@@ -13,19 +18,13 @@ import com.ahmadda.domain.organization.OrganizationMember;
 import com.ahmadda.domain.organization.OrganizationMemberRepository;
 import com.ahmadda.domain.organization.OrganizationMemberRole;
 import com.ahmadda.domain.organization.OrganizationRepository;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
 class PokeTest {
@@ -159,7 +158,7 @@ class PokeTest {
     }
 
     @Test
-    void 포키_30분내_10번_전송_횟수_제한을_초과할_때_예외가_발생한다() {
+    void 포키_30분내_3번_전송_횟수_제한을_초과할_때_예외가_발생한다() {
         // given
         var organization = createOrganization("ahmadda");
         var senderMember = createMember("sender");
@@ -170,7 +169,7 @@ class PokeTest {
         var sentAt = LocalDateTime.now();
 
         var firstSentAt = sentAt;
-        for (int i = 1; i <= 10; i++) {
+        for (int i = 1; i <= 3; i++) {
             if (i == 1) {
                 firstSentAt = sentAt.plusMinutes(i);
             }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #671 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
너무 많은 포키가 와 불편하다는 사용자의 의견을 수용해 30분내에 보낼 수 있는 포키 횟수를 3번으로 제한했습니다.

## 🙏 기타 참고 사항

포키 메시지 선택은 추후 메시지 형식이 정해지면 할 예정입니다~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 포크 전송 제한 강화: 30분 내 동일 대상에게 보낼 수 있는 횟수를 10회에서 3회로 축소. 제한 초과 시 남은 대기 시간을 안내하는 오류 메시지를 제공합니다.
- Refactor
  - 조직 멤버십 검증 로직을 단순화하여 검증 일관성과 유지보수성을 개선했습니다.
- Tests
  - 새 전송 제한 정책을 반영한 테스트 케이스 업데이트 및 알림 전송 모킹 검증을 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->