### PR TITLE
[BE] infra의 auth 관련 로직 리팩토링 및 Swagger 문서 개선

### DIFF
--- a/server/src/main/java/com/ahmadda/application/LoginService.java
+++ b/server/src/main/java/com/ahmadda/application/LoginService.java
@@ -5,7 +5,6 @@ import com.ahmadda.application.dto.MemberCreateAlarmPayload;
 import com.ahmadda.application.dto.MemberToken;
 import com.ahmadda.common.exception.NotFoundException;
 import com.ahmadda.common.exception.UnauthorizedException;
-import com.ahmadda.common.exception.UnprocessableEntityException;
 import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.member.MemberRepository;
 import com.ahmadda.infra.auth.HashEncoder;
@@ -14,7 +13,6 @@ import com.ahmadda.infra.auth.RefreshTokenRepository;
 import com.ahmadda.infra.auth.jwt.JwtProvider;
 import com.ahmadda.infra.auth.jwt.config.JwtAccessTokenProperties;
 import com.ahmadda.infra.auth.jwt.config.JwtRefreshTokenProperties;
-import com.ahmadda.infra.auth.jwt.dto.JwtMemberPayload;
 import com.ahmadda.infra.auth.oauth.GoogleOAuthProvider;
 import com.ahmadda.infra.auth.oauth.dto.OAuthUserInfoResponse;
 import com.ahmadda.infra.notification.slack.SlackAlarm;
@@ -24,8 +22,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
-import java.util.Optional;
 
 @Service
 @EnableConfigurationProperties({JwtAccessTokenProperties.class, JwtRefreshTokenProperties.class})
@@ -54,16 +50,14 @@ public class LoginService {
     }
 
     @Transactional
