### PR TITLE
[BE] 이벤트 공동 주최자 기능 구현

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -34,7 +34,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 @Slf4j
@@ -91,12 +94,16 @@ public class EventService {
     private List<OrganizationMember> getOrganizationMemberByIds(
             final List<Long> organizationMemberIds
     ) {
-        List<OrganizationMember> organizationMembers = organizationMemberRepository.findAllById(organizationMemberIds);
-        if (organizationMembers.size() != organizationMemberIds.size()) {
+        Set<Long> organizationMemberIdsSet = new HashSet<>(organizationMemberIds);
+
+        List<OrganizationMember> findOrganizationMembers =
+                organizationMemberRepository.findAllById(new ArrayList<>(organizationMemberIdsSet));
+
+        if (findOrganizationMembers.size() != organizationMemberIdsSet.size()) {
             throw new EntityNotFoundException("요청된 조직 구성원 중 일부를 찾을 수 없습니다.");
         }
 
-        return organizationMembers;
+        return findOrganizationMembers;
     }
 
     @Transactional

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -25,7 +25,6 @@ import com.ahmadda.domain.organization.Organization;
 import com.ahmadda.domain.organization.OrganizationMember;
 import com.ahmadda.domain.organization.OrganizationMemberRepository;
 import com.ahmadda.domain.organization.OrganizationRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -100,7 +99,7 @@ public class EventService {
                 organizationMemberRepository.findAllById(new ArrayList<>(organizationMemberIdsSet));
 
         if (findOrganizationMembers.size() != organizationMemberIdsSet.size()) {
-            throw new EntityNotFoundException("요청된 조직 구성원 중 일부를 찾을 수 없습니다.");
+            throw new NotFoundException("요청된 조직 구성원 중 일부 구성원을 찾을 수 없습니다.");
         }
 
         return findOrganizationMembers;

--- a/server/src/main/java/com/ahmadda/application/OrganizationMemberEventService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationMemberEventService.java
@@ -3,7 +3,8 @@ package com.ahmadda.application;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.common.exception.NotFoundException;
 import com.ahmadda.domain.event.Event;
-import com.ahmadda.domain.event.EventRepository;
+import com.ahmadda.domain.event.EventOwnerOrganizationMember;
+import com.ahmadda.domain.event.EventOwnerOrganizationMemberRepository;
 import com.ahmadda.domain.organization.OrganizationMember;
 import com.ahmadda.domain.organization.OrganizationMemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +16,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrganizationMemberEventService {
 
-    private final EventRepository eventRepository;
+    private final EventOwnerOrganizationMemberRepository eventOwnerOrganizationMemberRepository;
     private final OrganizationMemberRepository organizationMemberRepository;
 
     public List<Event> getOwnerEvents(final Long organizationId, final LoginMember loginMember) {
         OrganizationMember organizationMember = getOrganizationMember(organizationId, loginMember);
 
-        return eventRepository.findAllByOrganizer(organizationMember);
+        List<EventOwnerOrganizationMember> eventOwnerOrganizationMembers =
+                eventOwnerOrganizationMemberRepository.findAllByOrganizationMemberId(organizationMember.getId());
+
+        return eventOwnerOrganizationMembers.stream()
+                .map((EventOwnerOrganizationMember::getEvent))
+                .toList();
     }
 
     public List<Event> getParticipantEvents(final Long organizationId, final LoginMember loginMember) {

--- a/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
@@ -28,4 +28,26 @@ public record EventCreateRequest(
         List<Long> eventOwnerOrganizationMembers
 ) {
 
+    public EventCreateRequest(
+            String title,
+            String description,
+            String place,
+            LocalDateTime registrationEnd,
+            LocalDateTime eventStart,
+            LocalDateTime eventEnd,
+            int maxCapacity,
+            List<QuestionCreateRequest> questions
+    ) {
+        this(
+                title,
+                description,
+                place,
+                registrationEnd,
+                eventStart,
+                eventEnd,
+                maxCapacity,
+                questions,
+                List.of()
+        );
+    }
 }

--- a/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
@@ -23,7 +23,9 @@ public record EventCreateRequest(
         LocalDateTime eventEnd,
         int maxCapacity,
         @Valid
-        List<QuestionCreateRequest> questions
+        List<QuestionCreateRequest> questions,
+        @NotNull
+        List<Long> hasRoleOrganizationMembers
 ) {
 
 }

--- a/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
+++ b/server/src/main/java/com/ahmadda/application/dto/EventCreateRequest.java
@@ -25,7 +25,7 @@ public record EventCreateRequest(
         @Valid
         List<QuestionCreateRequest> questions,
         @NotNull
-        List<Long> hasRoleOrganizationMembers
+        List<Long> eventOwnerOrganizationMembers
 ) {
 
 }

--- a/server/src/main/java/com/ahmadda/domain/event/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/event/Event.java
@@ -29,6 +29,7 @@ import org.jspecify.annotations.Nullable;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -51,7 +52,7 @@ public class Event extends BaseEntity {
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Question> questions = new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "event")
     private final List<EventOwnerOrganizationMember> eventOwnerOrganizationMembers = new ArrayList<>();
 
     @Id
@@ -77,10 +78,8 @@ public class Event extends BaseEntity {
     @JoinColumn(name = "organization_id", nullable = false)
     private Organization organization;
 
-
     @Embedded
     private EventOperationPeriod eventOperationPeriod;
-
 
     @Column(nullable = false)
     private int maxCapacity;
@@ -112,7 +111,12 @@ public class Event extends BaseEntity {
     }
 
     private List<EventOwnerOrganizationMember> createEventOwnerOrganizationMembers(final List<OrganizationMember> eventOwnerOrganizationMembers) {
-        return eventOwnerOrganizationMembers.stream()
+        Set<OrganizationMember> organizationMembers = new HashSet<>(eventOwnerOrganizationMembers);
+        organizationMembers.add(organizer);
+
+        return organizationMembers.stream()
+                .toList()
+                .stream()
                 .map(organizationMember -> new EventOwnerOrganizationMember(this, organizationMember))
                 .toList();
     }
@@ -149,6 +153,29 @@ public class Event extends BaseEntity {
             final Organization organization,
             final EventOperationPeriod eventOperationPeriod,
             final int maxCapacity,
+            final Question... questions
+    ) {
+        return new Event(
+                title,
+                description,
+                place,
+                organizer,
+                organization,
+                eventOperationPeriod,
+                maxCapacity,
+                List.of(),
+                new ArrayList<>(List.of(questions))
+        );
+    }
+
+    public static Event create(
+            final String title,
+            final String description,
+            final String place,
+            final OrganizationMember organizer,
+            final Organization organization,
+            final EventOperationPeriod eventOperationPeriod,
+            final int maxCapacity,
             final List<OrganizationMember> eventOwnerOrganizationMembers,
             final List<Question> questions
     ) {
@@ -161,6 +188,29 @@ public class Event extends BaseEntity {
                 eventOperationPeriod,
                 maxCapacity,
                 eventOwnerOrganizationMembers,
+                questions
+        );
+    }
+
+    public static Event create(
+            final String title,
+            final String description,
+            final String place,
+            final OrganizationMember organizer,
+            final Organization organization,
+            final EventOperationPeriod eventOperationPeriod,
+            final int maxCapacity,
+            final List<Question> questions
+    ) {
+        return new Event(
+                title,
+                description,
+                place,
+                organizer,
+                organization,
+                eventOperationPeriod,
+                maxCapacity,
+                List.of(),
                 questions
         );
     }

--- a/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
@@ -73,8 +73,7 @@ public class EventOwnerOrganizationMember extends BaseEntity {
     }
 
     public boolean isSameOrganizationMember(final OrganizationMember organizationMember) {
-        return this.organizationMember.getId()
-                .equals(organizationMember.getId());
+        return this.organizationMember.equals(organizationMember);
     }
 
     private void validateIsInSameOrganization(final Event event, final OrganizationMember organizationMember) {

--- a/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
@@ -79,7 +79,7 @@ public class EventOwnerOrganizationMember extends BaseEntity {
     private void validateIsSameOrganization(final Event event, final OrganizationMember organizationMember) {
         if (!event.getOrganization()
                 .isExistOrganizationMember(organizationMember)) {
-            throw new ForbiddenException("공동 주최자가 같은 이벤트 스페이스에 속하지 않습니다.");
+            throw new ForbiddenException("자신과 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.");
         }
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
@@ -73,7 +73,8 @@ public class EventOwnerOrganizationMember extends BaseEntity {
     }
 
     public boolean isSameOrganizationMember(final OrganizationMember organizationMember) {
-        return this.organizationMember.equals(organizationMember);
+        return this.organizationMember.getId()
+                .equals(organizationMember.getId());
     }
 
     private void validateIsInSameOrganization(final Event event, final OrganizationMember organizationMember) {

--- a/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
@@ -1,0 +1,85 @@
+package com.ahmadda.domain.event;
+
+import com.ahmadda.common.exception.ForbiddenException;
+import com.ahmadda.domain.BaseEntity;
+import com.ahmadda.domain.member.Member;
+import com.ahmadda.domain.organization.Organization;
+import com.ahmadda.domain.organization.OrganizationMember;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE event_owner_organization_member SET deleted_at = CURRENT_TIMESTAMP WHERE event_owner_organization_mebmer_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_event_owner_event_id_organization_member_id",
+                        columnNames = {"event_id", "organization_member_id"}
+                )
+        }
+)
+public class EventOwnerOrganizationMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_owner_organization_member_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_member", nullable = false)
+    private OrganizationMember organizationMember;
+
+    public EventOwnerOrganizationMember(final Event event, final OrganizationMember organizationMember) {
+        validateIsSameOrgarnization(event, organizationMember);
+        
+        this.event = event;
+        this.organizationMember = organizationMember;
+    }
+
+    public static EventOwnerOrganizationMember create(
+            final Event event,
+            final OrganizationMember organizationMember
+    ) {
+        return new EventOwnerOrganizationMember(event, organizationMember);
+    }
+
+    public boolean isBelongTo(final Organization organization) {
+        return organizationMember.isBelongTo(organization);
+    }
+
+    public boolean isSameMember(final Member member) {
+        return organizationMember.getMember()
+                .equals(member);
+    }
+
+    public boolean isSameOrganizationMember(final OrganizationMember organizationMember) {
+        return this.organizationMember.equals(organizationMember);
+    }
+
+    private void validateIsSameOrgarnization(final Event event, final OrganizationMember organizationMember) {
+        if (!event.getOrganization()
+                .isExistOrganizationMember(organizationMember)) {
+            throw new ForbiddenException("공동 주최자가 같은 이벤트 스페이스에 속하지 않습니다.");
+        }
+    }
+}

--- a/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
@@ -24,7 +24,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE event_owner_organization_member SET deleted_at = CURRENT_TIMESTAMP WHERE event_owner_organization_mebmer_id = ?")
+@SQLDelete(sql = "UPDATE event_owner_organization_member SET deleted_at = CURRENT_TIMESTAMP WHERE event_owner_organization_member_id = ?")
 @SQLRestriction("deleted_at IS NULL")
 @Table(
         uniqueConstraints = {
@@ -46,12 +46,12 @@ public class EventOwnerOrganizationMember extends BaseEntity {
     private Event event;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "organization_member", nullable = false)
+    @JoinColumn(name = "organization_member_id", nullable = false)
     private OrganizationMember organizationMember;
 
     public EventOwnerOrganizationMember(final Event event, final OrganizationMember organizationMember) {
-        validateIsSameOrgarnization(event, organizationMember);
-        
+        validateIsSameOrganization(event, organizationMember);
+
         this.event = event;
         this.organizationMember = organizationMember;
     }
@@ -76,7 +76,7 @@ public class EventOwnerOrganizationMember extends BaseEntity {
         return this.organizationMember.equals(organizationMember);
     }
 
-    private void validateIsSameOrgarnization(final Event event, final OrganizationMember organizationMember) {
+    private void validateIsSameOrganization(final Event event, final OrganizationMember organizationMember) {
         if (!event.getOrganization()
                 .isExistOrganizationMember(organizationMember)) {
             throw new ForbiddenException("공동 주최자가 같은 이벤트 스페이스에 속하지 않습니다.");

--- a/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMember.java
@@ -50,7 +50,7 @@ public class EventOwnerOrganizationMember extends BaseEntity {
     private OrganizationMember organizationMember;
 
     public EventOwnerOrganizationMember(final Event event, final OrganizationMember organizationMember) {
-        validateIsSameOrganization(event, organizationMember);
+        validateIsInSameOrganization(event, organizationMember);
 
         this.event = event;
         this.organizationMember = organizationMember;
@@ -76,10 +76,10 @@ public class EventOwnerOrganizationMember extends BaseEntity {
         return this.organizationMember.equals(organizationMember);
     }
 
-    private void validateIsSameOrganization(final Event event, final OrganizationMember organizationMember) {
+    private void validateIsInSameOrganization(final Event event, final OrganizationMember organizationMember) {
         if (!event.getOrganization()
                 .isExistOrganizationMember(organizationMember)) {
-            throw new ForbiddenException("자신과 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.");
+            throw new ForbiddenException("주최자 혹은 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.");
         }
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMemberRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventOwnerOrganizationMemberRepository.java
@@ -1,0 +1,10 @@
+package com.ahmadda.domain.event;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EventOwnerOrganizationMemberRepository extends JpaRepository<EventOwnerOrganizationMember, Long> {
+
+    List<EventOwnerOrganizationMember> findAllByOrganizationMemberId(final Long organizationMemberId);
+}

--- a/server/src/main/java/com/ahmadda/domain/event/EventRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventRepository.java
@@ -1,14 +1,11 @@
 package com.ahmadda.domain.event;
 
-import com.ahmadda.domain.organization.OrganizationMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
-
-    List<Event> findAllByOrganizer(final OrganizationMember organizer);
 
     List<Event> findAllByEventOperationPeriodRegistrationEventPeriodEndBetween(
             final LocalDateTime from,

--- a/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
@@ -116,7 +116,9 @@ public class OrganizationMember extends BaseEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
+        if (this == o) {
+            return true;
+        }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
@@ -124,7 +126,7 @@ public class OrganizationMember extends BaseEntity {
         if (id == null || that.id == null) {
             return false;
         }
-        return Objects.equals(id, that.id);
+        return Objects.equals(getId(), that.getId());
     }
 
     @Override

--- a/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
@@ -104,33 +104,23 @@ public class OrganizationMember extends BaseEntity {
         }
     }
 
-    private void validateRoleChangeBy(final OrganizationMember operator) {
-        if (!operator.isBelongTo(this.organization)) {
-            throw new ForbiddenException("같은 이벤트 스페이스에 속한 구성원만 권한을 변경할 수 있습니다.");
-        }
-
-        if (!operator.isAdmin()) {
-            throw new ForbiddenException("관리자만 구성원의 권한을 변경할 수 있습니다.");
-        }
-    }
-
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof OrganizationMember that)) {
             return false;
         }
-        OrganizationMember that = (OrganizationMember) o;
-        if (id == null || that.id == null) {
+        if (getId() == null || that.getId() == null) {
             return false;
         }
+
         return Objects.equals(getId(), that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id);
+        return Objects.hashCode(getId());
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
@@ -22,6 +22,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -111,5 +112,23 @@ public class OrganizationMember extends BaseEntity {
         if (!operator.isAdmin()) {
             throw new ForbiddenException("관리자만 구성원의 권한을 변경할 수 있습니다.");
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrganizationMember that = (OrganizationMember) o;
+        if (id == null || that.id == null) {
+            return false;
+        }
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -161,7 +161,7 @@ public class OrganizationEventController {
                                                       "type": "about:blank",
                                                       "title": "Forbidden",
                                                       "status": 403,
-                                                      "detail": "자신과 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.",
+                                                      "detail": "주최자 혹은 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.",
                                                       "instance": "/api/organizations/{organizationId}/events"
                                                     }
                                                     """

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -161,7 +161,7 @@ public class OrganizationEventController {
                                                       "type": "about:blank",
                                                       "title": "Forbidden",
                                                       "status": 403,
-                                                      "detail": "이벤트 스페이스에 속하지 않은 구성원입니다.",
+                                                      "detail": "자신과 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.",
                                                       "instance": "/api/organizations/{organizationId}/events"
                                                     }
                                                     """
@@ -185,13 +185,13 @@ public class OrganizationEventController {
                                                     """
                                     ),
                                     @ExampleObject(
-                                            name = "구성원 없음",
+                                            name = "구성원 누락",
                                             value = """
                                                     {
                                                       "type": "about:blank",
                                                       "title": "Not Found",
                                                       "status": 404,
-                                                      "detail": "존재하지 않는 구성원 정보입니다.",
+                                                      "detail": "요청된 조직 구성원 중 일부 구성원을 찾을 수 없습니다.",
                                                       "instance": "/api/organizations/{organizationId}/events"
                                                     }
                                                     """

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -161,7 +161,7 @@ public class OrganizationEventController {
                                                       "type": "about:blank",
                                                       "title": "Forbidden",
                                                       "status": 403,
-                                                      "detail": "자신이 속한 이벤트 스페이스가 아닙니다.",
+                                                      "detail": "이벤트 스페이스에 속하지 않은 구성원입니다.",
                                                       "instance": "/api/organizations/{organizationId}/events"
                                                     }
                                                     """

--- a/server/src/main/resources/db/migration/V20250909153530__add_event_owner_organization_member.sql
+++ b/server/src/main/resources/db/migration/V20250909153530__add_event_owner_organization_member.sql
@@ -1,0 +1,21 @@
+CREATE TABLE event_owner_organization_member
+(
+    event_owner_organization_member_id BIGINT AUTO_INCREMENT NOT NULL,
+    event_id                           BIGINT                NOT NULL,
+    organization_member_id             BIGINT                NOT NULL,
+    created_at                         DATETIME(6)           NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at                         DATETIME(6)           NULL ON UPDATE CURRENT_TIMESTAMP(6),
+    deleted_at                         DATETIME(6)           NULL,
+
+    CONSTRAINT pk_event_owner_organization_member
+        PRIMARY KEY (event_owner_organization_member_id),
+
+    CONSTRAINT fk_event_owner_organization_member_on_event
+        FOREIGN KEY (event_id) REFERENCES event (event_id),
+
+    CONSTRAINT fk_event_owner_organization_member_on_org_member
+        FOREIGN KEY (organization_member_id) REFERENCES organization_member (organization_member_id),
+
+    CONSTRAINT uk_event_owner_per_event
+        UNIQUE (event_id, organization_member_id)
+);

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -289,7 +289,7 @@ class EventServiceTest {
         //when //then
         assertThatThrownBy(() -> createEvent(organizationMember, organization)).isInstanceOf(
                         ForbiddenException.class)
-                .hasMessage("자신과 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.");
+                .hasMessage("주최자 혹은 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.");
     }
 
     @Test

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -289,7 +289,7 @@ class EventServiceTest {
         //when //then
         assertThatThrownBy(() -> createEvent(organizationMember, organization)).isInstanceOf(
                         ForbiddenException.class)
-                .hasMessage("자신이 속한 이벤트 스페이스가 아닙니다.");
+                .hasMessage("자신과 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.");
     }
 
     @Test

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -279,7 +279,7 @@ class EventServiceTest {
     }
 
     @Test
-    void 이벤트_스페이스에_속해_있지_않으면_이벤트를_조회할_수_없다() {
+    void 이벤트_스페이스에_속해_있지_않으면_이벤트를_생성할_수_없다() {
         //given
         var organization = createOrganization();
         var otherOrganization = createOrganization();

--- a/server/src/test/java/com/ahmadda/application/EventStatisticServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventStatisticServiceTest.java
@@ -2,13 +2,13 @@ package com.ahmadda.application;
 
 import com.ahmadda.annotation.IntegrationTest;
 import com.ahmadda.application.dto.LoginMember;
+import com.ahmadda.common.exception.ForbiddenException;
 import com.ahmadda.common.exception.NotFoundException;
 import com.ahmadda.domain.event.Event;
 import com.ahmadda.domain.event.EventOperationPeriod;
 import com.ahmadda.domain.event.EventRepository;
 import com.ahmadda.domain.event.EventStatistic;
 import com.ahmadda.domain.event.EventStatisticRepository;
-import com.ahmadda.domain.event.EventViewMetric;
 import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.member.MemberRepository;
 import com.ahmadda.domain.organization.Organization;
@@ -47,7 +47,7 @@ class EventStatisticServiceTest {
     private EventStatisticRepository eventStatisticRepository;
 
     @Test
-    void 이벤트_조회수를_가지고_올_수_있다() {
+    void 주최자는_이벤트_조회수를_가지고_올_수_있다() {
         // given
         var organization = createOrganization();
         var member = createMember();
@@ -56,11 +56,47 @@ class EventStatisticServiceTest {
         createEventStatistic(event);
 
         //when
-        List<EventViewMetric> eventStatistics = sut.getEventStatistic(event.getId(), new LoginMember(member.getId()));
+        var eventStatistics = sut.getEventStatistic(event.getId(), new LoginMember(member.getId()));
 
         // then
         assertThat(eventStatistics).isEmpty();
     }
+
+    @Test
+    void 주최자에_속하지_않으면_이벤트_조회수를_요청시_예외가_발생한다() {
+        // given
+        var organization = createOrganization();
+        var member = createMember();
+        var nonCreateMember = createMember("test", "test@naver.com");
+        var organizationMember = createOrganizationMember(organization, member);
+        var nonCreateOrganizationMember = createOrganizationMember(organization, nonCreateMember);
+        var event = createEvent(organization, organizationMember);
+        createEventStatistic(event);
+
+        // when //then
+        assertThatThrownBy(() -> sut.getEventStatistic(event.getId(), new LoginMember(nonCreateMember.getId())))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("이벤트의 조회수는 이벤트의 주최자만 조회할 수 있습니다.");
+    }
+
+    @Test
+    void 공동_주최자는_이벤트_조회수를_가져올_수_있다() {
+        // given
+        var organization = createOrganization();
+        var member = createMember();
+        var otherCreateMember = createMember("test", "test@naver.com");
+        var organizationMember = createOrganizationMember(organization, member);
+        var otherCreateOrganizationMember = createOrganizationMember(organization, otherCreateMember);
+        var event = createEvent(organization, organizationMember, List.of(otherCreateOrganizationMember.getId()));
+        createEventStatistic(event);
+
+        //when
+        var eventStatistics = sut.getEventStatistic(event.getId(), new LoginMember(otherCreateMember.getId()));
+
+        // when //then
+        assertThat(eventStatistics).isEmpty();
+    }
+
 
     @Test
     void 존재하지_않는_구성원일시_예외가_발생한다() {
@@ -121,6 +157,11 @@ class EventStatisticServiceTest {
         return memberRepository.save(member);
     }
 
+    private Member createMember(String name, String email) {
+        Member member = Member.create(name, email, "testPicture");
+        return memberRepository.save(member);
+    }
+
     private OrganizationMember createOrganizationMember(Organization organization, Member member) {
         OrganizationMember organizationMember =
                 OrganizationMember.create("테스트닉네임", member, organization, OrganizationMemberRole.USER);
@@ -145,6 +186,38 @@ class EventStatisticServiceTest {
                 organization,
                 operationPeriod,
                 30
+        );
+
+        return eventRepository.save(event);
+    }
+
+    private Event createEvent(
+            Organization organization,
+            OrganizationMember organizationMember,
+            List<Long> organizationMemberIds
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        EventOperationPeriod operationPeriod = EventOperationPeriod.create(
+                now.plusDays(1), // registrationStart
+                now.plusDays(2),  // registrationEnd
+                now.plusDays(3),  // eventStart
+                now.plusDays(5),  // eventEnd
+                now               // currentDateTime
+        );
+
+        List<OrganizationMember> organizationMembers = organizationMemberIds.stream()
+                .map(organizationMemberId -> organizationMemberRepository.getReferenceById(organizationMemberId))
+                .toList();
+
+        Event event = Event.create(
+                "테스트 이벤트",
+                "테스트 설명",
+                "test-location",
+                organizationMember,
+                organization,
+                operationPeriod,
+                30,
+                organizationMembers
         );
 
         return eventRepository.save(event);

--- a/server/src/test/java/com/ahmadda/application/EventStatisticServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventStatisticServiceTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -78,25 +77,6 @@ class EventStatisticServiceTest {
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("이벤트의 조회수는 이벤트의 주최자만 조회할 수 있습니다.");
     }
-
-    @Test
-    void 공동_주최자는_이벤트_조회수를_가져올_수_있다() {
-        // given
-        var organization = createOrganization();
-        var member = createMember();
-        var otherCreateMember = createMember("test", "test@naver.com");
-        var organizationMember = createOrganizationMember(organization, member);
-        var otherCreateOrganizationMember = createOrganizationMember(organization, otherCreateMember);
-        var event = createEvent(organization, organizationMember, List.of(otherCreateOrganizationMember.getId()));
-        createEventStatistic(event);
-
-        //when
-        var eventStatistics = sut.getEventStatistic(event.getId(), new LoginMember(otherCreateMember.getId()));
-
-        // when //then
-        assertThat(eventStatistics).isEmpty();
-    }
-
 
     @Test
     void 존재하지_않는_구성원일시_예외가_발생한다() {
@@ -186,38 +166,6 @@ class EventStatisticServiceTest {
                 organization,
                 operationPeriod,
                 30
-        );
-
-        return eventRepository.save(event);
-    }
-
-    private Event createEvent(
-            Organization organization,
-            OrganizationMember organizationMember,
-            List<Long> organizationMemberIds
-    ) {
-        LocalDateTime now = LocalDateTime.now();
-        EventOperationPeriod operationPeriod = EventOperationPeriod.create(
-                now.plusDays(1), // registrationStart
-                now.plusDays(2),  // registrationEnd
-                now.plusDays(3),  // eventStart
-                now.plusDays(5),  // eventEnd
-                now               // currentDateTime
-        );
-
-        List<OrganizationMember> organizationMembers = organizationMemberIds.stream()
-                .map(organizationMemberId -> organizationMemberRepository.getReferenceById(organizationMemberId))
-                .toList();
-
-        Event event = Event.create(
-                "테스트 이벤트",
-                "테스트 설명",
-                "test-location",
-                organizationMember,
-                organization,
-                operationPeriod,
-                30,
-                organizationMembers
         );
 
         return eventRepository.save(event);

--- a/server/src/test/java/com/ahmadda/domain/event/EventOwnerOrganizationMemberTest.java
+++ b/server/src/test/java/com/ahmadda/domain/event/EventOwnerOrganizationMemberTest.java
@@ -1,0 +1,160 @@
+package com.ahmadda.domain.event;
+
+import com.ahmadda.common.exception.ForbiddenException;
+import com.ahmadda.domain.member.Member;
+import com.ahmadda.domain.organization.Organization;
+import com.ahmadda.domain.organization.OrganizationMember;
+import com.ahmadda.domain.organization.OrganizationMemberRole;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class EventOwnerOrganizationMemberTest {
+
+    @Test
+    void 공동_주최자를_생성할_수_있다() {
+        // given
+        var organization = createOrganization();
+        var member = createMember();
+        var organizationMember = createOrganizationMember(member, organization);
+        var event = createEvent(organizationMember, organization);
+        var coOwnerMember = createOrganizationMember(createMember("공동주최자", "coowner@email.com"), organization);
+
+        // when
+        var sut = EventOwnerOrganizationMember.create(event, coOwnerMember);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(sut.getEvent())
+                    .isEqualTo(event);
+            softly.assertThat(sut.getOrganizationMember())
+                    .isEqualTo(coOwnerMember);
+        });
+    }
+
+    @Test
+    void 이벤트와_구성원이_다른_이벤트_스페이스에_속해있으면_공동_주최자_생성시_예외가_발생한다() {
+        // given
+        var organization = createOrganization();
+        var member = createMember();
+        var organizationMember = createOrganizationMember(member, organization);
+        var event = createEvent(organizationMember, organization);
+
+        var anotherOrganization = createOrganization("다른 이벤트 스페이스");
+        var memberInAnotherOrg = createOrganizationMember(createMember(), anotherOrganization);
+
+        // when // then
+        assertThatThrownBy(() -> EventOwnerOrganizationMember.create(event, memberInAnotherOrg))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("주최자 혹은 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.");
+    }
+
+    @Test
+    void 공동_주최자가_같은_이벤트_스페이스에_속해있는지_확인할_수_있다() {
+        // given
+        var organization = createOrganization();
+        var member = createMember();
+        var organizationMember = createOrganizationMember(member, organization);
+        var event = createEvent(organizationMember, organization);
+        var sut = EventOwnerOrganizationMember.create(event, organizationMember);
+        var anotherOrganization = createOrganization("다른 이벤트 스페이스");
+
+        // when
+        var actual1 = sut.isBelongTo(organization);
+        var actual2 = sut.isBelongTo(anotherOrganization);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(actual1)
+                    .isTrue();
+            softly.assertThat(actual2)
+                    .isFalse();
+        });
+    }
+
+    @Test
+    void 공동_주최자가_같은_회원인지_확인할_수_있다() {
+        // given
+        var organization = createOrganization();
+        var member = createMember();
+        var organizationMember = createOrganizationMember(member, organization);
+        var event = createEvent(organizationMember, organization);
+        var sut = EventOwnerOrganizationMember.create(event, organizationMember);
+        var anotherMember = createMember("다른 회원", "another@email.com");
+
+        // when
+        var actual1 = sut.isSameMember(member);
+        var actual2 = sut.isSameMember(anotherMember);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(actual1)
+                    .isTrue();
+            softly.assertThat(actual2)
+                    .isFalse();
+        });
+    }
+
+    @Test
+    void 공동_주최자가_같은_이벤트_스페이스_구성원인지_확인할_수_있다() {
+        // given
+        var organization = createOrganization();
+        var member = createMember();
+        var organizationMember = createOrganizationMember(member, organization);
+        var event = createEvent(organizationMember, organization);
+        var sut = EventOwnerOrganizationMember.create(event, organizationMember);
+        var anotherOrganizationMember = createOrganizationMember(createMember(), organization);
+
+        // when
+        var actual1 = sut.isSameOrganizationMember(organizationMember);
+        var actual2 = sut.isSameOrganizationMember(anotherOrganizationMember);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(actual1)
+                    .isTrue();
+            softly.assertThat(actual2)
+                    .isFalse();
+        });
+    }
+
+    private Member createMember() {
+        return Member.create("테스트 멤버", "test@email.com", "testPicture");
+    }
+
+    private Member createMember(String name, String email) {
+        return Member.create(name, email, "testPicture");
+    }
+
+    private Organization createOrganization() {
+        return Organization.create("테스트 이벤트 스페이스", "설명", "image.png");
+    }
+
+    private Organization createOrganization(String name) {
+        return Organization.create(name, "설명", "image.png");
+    }
+
+    private OrganizationMember createOrganizationMember(Member member, Organization organization) {
+        return OrganizationMember.create("테스트 닉네임", member, organization, OrganizationMemberRole.USER);
+    }
+
+    private Event createEvent(OrganizationMember organizer, Organization organization) {
+        var now = LocalDateTime.now();
+        return Event.create(
+                "테스트 이벤트",
+                "설명",
+                "장소",
+                organizer,
+                organization,
+                EventOperationPeriod.create(
+                        now.plusDays(1), now.plusDays(2),
+                        now.plusDays(3), now.plusDays(4),
+                        now
+                ),
+                10
+        );
+    }
+}

--- a/server/src/test/java/com/ahmadda/domain/event/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/event/EventTest.java
@@ -203,7 +203,7 @@ class EventTest {
         //when //then
         assertThatThrownBy(() -> createEvent(organizationMember, organization2))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("자신과 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.");
+                .hasMessage("주최자 혹은 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.");
     }
 
     @ParameterizedTest

--- a/server/src/test/java/com/ahmadda/domain/event/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/event/EventTest.java
@@ -203,7 +203,7 @@ class EventTest {
         //when //then
         assertThatThrownBy(() -> createEvent(organizationMember, organization2))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("이벤트 스페이스에 속하지 않은 구성원입니다.");
+                .hasMessage("자신과 공동 주최자는 동일한 이벤트 스페이스에 속해야 합니다.");
     }
 
     @ParameterizedTest

--- a/server/src/test/java/com/ahmadda/domain/event/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/event/EventTest.java
@@ -323,16 +323,36 @@ class EventTest {
                 LocalDateTime.now()
                         .plusDays(2)
         );
-        var sut = createEvent(now, registrationPeriod);
+        var coOrganizer =
+                createOrganizationMember("공동주최자", createMember("co-organizer", "co@email.com"), baseOrganization);
+
+        var eventOperationPeriod = EventOperationPeriod.create(
+                registrationPeriod.start(), registrationPeriod.end(),
+                now.plusDays(3), now.plusDays(4),
+                now
+        );
+        var sut = Event.create(
+                "title",
+                "description",
+                "place",
+                baseOrganizer,
+                baseOrganization,
+                eventOperationPeriod,
+                10,
+                List.of(coOrganizer)
+        );
         var nonOrganizer = createOrganizationMember("다른 구성원", createMember(), baseOrganization);
 
         // when
         var isOrganizer = sut.isOrganizer(baseOrganizer.getMember());
+        var isCoOrganizer = sut.isOrganizer(coOrganizer.getMember());
         var isNotOrganizer = sut.isOrganizer(nonOrganizer.getMember());
 
         // then
         assertSoftly(softly -> {
             softly.assertThat(isOrganizer)
+                    .isTrue();
+            softly.assertThat(isCoOrganizer)
                     .isTrue();
             softly.assertThat(isNotOrganizer)
                     .isFalse();

--- a/server/src/test/java/com/ahmadda/domain/event/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/event/EventTest.java
@@ -203,7 +203,7 @@ class EventTest {
         //when //then
         assertThatThrownBy(() -> createEvent(organizationMember, organization2))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("자신이 속한 이벤트 스페이스가 아닙니다.");
+                .hasMessage("이벤트 스페이스에 속하지 않은 구성원입니다.");
     }
 
     @ParameterizedTest


### PR DESCRIPTION


## 관련 이슈

-   close #685

## 🚀 주요 변경사항

기존의 단일 주최자(`Organizer`) 모델에서 다수의 **공동 주최자를 지원하는 기능을 추가**했습니다.

-   `Event`와 `EventOwnerOrganizationMember` 간의 양방향 연관 관계를 설정하여 공동 주최자 목록을 관리합니다.
-   `Event.isOrganizer()` 메서드를 도입하여, 대표 주최자와 공동 주최자 여부를 한 번에 확인할 수 있도록 **권한 확인 로직을 중앙화**했습니다.

---

## 💡 핵심 설계 결정

### 1. 데이터 모델: `EventOwnerOrganizationMember` 도입

단순히 `List<OrganizationMember>`로 관계를 맺는 대신, `EventOwnerOrganizationMember`라는 별도의 엔티티를 통해 관계를 설정했습니다.

-   **확장성**: 추후 공동 주최자별로 다른 역할(Role)이나 권한을 부여하는 등 관계에 특화된 데이터를 추가하기 용이합니다.
-   **명확한 생명주기**: 공동 주최자 정보는 `Event`에 종속되므로, `Event`와 생명주기를 같이하는 양방향 연관 관계가 더 적합하다고 판단했습니다.

### 2. 테스트 전략: `Event.isOrganizer()` 집중 테스트

모든 서비스에 개별적인 공동 주최자 테스트를 추가하는 대신, `EventTest`에 **`isOrganizer()`가 공동 주최자를 올바르게 인식하는지 검증하는 테스트만 추가**했습니다.

-   **중복 최소화**: 기존 테스트들이 "주최자가 아닐 경우"의 시나리오를 이미 충분히 검증하고 있습니다. 따라서 중앙화된 `isOrganizer()` 로직의 정확성만 보장된다면, 다른 서비스에서 동일한 내용을 중복해서 테스트할 필요가 없다고 판단했습니다.

### 3. 단일 `Organizer` 필드 유지

공동 주최자 목록(`List<EventOwnerOrganizationMember>`)과 별개로, **기존의 단일 `Organizer` 필드를 유지**했습니다.

-   **개념적 분리**: "대표 주최자"와 "공동 주최자"는 역할의 의미가 다르다고 보았습니다. 향후 UI에 `"투다 주최 및 N명 공동 주최"`와 같이 정보를 구분하여 표시할 때 유용합니다.
-   **클라이언트 호환성**: 기존 API 클라이언트가 **요청 구조를 변경할 필요가 없습니다.** 대표 주최자를 공동 주최자 목록에 포함해서 보내야 하는 등 클라이언트 측의 부담과 실수를 줄일 수 있습니다.
-   **기존 코드 호환성**: 단일 주최자 필드를 유지함으로써, `EventCreateRequest`를 비롯한 기존 DTO와 테스트 코드의 대규모 수정을 피할 수 있었습니다.

---

## ⚠️ 리뷰어를 위한 중요 안내

향후 모든 주최자 관련 권한 확인은 반드시 **`Event.isOrganizer()` 메서드를 통해 이루어져야 합니다.**

직접적인 DB 쿼리나 다른 방식으로 권한을 확인하면, 공동 주최자 로직이 누락되어 예기치 않은 동작을 유발할 수 있습니다. `isOrganizer()`를 거치지 않는 권한 확인 로직이 필요할 것으로 예상된다면 말씀해 주세요.

---

## ✅ 기능 확인 목록

-   [x] 이벤트 수정 ✅ 2025-09-09
-   [x] 이벤트 마감 ✅ 2025-09-09
-   [x] 이벤트 조회수 조회 ✅ 2025-09-09
-   [x] 내가 주최한 이벤트 조회 ✅ 2025-09-09