### PR TITLE
[FE] 필수 입력 Input에 * 표시

### DIFF
--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -12,6 +12,7 @@ import type { EventTemplateAPIResponse, TemplateDetailAPIResponse } from '@/api/
 import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
 import { Input } from '@/shared/components/Input';
+import { RequiredMark } from '@/shared/components/RequiredMark/RequiredMark';
 import { Text } from '@/shared/components/Text';
 import { Textarea } from '@/shared/components/Textarea';
 import { useToast } from '@/shared/components/Toast/ToastContext';
@@ -276,6 +277,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
             <Flex justifyContent="space-between">
               <Text as="label" htmlFor="title" type="Heading" weight="medium">
                 이벤트 이름
+                <RequiredMark />
               </Text>
               <Flex
                 onClick={handleAddTemplate}
@@ -320,6 +322,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
             >
               <Text as="label" type="Heading" weight="medium" htmlFor="eventDateRange">
                 이벤트 기간
+                <RequiredMark />
               </Text>
               <Input
                 id="eventDateRange"
@@ -373,6 +376,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
             >
               <Text as="label" type="Heading" weight="medium" htmlFor="registrationEnd">
                 신청 종료일
+                <RequiredMark />
               </Text>
               <Input
                 id="registrationEnd"

--- a/client/src/features/Organization/New/components/OrganizationCreateForm.tsx
+++ b/client/src/features/Organization/New/components/OrganizationCreateForm.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
 import { Input } from '@/shared/components/Input';
+import { RequiredMark } from '@/shared/components/RequiredMark/RequiredMark';
 import { Text } from '@/shared/components/Text';
 import { useModal } from '@/shared/hooks/useModal';
 
@@ -144,6 +145,7 @@ export const OrganizationCreateForm = () => {
           >
             <Text as="label" htmlFor="orgImage" type="Heading" weight="medium">
               이벤트 스페이스 이미지
+              <RequiredMark />
             </Text>
             <OrganizationImageInput
               onChange={onSelectLogo}
@@ -155,6 +157,7 @@ export const OrganizationCreateForm = () => {
           <Flex dir="column" gap="12px">
             <Text as="label" htmlFor="orgName" type="Heading" weight="medium">
               이벤트 스페이스 이름
+              <RequiredMark />
             </Text>
             <Input
               id="orgName"
@@ -172,6 +175,7 @@ export const OrganizationCreateForm = () => {
           <Flex dir="column" gap="12px">
             <Text as="label" htmlFor="orgDescription" type="Heading" weight="medium">
               한 줄 소개
+              <RequiredMark />
             </Text>
             <Input
               id="orgDescription"

--- a/client/src/shared/components/Input/Input.styled.ts
+++ b/client/src/shared/components/Input/Input.styled.ts
@@ -15,11 +15,6 @@ export const StyledLabel = styled.label`
   font-size: 14px;
 `;
 
-export const StyledRequiredMark = styled.span`
-  color: red;
-  font-size: 14px;
-`;
-
 export const StyledFieldWrapper = styled.div`
   position: relative;
 `;

--- a/client/src/shared/components/RequiredMark/RequiredMark.stories.tsx
+++ b/client/src/shared/components/RequiredMark/RequiredMark.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { RequiredMark } from './RequiredMark';
+
+const meta = {
+  title: 'components/RequiredMark',
+  component: RequiredMark,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A small decorative asterisk used next to form labels to indicate a required field.',
+      },
+    },
+  },
+} satisfies Meta<typeof RequiredMark>;
+
+export default meta;
+type Story = StoryObj<typeof RequiredMark>;
+
+export const Basic: Story = {};

--- a/client/src/shared/components/RequiredMark/RequiredMark.styled.ts
+++ b/client/src/shared/components/RequiredMark/RequiredMark.styled.ts
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+
+import { theme } from '@/shared/styles/theme';
+
+export const StyledRequiredMark = styled.span`
+  margin-left: 8px;
+  color: ${theme.colors.red600};
+`;

--- a/client/src/shared/components/RequiredMark/RequiredMark.tsx
+++ b/client/src/shared/components/RequiredMark/RequiredMark.tsx
@@ -1,0 +1,3 @@
+import { StyledRequiredMark } from './RequiredMark.styled';
+
+export const RequiredMark = () => <StyledRequiredMark>*</StyledRequiredMark>;

--- a/client/src/shared/components/RequiredMark/index.ts
+++ b/client/src/shared/components/RequiredMark/index.ts
@@ -1,0 +1,1 @@
+export { RequiredMark } from './RequiredMark';


### PR DESCRIPTION
## 관련 이슈

close #683 

## ✨ 작업 내용
- 필수 입력 Input 제목 옆에 시각용 `*` 표시를 추가했습니다.
- `RequiredMark` 공통 컴포넌트와 Storybook을 구현했습니다.
  - 이벤트 생성 폼과 이벤트 스페이스 생성 폼에서 사용합니다.

## 🙏 기타 참고 사항

|이벤트 생성 폼|이벤트 스페이스 생성 폼|
|---|---|
|<img width="876" height="872" alt="image" src="https://github.com/user-attachments/assets/12a76120-22c5-43b8-944a-c7700cc49ca1" />|<img width="876" height="738" alt="image" src="https://github.com/user-attachments/assets/e360b5bd-1c25-434e-ab23-e4edc8bc50a4" />|