### PR TITLE
[BE] 이벤트 스페이스 참가 시 중복 닉네임 불가, 이벤트 스페이스에서 닉네임 변경 기능 추가

### DIFF
--- a/server/src/main/java/com/ahmadda/application/OrganizationMemberService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationMemberService.java
@@ -43,6 +43,19 @@ public class OrganizationMemberService {
         updateRoles(operator, targets, request.role());
     }
 
+    @Transactional
+    public void renameOrganizationMemberNickname(final Long organizationId,
+                                                 final LoginMember loginMember,
+                                                 final String newNickName) {
+        OrganizationMember organizationMember = getOrganizationMember(organizationId, loginMember);
+
+        if (organizationMemberRepository.existsByOrganizationIdAndNickname(organizationId, newNickName)) {
+            throw new UnprocessableEntityException("이미 사용 중인 닉네임입니다.");
+        }
+
+        organizationMember.rename(newNickName);
+    }
+
     public List<OrganizationMember> getAllOrganizationMembers(
             final Long organizationId,
             final LoginMember loginMember

--- a/server/src/main/java/com/ahmadda/application/OrganizationService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationService.java
@@ -78,6 +78,7 @@ public class OrganizationService {
             final OrganizationParticipateRequest organizationParticipateRequest
     ) {
         validateAlreadyParticipationMember(organizationId, loginMember);
+        validateDuplicateNickname(organizationId, organizationParticipateRequest.nickname());
 
         Organization organization = getOrganization(organizationId);
         Member member = getMember(loginMember);
@@ -128,6 +129,12 @@ public class OrganizationService {
         validateAdmin(deletingMember);
 
         organizationRepository.delete(organization);
+    }
+
+    private void validateDuplicateNickname(final Long organizationId, final String nickname) {
+        if (organizationMemberRepository.existsByOrganizationIdAndNickname(organizationId, nickname)) {
+            throw new UnprocessableEntityException("이미 사용 중인 닉네임입니다.");
+        }
     }
 
     private void validateAdmin(final OrganizationMember organizationMember) {

--- a/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
@@ -103,6 +103,10 @@ public class OrganizationMember extends BaseEntity {
         }
     }
 
+    public void rename(final String newNickname) {
+        this.nickname = newNickname;
+    }
+
     private void validateRoleChangeBy(final OrganizationMember operator) {
         if (!operator.isBelongTo(this.organization)) {
             throw new ForbiddenException("같은 이벤트 스페이스에 속한 구성원만 권한을 변경할 수 있습니다.");

--- a/server/src/main/java/com/ahmadda/domain/organization/OrganizationMemberRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/OrganizationMemberRepository.java
@@ -19,4 +19,8 @@ public interface OrganizationMemberRepository extends JpaRepository<Organization
     boolean existsByOrganizationIdAndMemberId(final Long organizationId, final Long memberId);
 
     List<OrganizationMember> findAllByOrganizationId(final Long organizationId);
+
+    boolean existsByOrganization(Organization organization);
+
+    boolean existsByOrganizationIdAndNickname(Long organizationId, String nickname);
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationMemberController.java
@@ -4,6 +4,7 @@ import com.ahmadda.application.OrganizationMemberService;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.OrganizationMemberRoleUpdateRequest;
 import com.ahmadda.domain.organization.OrganizationMember;
+import com.ahmadda.presentation.dto.OrganizationMemberRenameRequest;
 import com.ahmadda.presentation.dto.OrganizationMemberResponse;
 import com.ahmadda.presentation.resolver.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -272,5 +273,83 @@ public class OrganizationMemberController {
                 .toList();
 
         return ResponseEntity.ok(response);
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(
+                    responseCode = "401",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unauthorized",
+                                              "status": 401,
+                                              "detail": "유효하지 않은 인증 정보입니다.",
+                                              "instance": "/api/organizations/{organizationId}/organization-members/rename"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "일부 구성원 없음",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 선택된 구성원입니다.",
+                                                      "instance": "/api/organizations/{organizationId}/organization-members/rename"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "구성원 없음",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Not Found",
+                                                      "status": 404,
+                                                      "detail": "존재하지 않는 구성원입니다.",
+                                                      "instance": "/api/organizations/{organizationId}/organization-members/rename"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "422",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "type": "about:blank",
+                                              "title": "Unprocessable Entity",
+                                              "status": 422,
+                                              "detail": "이미 사용 중인 닉네임입니다.",
+                                              "instance": "/api/organizations/{organizationId}/organization-members/rename"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @PatchMapping("/organizations-members/rename")
+    public ResponseEntity<Void> organizationMemberRenameNickname(
+            @PathVariable final Long organizationId,
+            @AuthMember final LoginMember loginMember,
+            @Valid @RequestBody final OrganizationMemberRenameRequest request
+    ) {
+        organizationMemberService.renameOrganizationMemberNickname(organizationId, loginMember, request.nickname());
+
+        return ResponseEntity.noContent()
+                .build();
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberRenameRequest.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberRenameRequest.java
@@ -1,0 +1,10 @@
+package com.ahmadda.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record OrganizationMemberRenameRequest(
+        @NotBlank
+        String nickname
+) {
+
+}

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -378,6 +378,35 @@ class OrganizationServiceTest {
                 .hasMessage("이벤트 스페이스의 관리자만 삭제할 수 있습니다.");
     }
 
+    @Test
+    void 이미_같은_이름의_사용자가_존재한다면_가입할_수_없다() {
+        // given
+        var member1 = memberRepository.save(Member.create("user1", "user1@test.com", "testPicture"));
+        var member2 = memberRepository.save(Member.create("user2", "user2@test.com", "testPicture"));
+        var organization = organizationRepository.save(createOrganization("Org", "Desc", "img.png"));
+        var inviter = createOrganizationMember("surf", member2, organization, OrganizationMemberRole.USER);
+        var inviteCode = createInviteCode("code", organization, inviter, LocalDateTime.now());
+
+        var loginMember = new LoginMember(member1.getId());
+        var request = new OrganizationParticipateRequest("new_nickname", inviteCode.getCode());
+
+        sut.participateOrganization(organization.getId(), loginMember, request);
+
+        var duplicateNameMember =
+                memberRepository.save(Member.create("duplicateNameMember", "user3@test.com", "testPicture"));
+        var duplicateName = "surf";
+        var duplicateNameRequest = new OrganizationParticipateRequest(duplicateName, inviteCode.getCode());
+        var duplicateLoginMember = new LoginMember(duplicateNameMember.getId());
+
+        // when // then
+        assertThatThrownBy(() -> sut.participateOrganization(organization.getId(),
+                                                             duplicateLoginMember,
+                                                             duplicateNameRequest
+        ))
+                .isInstanceOf(UnprocessableEntityException.class)
+                .hasMessage("이미 사용 중인 닉네임입니다.");
+    }
+
     private Organization createOrganization(String name) {
         var organization = createOrganization(name, "Desc", "img.png");
         return organizationRepository.save(organization);


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #700 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
- 이벤트 스페이스 참가 시 이미 존재하는 닉네임인 경우 가입 불가능하게 하였습니다.

- 이벤트 스페이스에서 본인의 닉네임을 변경할 수 있는 기능을 추가했습니다.
- 이벤트 스페이스에서 본인의 닉네임을 수정 시 이미 존재하는 닉네임이면 닉네임 변경이 불가능하게 하였습니다.
