### PR TITLE
[BE] 이벤트 주최자들이 데이터베이스에 저장안되는 문제 해결

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/event/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/event/Event.java
@@ -53,7 +53,7 @@ public class Event extends BaseEntity {
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Question> questions = new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "event")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "event", cascade = CascadeType.ALL)
     private final List<EventOrganizer> eventOrganizers = new ArrayList<>();
 
     @Id

--- a/server/src/main/java/com/ahmadda/domain/organization/OrganizationMemberRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/OrganizationMemberRepository.java
@@ -3,7 +3,6 @@ package com.ahmadda.domain.organization;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface OrganizationMemberRepository extends JpaRepository<OrganizationMember, Long> {
@@ -17,10 +16,6 @@ public interface OrganizationMemberRepository extends JpaRepository<Organization
     Optional<OrganizationMember> findByOrganizationIdAndMemberId(final Long organizationId, final Long memberId);
 
     boolean existsByOrganizationIdAndMemberId(final Long organizationId, final Long memberId);
-
-    List<OrganizationMember> findAllByOrganizationId(final Long organizationId);
-
-    boolean existsByOrganization(final Organization organization);
 
     boolean existsByOrganizationIdAndNickname(final Long organizationId, final String nickname);
 }

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -118,6 +118,10 @@ class EventServiceTest {
                                         now.plusDays(5), now.plusDays(6),
                                         now
                                 ));
+                        softly.assertThat(event.getEventOrganizers()
+                                .getFirst()
+                                .getOrganizationMember()
+                                .equals(organizationMember));
                         List<Question> questions = savedEvent.getQuestions();
                         softly.assertThat(questions)
                                 .hasSize(2)
@@ -797,7 +801,7 @@ class EventServiceTest {
             softly.assertThat(pastEvents)
                     .hasSize(1);
             softly.assertThat(pastEvents.get(0)
-                                      .getId())
+                            .getId())
                     .isEqualTo(pastEvent.getId());
         });
     }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #730 


## 작업 내용
- 주최자들 엔티티가 데이터베이스에 저장 안되는 문제를 cascade로 해결했습니다.
 

## 기타 참고사항

```
 @OneToMany(fetch = FetchType.LAZY, mappedBy = "event", cascade = CascadeType.ALL)
    private final List<EventOrganizer> eventOrganizers = new ArrayList<>();
```
- 위와 같이 cascade 설정을 추가했습니다
### 사유
- 생성 편의성
  - 기존에 사용중이던 create 메서드, 생성자를 그대로 유지하는 방법
- 왜 persist말고 all 걸었나
  -  추후에 충분히 이벤트 주최자를 제거하는것이 가능하다고 보았습니다
- remove의 위험성
  - EventOragnizer는 event가 없으면 의미없는 엔티티입니다.
  - EventOragnizer 내부 필드 엔티티들 remove를 사용함으로써 전파되는 문제가 없습니다.


