### PR TITLE
[BE] 학습테스트의 Transactional으로 인한 문제 해결

### DIFF
--- a/server/src/test/java/com/ahmadda/annotation/LearningTest.java
+++ b/server/src/test/java/com/ahmadda/annotation/LearningTest.java
@@ -1,0 +1,20 @@
+package com.ahmadda.annotation;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@ActiveProfiles("test")
+public @interface LearningTest {
+
+}

--- a/server/src/test/java/com/ahmadda/infra/notification/push/FcmPushErrorHandlerTest.java
+++ b/server/src/test/java/com/ahmadda/infra/notification/push/FcmPushErrorHandlerTest.java
@@ -1,8 +1,6 @@
 package com.ahmadda.infra.notification.push;
 
 import com.ahmadda.annotation.IntegrationTest;
-import com.ahmadda.infra.auth.jwt.config.JwtAccessTokenProperties;
-import com.ahmadda.infra.auth.jwt.config.JwtRefreshTokenProperties;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MessagingErrorCode;
@@ -21,12 +19,6 @@ class FcmPushErrorHandlerTest {
 
     @Autowired
     private FcmRegistrationTokenRepository fcmRegistrationTokenRepository;
-
-    @Autowired
-    private JwtAccessTokenProperties accessTokenProperties;
-
-    @Autowired
-    private JwtRefreshTokenProperties refreshTokenProperties;
 
     @Test
     void 요청_실패시_유효하지_않는_토큰이_있으면_제거한다() {

--- a/server/src/test/java/com/ahmadda/learning/infra/image/AwsS3OrganizationImageUploaderTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/image/AwsS3OrganizationImageUploaderTest.java
@@ -1,6 +1,6 @@
 package com.ahmadda.learning.infra.image;
 
-import com.ahmadda.annotation.IntegrationTest;
+import com.ahmadda.annotation.LearningTest;
 import com.ahmadda.domain.organization.OrganizationImageFile;
 import com.ahmadda.infra.image.AwsS3OrganizationImageUploader;
 import org.junit.jupiter.api.Disabled;
@@ -12,7 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 @Disabled
-@IntegrationTest
+@LearningTest
 @TestPropertySource(properties = {
         "aws.s3.mock=false",
         "aws.s3.region=${aws.dev.s3.region}",

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/FailoverEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/FailoverEmailNotifierTest.java
@@ -1,6 +1,6 @@
 package com.ahmadda.learning.infra.notification;
 
-import com.ahmadda.annotation.IntegrationTest;
+import com.ahmadda.annotation.LearningTest;
 import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.member.MemberRepository;
 import com.ahmadda.domain.notification.EmailNotifier;
@@ -11,7 +11,6 @@ import com.ahmadda.domain.organization.OrganizationMemberRepository;
 import com.ahmadda.domain.organization.OrganizationMemberRole;
 import com.ahmadda.domain.organization.OrganizationRepository;
 import com.ahmadda.infra.notification.mail.SmtpEmailNotifier;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.MailSendException;
@@ -29,8 +28,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@Disabled
-@IntegrationTest
+@LearningTest
 @TestPropertySource(properties = "mail.mock=false")
 class FailoverEmailNotifierTest {
 

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/FailoverEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/FailoverEmailNotifierTest.java
@@ -11,6 +11,7 @@ import com.ahmadda.domain.organization.OrganizationMemberRepository;
 import com.ahmadda.domain.organization.OrganizationMemberRole;
 import com.ahmadda.domain.organization.OrganizationRepository;
 import com.ahmadda.infra.notification.mail.SmtpEmailNotifier;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.MailSendException;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@Disabled
 @LearningTest
 @TestPropertySource(properties = "mail.mock=false")
 class FailoverEmailNotifierTest {

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/FcmPushNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/FcmPushNotifierTest.java
@@ -1,6 +1,6 @@
 package com.ahmadda.learning.infra.notification;
 
-import com.ahmadda.annotation.IntegrationTest;
+import com.ahmadda.annotation.LearningTest;
 import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.member.MemberRepository;
 import com.ahmadda.domain.notification.PushNotificationPayload;
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Disabled
-@IntegrationTest
+@LearningTest
 @TestPropertySource(properties = "push.mock=false")
 class FcmPushNotifierTest {
 

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/SlackAlarmTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/SlackAlarmTest.java
@@ -1,7 +1,7 @@
 package com.ahmadda.learning.infra.notification;
 
 
-import com.ahmadda.annotation.IntegrationTest;
+import com.ahmadda.annotation.LearningTest;
 import com.ahmadda.application.dto.MemberCreateAlarmPayload;
 import com.ahmadda.domain.member.Member;
 import com.ahmadda.infra.notification.slack.SlackAlarm;
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
 @Disabled
-@IntegrationTest
+@LearningTest
 @TestPropertySource(properties = "slack.mock=false")
 class SlackAlarmTest {
 

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
@@ -66,8 +66,10 @@ class SmtpEmailNotifierTest {
         smtpEmailNotifier.sendEmails(List.of(organizationMember), emailPayload);
     }
 
+    // Gmail: BCC 최대 100명
+    // AWS: BCC 최대 50명
     @Test
-    void BCC_수신자가_100명_이상이면_예외가_발생한다() {
+    void BCC_수신자_허용_범위를_초과하면_예외가_발생한다() {
         // given
         var organizationName = "테스트 이벤트 스페이스";
         var eventTitle = "테스트 이벤트";

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
@@ -1,6 +1,6 @@
 package com.ahmadda.learning.infra.notification;
 
-import com.ahmadda.annotation.IntegrationTest;
+import com.ahmadda.annotation.LearningTest;
 import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.notification.EventEmailPayload;
 import com.ahmadda.domain.organization.Organization;
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Disabled
-@IntegrationTest
+@LearningTest
 @TestPropertySource(properties = "mail.mock=false")
 class SmtpEmailNotifierTest {
 


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #736

## ✨ 작업 내용

- 학습 테스트(learning 패키지) 전용 애노테이션 `@LearningTest` 정의
  - `@Transactional`은 제거
  - 나머지 공통 설정(`@SpringBootTest`, `@ActiveProfiles("test")`은 유지
- 기존 학습 테스트에서 `@IntegrationTest` 대신 `@LearningTest`를 사용하도록 교체

## 🙏 기타 참고 사항

현재 IntegrationTest에는 `@Transactional`이 기본 포함되어 있어, 테스트 실행 시 모든 DB 연산이 롤백 처리됩니다.
하지만 `@Async` 메서드는 별도의 트랜잭션/스레드에서 실행되므로, 아직 커밋되지 않은 데이터를 조회할 수 없어 아래와 같은 예외가 발생했습니다.
```
Caused by: org.hibernate.StaleObjectStateException:
Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect):
[com.ahmadda.domain.organization.OrganizationMember#1]

jakarta.persistence.OptimisticLockException:
Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect):
[com.ahmadda.domain.organization.OrganizationMember#1]
	at com.ahmadda.infra.notification.mail.FailoverEmailNotifier.sendEmails(FailoverEmailNotifier.java:33)
```
해결책은 학습 테스트에서는 DB 롤백을 강제하지 않도록 `@Transactional`을 제거한 별도 설정을 적용하는 것이며, 이를 위해 `@LearningTest`를 새로 도입했습니다.

이제 학습 테스트에서도 `@Async` 로직이 정상적으로 실행되며, 테스트가 아래와 같이 잘 동작합니다.
<img width="2126" height="846" alt="image" src="https://github.com/user-attachments/assets/46e78672-2cdb-418b-a267-09ce915dd2d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 없음 (사용자에게 노출되는 변경 사항 없음)
- 테스트
  - 공용 테스트 어노테이션을 도입해 테스트 프로필과 비웹 환경 설정을 일원화.
  - 기존 통합 테스트 어노테이션을 대체해 여러 테스트 클래스에 적용하여 일관성 향상.
- 정리
  - 일부 테스트에서 사용되지 않는 의존성을 제거해 구성 단순화 및 유지보수성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->