-    public MemberToken renewMemberToken(final String accessToken, final String refreshToken, final String userAgent) {
-        validateTokenExpired(accessToken, refreshToken);
+    public MemberToken renewMemberToken(final String refreshToken, final String userAgent) {
+        validateRefreshTokenActive(refreshToken);
 
         Long memberId = parseRefreshTokenMemberId(refreshToken);
         RefreshToken savedRefreshToken = getRefreshToken(memberId, userAgent);
-
-        validateTokenMatch(refreshToken, savedRefreshToken, memberId);
+        validateSavedRefreshTokenMatch(refreshToken, savedRefreshToken);
 
         MemberToken refreshedMemberToken = createMemberToken(memberId);
-
         rotateRefreshToken(refreshedMemberToken.refreshToken(), memberId, userAgent);
 
         return refreshedMemberToken;
@@ -73,30 +67,16 @@ public class LoginService {
     public void logout(final LoginMember loginMember, final String refreshToken, final String userAgent) {
         Member member = getMember(loginMember);
         RefreshToken savedRefreshToken = getRefreshToken(member.getId(), userAgent);
-
-        validateTokenMatch(refreshToken, savedRefreshToken, member.getId());
+        validateSavedRefreshTokenMatch(refreshToken, savedRefreshToken);
 
         refreshTokenRepository.delete(savedRefreshToken);
     }
 
-    private void validateTokenExpired(final String accessToken, final String refreshToken) {
-        validateAccessTokenNotActive(accessToken);
-        validateRefreshTokenActive(refreshToken);
-    }
+    private void validateRefreshTokenActive(final String refreshToken) {
+        boolean expired = jwtProvider.isTokenExpired(refreshToken, jwtRefreshTokenProperties.getRefreshSecretKey());
 
-    private void validateTokenMatch(final String refreshToken,
-                                    final RefreshToken savedRefreshToken,
-                                    final Long memberId) {
-        validateRefreshTokenMemberIdMatch(refreshToken, memberId);
-        validateSavedRefreshTokenMatch(refreshToken, savedRefreshToken);
-    }
-
-    private void validateRefreshTokenMemberIdMatch(final String refreshToken,
-                                                   final Long memberId) {
-        Long refreshTokenMemberId = parseRefreshTokenMemberId(refreshToken);
-
-        if (!Objects.equals(memberId, refreshTokenMemberId)) {
-            throw new UnauthorizedException("토큰 정보가 일치하지 않습니다.");
+        if (expired) {
+            throw new UnauthorizedException("리프레시 토큰이 만료되었습니다.");
         }
     }
 
@@ -105,34 +85,6 @@ public class LoginService {
 
         if (!encodedRefreshToken.equals(savedRefreshToken.getToken())) {
             throw new UnauthorizedException("리프레시 토큰이 유효하지 않습니다.");
-        }
-    }
-
-    private void validateAccessTokenNotActive(final String accessToken) {
-        Optional<Boolean> accessTokenExpired = jwtProvider.isTokenExpired(accessToken,
-                                                                          jwtAccessTokenProperties.getAccessSecretKey()
-        );
-
-        if (accessTokenExpired.isEmpty()) {
-            throw new UnauthorizedException("엑세스 토큰이 올바르지 않습니다.");
-        }
-
-        if (Objects.equals(accessTokenExpired.get(), Boolean.FALSE)) {
-            throw new UnauthorizedException("엑세스 토큰이 만료되지 않았습니다.");
-        }
-    }
-
-    private void validateRefreshTokenActive(final String refreshToken) {
-        Optional<Boolean> refreshTokenExpired = jwtProvider.isTokenExpired(refreshToken,
-                                                                           jwtRefreshTokenProperties.getRefreshSecretKey()
-        );
-
-        if (refreshTokenExpired.isEmpty()) {
-            throw new UnauthorizedException("리프레시 토큰이 올바르지 않습니다.");
-        }
-
-        if (Objects.equals(refreshTokenExpired.get(), Boolean.TRUE)) {
-            throw new UnauthorizedException("리프레시 토큰이 만료되었습니다.");
         }
     }
 
@@ -149,14 +101,14 @@ public class LoginService {
 
     private Member getMember(final LoginMember loginMember) {
         return memberRepository.findById(loginMember.memberId())
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다"));
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));
     }
 
     private RefreshToken getRefreshToken(final Long memberId, final String userAgent) {
         String deviceId = hashEncoder.encodeSha256(userAgent);
 
         return refreshTokenRepository.findByMemberIdAndDeviceId(memberId, deviceId)
-                .orElseThrow(() -> new NotFoundException("토큰을 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 리프레시 토큰입니다."));
     }
 
     private void rotateRefreshToken(final String refreshToken, final Long memberId, final String userAgent) {
@@ -173,9 +125,11 @@ public class LoginService {
         refreshTokenRepository.deleteByMemberIdAndDeviceId(memberId, deviceId);
     }
 
-    private RefreshToken issueEncodedRefreshToken(final String refreshToken,
-                                                  final Long memberId,
-                                                  final String userAgent) {
+    private RefreshToken issueEncodedRefreshToken(
+            final String refreshToken,
+            final Long memberId,
+            final String userAgent
+    ) {
         LocalDateTime expiresAt = parseRefreshTokenExpiresAt(refreshToken);
 
         String encodedToken = hashEncoder.encodeSha256(refreshToken);
@@ -185,13 +139,15 @@ public class LoginService {
     }
 
     private MemberToken createMemberToken(final Long memberId) {
-        String accessToken = jwtProvider.createToken(memberId,
-                                                     jwtAccessTokenProperties.getAccessExpiration(),
-                                                     jwtAccessTokenProperties.getAccessSecretKey()
+        String accessToken = jwtProvider.createToken(
+                memberId,
+                jwtAccessTokenProperties.getAccessExpiration(),
+                jwtAccessTokenProperties.getAccessSecretKey()
         );
-        String refreshToken = jwtProvider.createToken(memberId,
-                                                      jwtRefreshTokenProperties.getRefreshExpiration(),
-                                                      jwtRefreshTokenProperties.getRefreshSecretKey()
+        String refreshToken = jwtProvider.createToken(
+                memberId,
+                jwtRefreshTokenProperties.getRefreshExpiration(),
+                jwtRefreshTokenProperties.getRefreshSecretKey()
         );
 
         return new MemberToken(accessToken, refreshToken);
@@ -199,13 +155,11 @@ public class LoginService {
 
     private LocalDateTime parseRefreshTokenExpiresAt(final String refreshToken) {
         return jwtProvider.parsePayload(refreshToken, jwtRefreshTokenProperties.getRefreshSecretKey())
-                .map(JwtMemberPayload::getExpiresAt)
-                .orElseThrow(() -> new UnauthorizedException("리프레시 토큰이 유효하지 않습니다."));
+                .expiresAt();
     }
 
     private Long parseRefreshTokenMemberId(final String refreshToken) {
         return jwtProvider.parsePayload(refreshToken, jwtRefreshTokenProperties.getRefreshSecretKey())
-                .map(JwtMemberPayload::getMemberId)
-                .orElseThrow(() -> new UnauthorizedException("리프레시 토큰이 유효하지 않습니다."));
+                .memberId();
     }
 }

--- a/server/src/main/java/com/ahmadda/common/exception/UnauthorizedException.java
+++ b/server/src/main/java/com/ahmadda/common/exception/UnauthorizedException.java
@@ -2,7 +2,11 @@ package com.ahmadda.common.exception;
 
 public class UnauthorizedException extends RuntimeException {
 
-    public UnauthorizedException(String message) {
+    public UnauthorizedException(final String message) {
         super(message);
+    }
+
+    public UnauthorizedException(final String message, final Throwable cause) {
+        super(message, cause);
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/auth/HashEncoder.java
+++ b/server/src/main/java/com/ahmadda/infra/auth/HashEncoder.java
@@ -27,7 +27,6 @@ public final class HashEncoder {
                 hexString.append(hex);
             }
             return hexString.toString();
-
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(HASH_ALGORITHM + "는 지원하지 않습니다", e);
         }

--- a/server/src/main/java/com/ahmadda/infra/auth/jwt/dto/JwtMemberPayload.java
+++ b/server/src/main/java/com/ahmadda/infra/auth/jwt/dto/JwtMemberPayload.java
@@ -2,31 +2,24 @@ package com.ahmadda.infra.auth.jwt.dto;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
-@Getter
-public class JwtMemberPayload {
+public record JwtMemberPayload(
+        Long memberId,
+        LocalDateTime expiresAt
+) {
 
     private static final String MEMBER_ID_KEY = "memberId";
 
-    private final Long memberId;
-    private final LocalDateTime expiresAt;
-
-    private JwtMemberPayload(final Long memberId, final LocalDateTime expiresAt) {
-        this.memberId = memberId;
-        this.expiresAt = expiresAt;
-    }
-
     public static JwtMemberPayload from(final Claims claims) {
         Long memberId = claims.get(MEMBER_ID_KEY, Long.class);
-
-        LocalDateTime expiresAt = claims.getExpiration()
-                .toInstant()
-                .atZone(ZoneId.systemDefault())
-                .toLocalDateTime();
+        LocalDateTime expiresAt = LocalDateTime.ofInstant(
+                claims.getExpiration()
+                        .toInstant(),
+                ZoneId.systemDefault()
+        );
 
         return new JwtMemberPayload(memberId, expiresAt);
     }

--- a/server/src/main/java/com/ahmadda/infra/auth/jwt/exception/InvalidJwtException.java
+++ b/server/src/main/java/com/ahmadda/infra/auth/jwt/exception/InvalidJwtException.java
@@ -1,8 +1,0 @@
-package com.ahmadda.infra.auth.jwt.exception;
-
-public class InvalidJwtException extends RuntimeException {
-
-    public InvalidJwtException(final String message, final Throwable cause) {
-        super(message, cause);
-    }
-}

--- a/server/src/main/java/com/ahmadda/infra/auth/oauth/GoogleOAuthProvider.java
+++ b/server/src/main/java/com/ahmadda/infra/auth/oauth/GoogleOAuthProvider.java
@@ -4,7 +4,6 @@ package com.ahmadda.infra.auth.oauth;
 import com.ahmadda.infra.auth.oauth.config.GoogleOAuthProperties;
 import com.ahmadda.infra.auth.oauth.dto.GoogleAccessTokenResponse;
 import com.ahmadda.infra.auth.oauth.dto.OAuthUserInfoResponse;
-import com.ahmadda.infra.auth.oauth.exception.InvalidOauthTokenException;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -50,18 +49,14 @@ public class GoogleOAuthProvider {
     private String requestGoogleAccessToken(final String code, final String redirectUri) {
         MultiValueMap<String, String> tokenRequestParams = createTokenRequestParams(code, redirectUri);
 
-        GoogleAccessTokenResponse googleAccessTokenResponse = restClient.post()
+        GoogleAccessTokenResponse response = restClient.post()
                 .uri(googleOAuthProperties.getTokenUri())
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(tokenRequestParams)
                 .retrieve()
                 .body(GoogleAccessTokenResponse.class);
 
-        if (googleAccessTokenResponse == null) {
-            throw new InvalidOauthTokenException("유효하지 않은 인증 정보입니다. 인가 코드가 만료되었거나, 잘못되었습니다.");
-        }
-
-        return googleAccessTokenResponse.accessToken();
+        return response.accessToken();
     }
 
     private OAuthUserInfoResponse requestGoogleUserInfo(final String accessToken) {

--- a/server/src/main/java/com/ahmadda/infra/auth/oauth/exception/InvalidOauthTokenException.java
+++ b/server/src/main/java/com/ahmadda/infra/auth/oauth/exception/InvalidOauthTokenException.java
@@ -1,8 +1,0 @@
-package com.ahmadda.infra.auth.oauth.exception;
-
-public class InvalidOauthTokenException extends RuntimeException {
-
-    public InvalidOauthTokenException(final String message) {
-        super(message);
-    }
-}

--- a/server/src/main/java/com/ahmadda/presentation/filter/ratelimit/SlidingWindowRateLimitFilter.java
+++ b/server/src/main/java/com/ahmadda/presentation/filter/ratelimit/SlidingWindowRateLimitFilter.java
@@ -1,11 +1,7 @@
 package com.ahmadda.presentation.filter.ratelimit;
 
-import com.ahmadda.application.dto.LoginMember;
-import com.ahmadda.common.exception.UnauthorizedException;
-import com.ahmadda.common.exception.UnprocessableEntityException;
 import com.ahmadda.infra.auth.jwt.JwtProvider;
 import com.ahmadda.infra.auth.jwt.config.JwtAccessTokenProperties;
-import com.ahmadda.infra.auth.jwt.dto.JwtMemberPayload;
 import com.ahmadda.presentation.header.HeaderProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -144,8 +140,7 @@ public class SlidingWindowRateLimitFilter extends OncePerRequestFilter {
             String accessToken = headerProvider.extractAccessToken(authorizationHeader);
 
             return jwtProvider.parsePayload(accessToken, jwtAccessTokenProperties.getAccessSecretKey())
-                    .map(JwtMemberPayload::getMemberId)
-                    .orElseThrow(() -> new UnauthorizedException("유효하지 않은 액세스 토큰입니다."));
+                    .memberId();
         } catch (Exception e) {
             return null;
         }

--- a/server/src/main/java/com/ahmadda/presentation/resolver/MemberArgumentResolver.java
+++ b/server/src/main/java/com/ahmadda/presentation/resolver/MemberArgumentResolver.java
@@ -43,16 +43,13 @@ public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
         HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
         String accessToken = headerProvider.extractAccessToken(httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION));
 
-        boolean isExpired = jwtProvider.isTokenExpired(accessToken, jwtAccessTokenProperties.getAccessSecretKey())
-                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 액세스 토큰입니다."));
-
+        boolean isExpired = jwtProvider.isTokenExpired(accessToken, jwtAccessTokenProperties.getAccessSecretKey());
         if (isExpired) {
             throw new UnauthorizedException("만료기한이 지난 토큰입니다.");
         }
 
-        return jwtProvider.parsePayload(accessToken, jwtAccessTokenProperties.getAccessSecretKey())
-                .map(JwtMemberPayload::getMemberId)
-                .map(LoginMember::new)
-                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 액세스 토큰입니다."));
+        JwtMemberPayload payload = jwtProvider.parsePayload(accessToken, jwtAccessTokenProperties.getAccessSecretKey());
+
+        return new LoginMember(payload.memberId());
     }
 }

--- a/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
@@ -8,7 +8,6 @@ import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.member.MemberRepository;
 import com.ahmadda.infra.auth.HashEncoder;
 import com.ahmadda.infra.auth.RefreshTokenRepository;
-import com.ahmadda.infra.auth.jwt.config.JwtAccessTokenProperties;
 import com.ahmadda.infra.auth.jwt.config.JwtRefreshTokenProperties;
 import com.ahmadda.infra.auth.jwt.dto.JwtMemberPayload;
 import com.ahmadda.infra.auth.oauth.GoogleOAuthProvider;
@@ -39,9 +38,6 @@ class LoginServiceTest {
 
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
-
-    @Autowired
-    private JwtAccessTokenProperties accessTokenProperties;
 
     @Autowired
     private JwtRefreshTokenProperties refreshTokenProperties;
@@ -97,64 +93,57 @@ class LoginServiceTest {
     }
 
     @Test
-    void 로그인을하여_엑세스토큰과_리프레시_토큰을_저장한다() {
+    void 로그인을하면_리프레시토큰이_저장된다() {
         // given
         var code = "code";
-        var name = "홍길동";
         var email = "test@example.com";
-        var userAgent = createUserAgent();
-
         var redirectUri = "redirectUri";
-        var testPicture = "testPicture";
 
         given(googleOAuthProvider.getUserInfo(code, redirectUri))
-                .willReturn(new OAuthUserInfoResponse(email, name, testPicture));
+                .willReturn(new OAuthUserInfoResponse(email, "홍길동", "pic"));
 
         // when
-        sut.login(code, redirectUri, userAgent);
+        sut.login(code, redirectUri, createUserAgent());
 
         // then
         assertThat(refreshTokenRepository.findAll()).hasSize(1);
     }
 
     @Test
-    void 로그인_시_이전의_토큰을_제거한다() {
+    void 로그인_시_기존토큰은_제거된다() {
         // given
         var code = "code";
-        var name = "홍길동";
         var email = "test@example.com";
         var userAgent = createUserAgent();
-
         var redirectUri = "redirectUri";
-        var testPicture = "testPicture";
 
         given(googleOAuthProvider.getUserInfo(code, redirectUri))
-                .willReturn(new OAuthUserInfoResponse(email, name, testPicture));
+                .willReturn(new OAuthUserInfoResponse(email, "홍길동", "pic"));
 
         var member = createMember();
 
         sut.login(code, redirectUri, userAgent);
 
         var deviceId = hashEncoder.encodeSha256(userAgent);
-        var oldSavedToken = refreshTokenRepository.findByMemberIdAndDeviceId(member.getId(), deviceId)
+        var oldToken = refreshTokenRepository.findByMemberIdAndDeviceId(member.getId(), deviceId)
                 .get();
 
         // when
         sut.login(code, redirectUri, userAgent);
 
         // then
+        var newToken = refreshTokenRepository.findByMemberIdAndDeviceId(member.getId(), deviceId)
+                .get();
         assertSoftly(softly -> {
-            var newSavedToken = refreshTokenRepository.findByMemberIdAndDeviceId(member.getId(), deviceId)
-                    .get();
-            softly.assertThat(oldSavedToken.getId())
-                    .isNotEqualTo(newSavedToken.getId());
+            softly.assertThat(oldToken.getId())
+                    .isNotEqualTo(newToken.getId());
             softly.assertThat(refreshTokenRepository.findAll())
                     .hasSize(1);
         });
     }
 
     @Test
-    void 액세스토큰이_만료된_경우_리프레시_토큰을_재발급_받을_수_있다() {
+    void 리프레시_토큰을_재발급_받을_수_있다() {
         // given
         var code = "code";
         var name = "홍길동";
@@ -171,7 +160,6 @@ class LoginServiceTest {
         var member = createMember();
 
         sut.login(code, redirectUri, userAgent);
-        var expiredAccessToken = createExpiredAccessToken(member.getId());
 
         var loginTokens = sut.login(code, redirectUri, userAgent);
 
@@ -179,7 +167,7 @@ class LoginServiceTest {
                 .get();
 
         // when
-        sut.renewMemberToken(expiredAccessToken, loginTokens.refreshToken(), userAgent);
+        sut.renewMemberToken(loginTokens.refreshToken(), userAgent);
 
         // then
         assertSoftly(softly -> {
@@ -193,191 +181,103 @@ class LoginServiceTest {
     }
 
     @Test
-    void 액세스토큰이_만료되지_않는_경우_재발급_받으려하면_예외가_발생한다() {
+    void 리프레시토큰이_만료되면_재발급시_예외가_발생한다() {
         // given
-        var code = "code";
-        var name = "홍길동";
-        var email = "test@example.com";
-        var userAgent = createUserAgent();
-
-        var redirectUri = "redirectUri";
-        var testPicture = "testPicture";
-
-        given(googleOAuthProvider.getUserInfo(code, redirectUri))
-                .willReturn(new OAuthUserInfoResponse(email, name, testPicture));
-
-        createMember();
-
-        var loginTokens = sut.login(code, redirectUri, userAgent);
-
-        // when // then
-        assertThatThrownBy(() -> sut.renewMemberToken(
-                loginTokens.accessToken(),
-                loginTokens.refreshToken(),
-                userAgent
-        ))
-                .isInstanceOf(UnauthorizedException.class)
-                .hasMessage("엑세스 토큰이 만료되지 않았습니다.");
-    }
-
-    @Test
-    void 액세스토큰이_올바르지_않은_경우_재발급_시_예외가_발생한다() {
-        // given
-        var code = "code";
-        var name = "홍길동";
-        var email = "test@example.com";
-        var userAgent = createUserAgent();
-
-        var redirectUri = "redirectUri";
-        var testPicture = "testPicture";
-
-        var invalidAccessToken = "invalidAccessToken";
-
-        given(googleOAuthProvider.getUserInfo(code, redirectUri))
-                .willReturn(new OAuthUserInfoResponse(email, name, testPicture));
-
         var member = createMember();
-
-        var loginTokens = sut.login(code, redirectUri, userAgent);
-
-        // when // then
-        assertThatThrownBy(() -> sut.renewMemberToken(
-                invalidAccessToken,
-                loginTokens.refreshToken(),
-                userAgent
-        ))
-                .isInstanceOf(UnauthorizedException.class)
-                .hasMessage("엑세스 토큰이 올바르지 않습니다.");
-    }
-
-    @Test
-    void 리프레시_토큰이_만료된_경우_재발급_시_예외가_발생한다() {
-        // given
-        var code = "code";
-        var name = "홍길동";
-        var email = "test@example.com";
-        var userAgent = createUserAgent();
-
-        var redirectUri = "redirectUri";
-        var testPicture = "testPicture";
-
-        given(googleOAuthProvider.getUserInfo(code, redirectUri))
-                .willReturn(new OAuthUserInfoResponse(email, name, testPicture));
-
-        var member = createMember();
-
-        var expiredAccessToken = createExpiredAccessToken(member.getId());
-        var expiredRefreshToken = createExpiredRefreshToken(member.getId());
+        var expiredRefresh = createExpiredRefreshToken(member.getId());
 
         // when // then
-        assertThatThrownBy(() -> sut.renewMemberToken(
-                expiredAccessToken,
-                expiredRefreshToken,
-                userAgent
-        ))
+        assertThatThrownBy(() -> sut.renewMemberToken(expiredRefresh, createUserAgent()))
                 .isInstanceOf(UnauthorizedException.class)
                 .hasMessage("리프레시 토큰이 만료되었습니다.");
     }
 
     @Test
-    void 리프레시_토큰이_없는_경우_재발급_시_예외가_발생한다() {
+    void 리프레시토큰이_저장된값과_불일치하면_예외가_발생한다() {
         // given
-        var code = "code";
-        var name = "홍길동";
-        var email = "test@example.com";
-        var userAgent = createUserAgent();
-
-        var redirectUri = "redirectUri";
-        var testPicture = "testPicture";
-
-        given(googleOAuthProvider.getUserInfo(code, redirectUri))
-                .willReturn(new OAuthUserInfoResponse(email, name, testPicture));
-
         var member = createMember();
+        var userAgent = createUserAgent();
+        var redirectUri = "redirectUri";
+        var email = "test@example.com";
 
-        var expiredAccessToken = createExpiredAccessToken(member.getId());
+        given(googleOAuthProvider.getUserInfo("code", redirectUri))
+                .willReturn(new OAuthUserInfoResponse(email, "홍길동", "pic"));
+
+        sut.login("code", redirectUri, userAgent);
+        var otherRefresh = createValidRefreshToken(member.getId());
 
         // when // then
-        assertThatThrownBy(() -> sut.renewMemberToken(
-                expiredAccessToken,
-                null,
-                userAgent
-        ))
+        assertThatThrownBy(() -> sut.renewMemberToken(otherRefresh, userAgent))
                 .isInstanceOf(UnauthorizedException.class)
-                .hasMessage("리프레시 토큰이 올바르지 않습니다.");
+                .hasMessage("리프레시 토큰이 유효하지 않습니다.");
     }
 
     @Test
-    void 리프레시_토큰이_올바르지_않은_경우_재발급_시_예외가_발생한다() {
+    void 저장된_리프레시토큰이_없으면_예외가_발생한다() {
         // given
-        var code = "code";
-        var name = "홍길동";
-        var email = "test@example.com";
-        var userAgent = createUserAgent();
-
-        var redirectUri = "redirectUri";
-        var testPicture = "testPicture";
-
-        var invalidRefreshToken = "InvalidRefreshToken";
-
-        given(googleOAuthProvider.getUserInfo(code, redirectUri))
-                .willReturn(new OAuthUserInfoResponse(email, name, testPicture));
-
         var member = createMember();
-
-        var expiredAccessToken = createExpiredAccessToken(member.getId());
-
-        // when // then
-        assertThatThrownBy(() -> sut.renewMemberToken(
-                expiredAccessToken,
-                invalidRefreshToken,
-                userAgent
-        ))
-                .isInstanceOf(UnauthorizedException.class)
-                .hasMessage("리프레시 토큰이 올바르지 않습니다.");
-    }
-
-    @Test
-    void 존재하지_않는_회원을_로그아웃_하면_예외가_발생한다() {
-        // given
-        createMember();
-
         var userAgent = createUserAgent();
-        var refresh = "raw_refresh_token";
-        var invalidLoginMember = new LoginMember(999L);
+
+        var refresh = createValidRefreshToken(member.getId());
 
         // when // then
-        assertThatThrownBy(() -> sut.logout(invalidLoginMember, refresh, userAgent))
+        assertThatThrownBy(() -> sut.renewMemberToken(refresh, userAgent))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 회원입니다");
+                .hasMessage("존재하지 않는 리프레시 토큰입니다.");
     }
 
     @Test
-    void 로그아웃을_정상적으로_할_수_있다() {
+    void 로그아웃을_정상적으로_수행한다() {
         // given
         var code = "code";
-        var name = "홍길동";
         var email = "test@example.com";
+        var redirectUri = "redirectUri";
         var userAgent = createUserAgent();
 
-        var redirectUri = "redirectUri";
-        var testPicture = "testPicture";
-
         given(googleOAuthProvider.getUserInfo(code, redirectUri))
-                .willReturn(new OAuthUserInfoResponse(email, name, testPicture));
+                .willReturn(new OAuthUserInfoResponse(email, "홍길동", "pic"));
 
         var member = createMember();
-
         var loginMember = new LoginMember(member.getId());
-
-        var newLoginToken = sut.login(code, redirectUri, userAgent);
+        var tokens = sut.login(code, redirectUri, userAgent);
 
         // when
-        sut.logout(loginMember, newLoginToken.refreshToken(), userAgent);
+        sut.logout(loginMember, tokens.refreshToken(), userAgent);
 
         // then
-        assertThat(refreshTokenRepository.findAll())
-                .hasSize(0);
+        assertThat(refreshTokenRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void 존재하지않는_회원이_로그아웃하면_예외가_발생한다() {
+        // given
+        var invalidMember = new LoginMember(999L);
+
+        // when // then
+        assertThatThrownBy(() -> sut.logout(invalidMember, "refresh", createUserAgent()))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 회원입니다.");
+    }
+
+    @Test
+    void 로그아웃시_리프레시토큰이_불일치하면_예외가_발생한다() {
+        // given
+        var code = "code";
+        var email = "test@example.com";
+        var redirectUri = "redirectUri";
+        var userAgent = createUserAgent();
+
+        given(googleOAuthProvider.getUserInfo(code, redirectUri))
+                .willReturn(new OAuthUserInfoResponse(email, "홍길동", "pic"));
+
+        var member = createMember();
+        var loginMember = new LoginMember(member.getId());
+        sut.login(code, redirectUri, userAgent);
+
+        // when // then
+        assertThatThrownBy(() -> sut.logout(loginMember, "invalidRefreshToken", userAgent))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("리프레시 토큰이 유효하지 않습니다.");
     }
 
     private String createUserAgent() {
@@ -396,19 +296,6 @@ class LoginServiceTest {
         return member;
     }
 
-    private String createExpiredAccessToken(Long memberId) {
-        var now = Instant.now();
-
-        var claims = JwtMemberPayload.toClaims(memberId);
-
-        return Jwts.builder()
-                .claims(claims)
-                .issuedAt(Date.from(now))
-                .expiration(Date.from(now.minus(Duration.ofDays(1))))
-                .signWith(accessTokenProperties.getAccessSecretKey())
-                .compact();
-    }
-
     private String createExpiredRefreshToken(Long memberId) {
         var now = Instant.now();
 
@@ -418,6 +305,18 @@ class LoginServiceTest {
                 .claims(claims)
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(now.minus(Duration.ofDays(1))))
+                .signWith(refreshTokenProperties.getRefreshSecretKey())
+                .compact();
+    }
+
+    private String createValidRefreshToken(Long memberId) {
+        var now = Instant.now();
+        var claims = JwtMemberPayload.toClaims(memberId);
+
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(Duration.ofDays(1))))
                 .signWith(refreshTokenProperties.getRefreshSecretKey())
                 .compact();
     }

--- a/server/src/test/java/com/ahmadda/infra/auth/jwt/JwtProviderTest.java
+++ b/server/src/test/java/com/ahmadda/infra/auth/jwt/JwtProviderTest.java
@@ -1,156 +1,90 @@
 package com.ahmadda.infra.auth.jwt;
 
-import com.ahmadda.infra.auth.jwt.config.JwtAccessTokenProperties;
-import com.ahmadda.infra.auth.jwt.config.JwtRefreshTokenProperties;
+import com.ahmadda.common.exception.UnauthorizedException;
+import com.ahmadda.infra.auth.jwt.dto.JwtMemberPayload;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
+import javax.crypto.SecretKey;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class JwtProviderTest {
 
-    static JwtAccessTokenProperties jwtAccessTokenProperties;
-    static JwtRefreshTokenProperties jwtRefreshProperties;
-    static JwtProvider sut;
+    private JwtProvider sut;
+    private SecretKey secretKey;
 
-    @BeforeAll
-    static void setUpAll() {
-        String accessSecretKey = UUID.randomUUID()
-                .toString();
-        String refreshSecretKey = UUID.randomUUID()
-                .toString();
-        Duration accessExpiration = Duration.ofHours(1);
-        Duration refreshExpiration = Duration.ofHours(1);
-
-        jwtAccessTokenProperties = new JwtAccessTokenProperties(
-                accessSecretKey, accessExpiration
-        );
-        jwtRefreshProperties = new JwtRefreshTokenProperties(
-                refreshSecretKey, refreshExpiration
-        );
-
+    @BeforeEach
+    void setUp() {
         sut = new JwtProvider();
+        secretKey = Keys.hmacShaKeyFor(UUID.randomUUID()
+                .toString()
+                .repeat(2)
+                .getBytes());
     }
 
     @Test
-    void JWT_토큰을_정상적으로_생성_및_검증_할_수_있다() {
+    void 정상적으로_토큰을_생성하고_파싱할_수_있다() {
         // given
-        var memberId = 1L;
-        var token = sut.createToken(memberId,
-                                    jwtAccessTokenProperties.getAccessExpiration(),
-                                    jwtAccessTokenProperties.getAccessSecretKey()
-        );
+        Long memberId = 1L;
+        var token = sut.createToken(memberId, Duration.ofHours(1), secretKey);
 
         // when
-        var memberPayload = sut.parsePayload(token, jwtAccessTokenProperties.getAccessSecretKey());
+        JwtMemberPayload payload = sut.parsePayload(token, secretKey);
 
         // then
-        assertThat(memberPayload.get()
-                           .getMemberId()).isEqualTo(memberId);
+        assertThat(payload.memberId()).isEqualTo(memberId);
     }
 
     @Test
-    void 페이로드_변환시_만료된_토큰일_경우_옵셔널_빈을_반환한다() {
+    void 유효하지_않은_토큰은_파싱시_예외가_발생한다() {
+        // given
+        var otherKey = Keys.hmacShaKeyFor(UUID.randomUUID()
+                .toString()
+                .repeat(2)
+                .getBytes());
+        var token = sut.createToken(3L, Duration.ofHours(1), otherKey);
+
+        // when // then
+        assertThatThrownBy(() -> sut.parsePayload(token, secretKey))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("유효하지 않은 인증 정보입니다.");
+    }
+
+    @Test
+    void 만료된_토큰은_만료여부를_확인할_수_있다() {
         // given
         var now = Instant.now();
-        var token = Jwts.builder()
+        var expiredToken = Jwts.builder()
                 .claims(Jwts.claims()
-                                .add("memberId", 3L)
-                                .issuedAt(Date.from(now.minus(Duration.ofHours(2))))
-                                .expiration(Date.from(now.minus(Duration.ofMinutes(1))))
-                                .build())
-                .signWith(jwtAccessTokenProperties.getAccessSecretKey())
+                        .add("memberId", 2L)
+                        .issuedAt(Date.from(now.minus(Duration.ofHours(2))))
+                        .expiration(Date.from(now.minus(Duration.ofMinutes(1))))
+                        .build())
+                .signWith(secretKey)
                 .compact();
 
         // when // then
-        assertThat(sut.parsePayload(token, jwtAccessTokenProperties.getAccessSecretKey())).isEmpty();
+        assertThat(sut.isTokenExpired(expiredToken, secretKey)).isTrue();
     }
 
     @Test
-    void 페이로드_변환시_잘못된_서명일_경우_예외가_발생한다() {
-        // given
-        var forgedKey = Keys.hmacShaKeyFor(UUID.randomUUID()
-                                                   .toString()
-                                                   .getBytes());
+    void 유효하지_않은_토큰은_만료여부_검증시_예외가_발생한다() {
+        var otherKey = Keys.hmacShaKeyFor(UUID.randomUUID()
+                .toString()
+                .repeat(2)
+                .getBytes());
+        var token = sut.createToken(4L, Duration.ofHours(1), otherKey);
 
-        var expiration = Duration.ofHours(1);
-
-        var claims = Jwts.claims()
-                .add("memberId", 4L)
-                .issuedAt(Date.from(Instant.now()))
-                .expiration(Date.from(Instant.now()
-                                              .plus(expiration)))
-                .build();
-
-        var token = Jwts.builder()
-                .claims(claims)
-                .signWith(forgedKey)
-                .compact();
-
-        // when // then
-        assertThat(sut.parsePayload(token, jwtAccessTokenProperties.getAccessSecretKey())).isEmpty();
-    }
-
-    @Test
-    void 페이로드_변환시_빈_토큰이면_빈_옵셔널을_반환한다() {
-        assertThat(sut.parsePayload("", jwtAccessTokenProperties.getAccessSecretKey())).isEmpty();
-    }
-
-    @Test
-    void 페이로드_변환시_null_토큰이면_빈_옵셔널을_반환한다() {
-        assertThat(sut.parsePayload(null, jwtAccessTokenProperties.getAccessSecretKey())).isEmpty();
-    }
-
-    @Test
-    void 페이로드_변환시_형식이_잘못된_토큰이면_빈_옵셔널을_반환한다() {
-        assertThat(sut.parsePayload("this is not jwt", jwtAccessTokenProperties.getAccessSecretKey())).isEmpty();
-    }
-
-    @Test
-    void 토큰_만료_여부를_확인할_수_있다() {
-        // given
-        var now = Instant.now();
-        var expiredAccessToken = Jwts.builder()
-                .claims(Jwts.claims()
-                                .add("memberId", 50L)
-                                .issuedAt(Date.from(now.minus(Duration.ofHours(2))))
-                                .expiration(Date.from(now.minus(Duration.ofMinutes(1))))
-                                .build())
-                .signWith(jwtAccessTokenProperties.getAccessSecretKey())
-                .compact();
-
-        //when // then
-        assertThat(sut.isTokenExpired(expiredAccessToken,
-                                      jwtAccessTokenProperties.getAccessSecretKey()
-        )).contains(true);
-    }
-
-    @Test
-    void 토큰_만료여부에서_올바르지_않으면_빈_옵셔널을_반환한다() {
-        var invalidToken = "invalidAccessToken";
-
-        //when // then
-        assertThat(sut.isTokenExpired(invalidToken, jwtAccessTokenProperties.getAccessSecretKey())).isEmpty();
-    }
-
-
-    @Test
-    void 토큰을_올바르지_않은_키로_검증시_빈_옵셔널을_반환한다() {
-        // given
-        var accessToken = sut.createToken(60L,
-                                          jwtAccessTokenProperties.getAccessExpiration(),
-                                          jwtAccessTokenProperties.getAccessSecretKey()
-        );
-
-        // when // then
-        assertThat(sut.isTokenExpired(accessToken, jwtRefreshProperties.getRefreshSecretKey())).isEmpty();
-
+        assertThatThrownBy(() -> sut.isTokenExpired(token, secretKey))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("유효하지 않은 인증 정보입니다.");
     }
 }

--- a/server/src/test/java/com/ahmadda/presentation/filter/ratelimit/SlidingWindowRateLimitFilterTest.java
+++ b/server/src/test/java/com/ahmadda/presentation/filter/ratelimit/SlidingWindowRateLimitFilterTest.java
@@ -14,7 +14,6 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.time.Duration;
 import java.util.ArrayDeque;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -52,8 +51,9 @@ class SlidingWindowRateLimitFilterTest {
                 accessSecretKey, accessExpiration
         );
 
-        filter = new SlidingWindowRateLimitFilter(headerProvider,
-                                                  jwtAccessTokenProperties, jwtProvider, rateLimitExceededHandler
+        filter = new SlidingWindowRateLimitFilter(
+                headerProvider,
+                jwtAccessTokenProperties, jwtProvider, rateLimitExceededHandler
         );
 
         request = new MockHttpServletRequest();
@@ -85,10 +85,9 @@ class SlidingWindowRateLimitFilterTest {
         request.setRequestURI("/api/test");
 
         var payload = mock(JwtMemberPayload.class);
-        when(payload.getMemberId()).thenReturn(memberId);
+        when(payload.memberId()).thenReturn(memberId);
         when(headerProvider.extractAccessToken(bearerToken)).thenReturn(token);
-        when(jwtProvider.parsePayload(token, jwtAccessTokenProperties.getAccessSecretKey())).thenReturn(Optional.of(
-                payload));
+        when(jwtProvider.parsePayload(token, jwtAccessTokenProperties.getAccessSecretKey())).thenReturn(payload);
 
         for (int i = 0; i < 100; i++) {
             filter.doFilterInternal(request, response, chain);


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #721

## ✨ 작업 내용

- JwtProvider의 Optional 기반 반환 방식을 제거하고, UnauthorizedException을 던지도록 변경하여 실패 원인을 명확히 전달하도록 개선했습니다.
- LoginService의 토큰 검증 로직을 단순화하고, 불필요한 중복 검증을 제거했습니다.
- 만료 여부, 유효성 검증 등 JWT 처리 플로우를 통일성 있게 정리했습니다.
- 로그인 및 액세스 토큰 재발급 API의 Swagger 문서를 실제 동작에 맞게 보완하고, 누락된 예외 케이스를 추가했습니다.

## 🙏 기타 참고 사항

후.. 이번 수술 집도 끝났습니다. 보호자(가이온)군 만족하시나요.

<img width="500" height="360" alt="Image" src="https://github.com/user-attachments/assets/8e6cc14c-7848-4cd7-b963-503bda694f1f" />
