### PR TITLE
[BE] Amazon SES를 통한 이메일 발송 기능 전환

### DIFF
--- a/server/src/main/java/com/ahmadda/infra/config/AsyncConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/config/AsyncConfig.java
@@ -1,7 +1,6 @@
 package com.ahmadda.infra.config;
 
 import com.ahmadda.infra.logger.AsyncTraceLoggingDecorator;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
@@ -15,9 +14,13 @@ import java.util.concurrent.Executor;
 public class AsyncConfig implements AsyncConfigurer {
 
     // TODO. 추후 ThreadPoolTaskExecutor의 thread 설정 변경 및 graceful shutdown 고려 필요
-    @Bean
     @Override
     public Executor getAsyncExecutor() {
+        return taskExecutor();
+    }
+
+    @Bean
+    public ThreadPoolTaskExecutor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setThreadNamePrefix("async-");
         executor.setTaskDecorator(new AsyncTraceLoggingDecorator());

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
@@ -101,7 +101,7 @@ public class SmtpEmailNotifier implements EmailNotifier {
         try {
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
 
-            helper.setTo("amadda.team@gmail.com");
+            helper.setFrom("아맞다 <noreply@ahmadda.com>");
             // TODO. 추후 BCC 수신자가 100명 이상일 경우, 배치 처리 고려
             helper.setBcc(bccRecipients.toArray(String[]::new));
             helper.setSubject(subject);

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/config/MailConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/config/MailConfig.java
@@ -10,26 +10,78 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.thymeleaf.TemplateEngine;
 
-@EnableConfigurationProperties(NotificationProperties.class)
+import java.util.Map;
+import java.util.Properties;
+
+@EnableConfigurationProperties({NotificationProperties.class, SmtpProperties.class})
 @Configuration
 public class MailConfig {
 
     @Bean
-    @ConditionalOnProperty(name = "mail.mock", havingValue = "true")
+    @ConditionalOnProperty(name = "mail.provider", havingValue = "mock")
     public EmailNotifier mockEmailNotifier() {
         return new MockEmailNotifier();
     }
 
     @Bean
-    @ConditionalOnProperty(name = "mail.mock", havingValue = "false", matchIfMissing = true)
-    public EmailNotifier smtpEmailNotifier(
-            final JavaMailSender javaMailSender,
+    @ConditionalOnProperty(name = "mail.provider", havingValue = "gmail")
+    public EmailNotifier gmailEmailNotifier(
+            final JavaMailSender smtpMailSender,
             final TemplateEngine templateEngine,
             final NotificationProperties notificationProperties,
             final EntityManager em
     ) {
-        return new SmtpEmailNotifier(javaMailSender, templateEngine, notificationProperties, em);
+        return new SmtpEmailNotifier(smtpMailSender, templateEngine, notificationProperties, em);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "mail.provider", havingValue = "aws")
+    public EmailNotifier awsEmailNotifier(
+            final JavaMailSender smtpMailSender,
+            final TemplateEngine templateEngine,
+            final NotificationProperties notificationProperties,
+            final EntityManager em
+    ) {
+        return new SmtpEmailNotifier(smtpMailSender, templateEngine, notificationProperties, em);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "mail.provider", havingValue = "gmail")
+    public JavaMailSender gmailSmtpMailSender(final SmtpProperties props) {
+        SmtpProperties.Account acc = props.getGoogle();
+
+        return getJavaMailSender(acc);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "mail.provider", havingValue = "aws")
+    public JavaMailSender awsSmtpMailSender(final SmtpProperties props) {
+        SmtpProperties.Account acc = props.getAws();
+        
+        return getJavaMailSender(acc);
+    }
+
+    private JavaMailSender getJavaMailSender(final SmtpProperties.Account acc) {
+        JavaMailSenderImpl sender = new JavaMailSenderImpl();
+        sender.setHost(acc.getHost());
+        sender.setPort(acc.getPort());
+        sender.setUsername(acc.getUsername());
+        sender.setPassword(acc.getPassword());
+        sender.setDefaultEncoding("UTF-8");
+        apply(sender, acc.getProperties());
+
+        return sender;
+    }
+
+    private void apply(final JavaMailSenderImpl sender, final Map<String, String> props) {
+        if (props == null) {
+            return;
+        }
+
+        Properties javaMailProps = sender.getJavaMailProperties();
+        javaMailProps.putAll(props);
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/config/SmtpProperties.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/config/SmtpProperties.java
@@ -1,0 +1,76 @@
+package com.ahmadda.infra.notification.mail.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Map;
+
+@ConfigurationProperties(prefix = "smtp")
+@Getter
+public class SmtpProperties {
+
+    private final Account google;
+    private final Account aws;
+
+    public SmtpProperties(final Account google, final Account aws) {
+        validateProperties(google, aws);
+
+        this.google = google;
+        this.aws = aws;
+    }
+
+    private void validateProperties(final Account google, final Account aws) {
+        if (google == null) {
+            throw new IllegalArgumentException("SMTP google 계정 설정이 존재하지 않습니다.");
+        }
+        if (aws == null) {
+            throw new IllegalArgumentException("SMTP aws 계정 설정이 존재하지 않습니다.");
+        }
+    }
+
+    @Getter
+    public static class Account {
+
+        private final String host;
+        private final int port;
+        private final String username;
+        private final String password;
+        private final Map<String, String> properties;
+
+        public Account(
+                final String host,
+                final int port,
+                final String username,
+                final String password,
+                final Map<String, String> properties
+        ) {
+            validateProperties(host, port, username, password);
+
+            this.host = host;
+            this.port = port;
+            this.username = username;
+            this.password = password;
+            this.properties = properties;
+        }
+
+        private static void validateProperties(
+                final String host,
+                final int port,
+                final String username,
+                final String password
+        ) {
+            if (host == null || host.isBlank()) {
+                throw new IllegalArgumentException("SMTP host 설정이 비어있습니다.");
+            }
+            if (port <= 0) {
+                throw new IllegalArgumentException("SMTP port 설정이 올바르지 않습니다.");
+            }
+            if (username == null || username.isBlank()) {
+                throw new IllegalArgumentException("SMTP username 설정이 비어있습니다.");
+            }
+            if (password == null || password.isBlank()) {
+                throw new IllegalArgumentException("SMTP password 설정이 비어있습니다.");
+            }
+        }
+    }
+}

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -21,7 +21,7 @@ spring:
   cloud:
     aws:
       s3:
-        region: ${aws.prod.s3.region}
+        region: ${aws.dev.s3.region}
 
 jwt:
   access-secret-key: ${jwt.dev.access.secret-key}
@@ -49,9 +49,6 @@ cors:
 
 notification:
   redirect-url-prefix: https://staging.ahmadda.com/
-
-mail:
-  provider: gmail
 
 aws:
   s3:

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -50,6 +50,9 @@ cors:
 notification:
   redirect-url-prefix: https://staging.ahmadda.com/
 
+mail:
+  provider: gmail
+
 aws:
   s3:
     bucket: ${aws.dev.s3.bucket}

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -24,10 +24,10 @@ spring:
         region: ${aws.prod.s3.region}
 
 jwt:
-  access-secret-key: ${jwt.dev.access-secret-key}
-  access-expiration: ${jwt.dev.access-expiration}
-  refresh-secret-key: ${jwt.dev.refresh-secret-key}
-  refresh-expiration: ${jwt.dev.refresh-expiration}
+  access-secret-key: ${jwt.dev.access.secret-key}
+  access-expiration: ${jwt.dev.access.expiration}
+  refresh-secret-key: ${jwt.dev.refresh.secret-key}
+  refresh-expiration: ${jwt.dev.refresh.expiration}
 
 cookie:
   refresh-token:

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -20,10 +20,10 @@ spring:
         region: ap-northeast-2
 
 jwt:
-  access-secret-key: ${jwt.local.access-secret-key}
-  access-expiration: ${jwt.local.access-expiration}
-  refresh-secret-key: ${jwt.local.refresh-secret-key}
-  refresh-expiration: ${jwt.local.refresh-expiration}
+  access-secret-key: ${jwt.local.access.secret-key}
+  access-expiration: ${jwt.local.access.expiration}
+  refresh-secret-key: ${jwt.local.refresh.secret-key}
+  refresh-expiration: ${jwt.local.refresh.expiration}
 
 cookie:
   refresh-token:

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -43,7 +43,7 @@ notification:
   redirect-url-prefix: http://localhost:5173/
 
 mail:
-  mock: true
+  provider: mock
 
 push:
   mock: true

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -17,7 +17,7 @@ spring:
   cloud:
     aws:
       s3:
-        region: ap-northeast-2
+        region: ${aws.local.s3.region}
 
 jwt:
   access-secret-key: ${jwt.local.access.secret-key}
@@ -43,7 +43,7 @@ notification:
   redirect-url-prefix: http://localhost:5173/
 
 mail:
-  provider: mock
+  mock: true
 
 push:
   mock: true

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -45,6 +45,9 @@ cors:
 notification:
   redirect-url-prefix: https://ahmadda.com/
 
+mail:
+  provider: gmail
+
 aws:
   s3:
     bucket: ${aws.prod.s3.bucket}

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -21,10 +21,10 @@ spring:
         static: ap-northeast-2
 
 jwt:
-  access-secret-key: ${jwt.prod.access-secret-key}
-  access-expiration: ${jwt.prod.access-expiration}
-  refresh-secret-key: ${jwt.prod.refresh-secret-key}
-  refresh-expiration: ${jwt.prod.refresh-expiration}
+  access-secret-key: ${jwt.prod.access.secret-key}
+  access-expiration: ${jwt.prod.access.expiration}
+  refresh-secret-key: ${jwt.prod.refresh.secret-key}
+  refresh-expiration: ${jwt.prod.refresh.expiration}
 
 cookie:
   refresh-token:

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -45,9 +45,6 @@ cors:
 notification:
   redirect-url-prefix: https://ahmadda.com/
 
-mail:
-  provider: gmail
-
 aws:
   s3:
     bucket: ${aws.prod.s3.bucket}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -20,21 +20,6 @@ spring:
   application:
     name: ah-madda
 
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: amadda.mailbot
-    password: ${smtp.password}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-          connectiontimeout: 5000
-          timeout: 10000
-          writetimeout: 5000
-
 oauth:
   google:
     client-id: ${oauth.google.client-id}
@@ -43,6 +28,31 @@ oauth:
     user-uri: ${oauth.google.user-uri}
     connect-timeout: 3000
     read-timeout: 5000
+
+smtp:
+  google:
+    host: ${secrets.smtp.google.host}
+    port: 587
+    username: ${secrets.smtp.google.username}
+    password: ${secrets.smtp.google.password}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+      mail.smtp.connectiontimeout: 5000
+      mail.smtp.timeout: 10000
+      mail.smtp.writetimeout: 5000
+
+  aws:
+    host: ${secrets.smtp.aws.host}
+    port: 587
+    username: ${secrets.smtp.aws.username}
+    password: ${secrets.smtp.aws.password}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+      mail.smtp.connectiontimeout: 5000
+      mail.smtp.timeout: 10000
+      mail.smtp.writetimeout: 5000
 
 springdoc:
   default-consumes-media-type: application/json

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/FcmPushNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/FcmPushNotifierTest.java
@@ -4,10 +4,10 @@ import com.ahmadda.annotation.IntegrationTest;
 import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.member.MemberRepository;
 import com.ahmadda.domain.notification.PushNotificationPayload;
-import com.ahmadda.domain.notification.PushNotifier;
 import com.ahmadda.domain.organization.Organization;
 import com.ahmadda.domain.organization.OrganizationMember;
 import com.ahmadda.domain.organization.OrganizationMemberRole;
+import com.ahmadda.infra.notification.push.FcmPushNotifier;
 import com.ahmadda.infra.notification.push.FcmRegistrationToken;
 import com.ahmadda.infra.notification.push.FcmRegistrationTokenRepository;
 import org.junit.jupiter.api.Disabled;
@@ -24,7 +24,7 @@ import java.util.List;
 class FcmPushNotifierTest {
 
     @Autowired
-    private PushNotifier fcmPushNotifier;
+    private FcmPushNotifier fcmPushNotifier;
 
     @Autowired
     private FcmRegistrationTokenRepository fcmRegistrationTokenRepository;

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Disabled
 @IntegrationTest
-@TestPropertySource(properties = "mail.mock=false")
+@TestPropertySource(properties = "mail.provider=gmail")
 class SmtpEmailNotifierTest {
 
     @Autowired

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
@@ -2,11 +2,11 @@ package com.ahmadda.learning.infra.notification;
 
 import com.ahmadda.annotation.IntegrationTest;
 import com.ahmadda.domain.member.Member;
-import com.ahmadda.domain.notification.EmailNotifier;
 import com.ahmadda.domain.notification.EventEmailPayload;
 import com.ahmadda.domain.organization.Organization;
 import com.ahmadda.domain.organization.OrganizationMember;
 import com.ahmadda.domain.organization.OrganizationMemberRole;
+import com.ahmadda.infra.notification.mail.SmtpEmailNotifier;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,11 +18,11 @@ import java.util.List;
 
 @Disabled
 @IntegrationTest
-@TestPropertySource(properties = "mail.provider=gmail")
+@TestPropertySource(properties = "mail.mock=false")
 class SmtpEmailNotifierTest {
 
     @Autowired
-    private EmailNotifier smtpEmailNotifier;
+    private SmtpEmailNotifier smtpEmailNotifier;
 
     @Test
     void 실제_SMTP로_메일을_발송한다() {

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -36,7 +36,7 @@ notification:
   redirect-url-prefix: http://localhost:5173/
 
 mail:
-  mock: true
+  provider: mock
 
 push:
   mock: true

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -36,7 +36,7 @@ notification:
   redirect-url-prefix: http://localhost:5173/
 
 mail:
-  provider: mock
+  mock: true
 
 push:
   mock: true

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -13,10 +13,10 @@ spring:
         region: ap-northeast-2
 
 jwt:
-  access-secret-key: ${jwt.local.access-secret-key}
-  access-expiration: ${jwt.local.access-expiration}
-  refresh-secret-key: ${jwt.local.refresh-secret-key}
-  refresh-expiration: ${jwt.local.refresh-expiration}
+  access-secret-key: ${jwt.local.access.secret-key}
+  access-expiration: ${jwt.local.access.expiration}
+  refresh-secret-key: ${jwt.local.refresh.secret-key}
+  refresh-expiration: ${jwt.local.refresh.expiration}
 
 cookie:
   refresh-token:


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #690

## ✨ 작업 내용

- Amazon SES SMTP 자격 증명 생성 및 설정
- `spring-boot-starter-mail` 기반 SES SMTP 연동 구성
- 기존 이메일 발송 로직이 SES 환경에서도 정상 동작하는지 검증
- 로컬/스테이징 환경 테스트 후 프로덕션 적용 준비
  - 정상 동작은 확인했습니다!

## 🙏 기타 참고 사항

현재 계정은 SES 샌드박스 심사 중이라 프로덕션 사용은 바로 어렵습니다.  
심사가 완료될 때까지는 환경별로 어떤 `EmailNotifier`를 사용할지 설정 방식을 함께 논의해보면 좋겠습니다.  

이번 구현은 제가 선호하는 패턴을 반영했는데, 이에 대해 여러분들의 의견도 듣고 싶습니다.  
샌드박스 심사가 통과될 때까지 계속 논의하며 방향을 다듬어가면 좋겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 프로파일 기반으로 Gmail/AWS 등 다중 SMTP 제공자 선택이 가능해졌습니다.
  - API 문서 UI가 /specification 경로에 제공되며, 메서드 정렬 및 인증 유지가 활성화되었습니다.

- **설정**
  - 기존 mail 설정이 제거되고 새로운 smtp.* 구성 구조(google/aws)로 전환되었습니다.
  - 개발/로컬/운영/테스트 환경의 JWT 키 참조가 중첩된 경로로 정리되었습니다.

- **버그 수정/동작 변경**
  - 발송 메시지의 From 헤더가 업데이트되고 To 수신자 설정 방식이 변경되었습니다.

- **테스트**
  - 관련 테스트들이 제공자별 구현에 맞게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->