### PR TITLE
[BE] 조직 삭제시 hibernate.TransientObjectException 문제 해결

### DIFF
--- a/server/src/main/java/com/ahmadda/application/OrganizationService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationService.java
@@ -30,9 +30,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrganizationService {
 
-    public static final String WOOWACOURSE_NAME = "우아한테크코스";
-    private static final String imageUrl = "techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/ah-madda/woowa.png";
-
     private final OrganizationRepository organizationRepository;
     private final OrganizationMemberRepository organizationMemberRepository;
     private final MemberRepository memberRepository;
@@ -122,12 +119,14 @@ public class OrganizationService {
 
     @Transactional
     public void deleteOrganization(final Long organizationId, final LoginMember loginMember) {
-        Organization organization = getOrganization(organizationId);
+        if (!organizationRepository.existsById(organizationId)) {
+            throw new NotFoundException("존재하지 않는 이벤트 스페이스입니다.");
+        }
         OrganizationMember deletingMember = getOrganizationMember(organizationId, loginMember);
 
         validateAdmin(deletingMember);
 
-        organizationRepository.delete(organization);
+        organizationRepository.deleteById(organizationId);
     }
 
     private void validateAdmin(final OrganizationMember organizationMember) {

--- a/server/src/main/java/com/ahmadda/domain/organization/OrganizationRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/OrganizationRepository.java
@@ -5,11 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface OrganizationRepository extends JpaRepository<Organization, Long> {
-
-    Optional<Organization> findByName(final String name);
 
     @Query("""
                 select org


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #707

## ✨ 작업 내용

- `OrganizationService.deleteOrganization()`에서 `organizationRepository.deleteById()` 방식으로 수정
- 기존 `organizationRepository.delete(organization)` 방식 제거

## 🙏 기타 참고 사항

### 왜 문제가 났는지
- JPA에서 `delete(entity)` 는 바로 SQL을 실행하는 게 아니라, 내부적으로 `em.merge()` → `em.remove()` → flush 시점에 DELETE SQL을 실행합니다.  
<img width="528" height="452" alt="image" src="https://github.com/user-attachments/assets/a64a20c9-4ed4-4831-9d6c-5845fd2055db" />

- 이 과정에서 Hibernate가 연관관계(`OrganizationMember → Organization`)를 검증하다가, 세션에 attach 되어 있던 `Organization` 과 다르다고 판단해 `TransientObjectException` 예외가 발생했습니다.  
- 테스트에서는 동일 트랜잭션/세션 내에서 동작했기 때문에 flush 타이밍 차이가 드러나지 않았지만, 실제 API 실행에서는 트랜잭션 경계가 달라져서 문제가 발생했습니다.  
- 반면 `deleteById(id)` 는 단순히 ID 기반 bulk update(soft delete) SQL을 바로 실행하기 때문에 merge 과정에서의 예외가 발생하지 않습니다.  

### 테스트에서 안 잡힌 이유
- 테스트는 같은 트랜잭션 안에서 이미 영속 상태라 flush가 안 나가다 보니 예외가 안 보였던 것 같아요.  
- 실제 API에서는 flush가 터지면서 문제가 드러났습니다.

### 얻은 교훈
- soft delete 구조에서는 ID 기반 삭제(`deleteById`)를 쓰는 게 더 깔끔합니다.  
- 그리고 단순해 보이는 API라도 꼭 직접 호출해서 확인해봐야 한다는 걸 다시 한번 느꼈네요 ㅎㅎ  
- 개발 서버 덕분에 빨리 잡혀서 다행입니다!
