### PR TITLE
[BE] BCC 수신자 제한 문제 해결

### DIFF
--- a/server/src/main/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifier.java
@@ -1,0 +1,25 @@
+package com.ahmadda.infra.notification.mail;
+
+import com.ahmadda.domain.notification.EmailNotifier;
+import com.ahmadda.domain.notification.EventEmailPayload;
+import com.ahmadda.domain.organization.OrganizationMember;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class BccChunkingEmailNotifier implements EmailNotifier {
+
+    private final EmailNotifier delegate;
+    private final int maxBcc;
+
+    @Override
+    public void sendEmails(final List<OrganizationMember> recipients, final EventEmailPayload payload) {
+        for (int i = 0; i < recipients.size(); i += maxBcc) {
+            int end = Math.min(i + maxBcc, recipients.size());
+            List<OrganizationMember> chunk = recipients.subList(i, end);
+
+            delegate.sendEmails(chunk, payload);
+        }
+    }
+}

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/FailoverEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/FailoverEmailNotifier.java
@@ -16,8 +16,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FailoverEmailNotifier implements EmailNotifier {
 
-    private final SmtpEmailNotifier primaryNotifier;
-    private final SmtpEmailNotifier secondaryNotifier;
+    private final EmailNotifier primaryNotifier;
+    private final EmailNotifier secondaryNotifier;
     private final EntityManager em;
 
     @Override

--- a/server/src/test/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifierTest.java
@@ -1,0 +1,88 @@
+package com.ahmadda.infra.notification.mail;
+
+import com.ahmadda.domain.member.Member;
+import com.ahmadda.domain.notification.EmailNotifier;
+import com.ahmadda.domain.notification.EventEmailPayload;
+import com.ahmadda.domain.organization.Organization;
+import com.ahmadda.domain.organization.OrganizationMember;
+import com.ahmadda.domain.organization.OrganizationMemberRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class BccChunkingEmailNotifierTest {
+
+    private EmailNotifier delegate;
+    private BccChunkingEmailNotifier chunkingNotifier;
+    private EventEmailPayload payload;
+
+    @BeforeEach
+    void setUp() {
+        delegate = mock(EmailNotifier.class);
+        chunkingNotifier = new BccChunkingEmailNotifier(delegate, 50);
+
+        payload = new EventEmailPayload(
+                new EventEmailPayload.Subject("이벤트 스페이스", "이벤트"),
+                new EventEmailPayload.Body(
+                        "본문",
+                        "이벤트 스페이스",
+                        "이벤트",
+                        "주최자",
+                        "루터회관",
+                        LocalDateTime.now()
+                                .plusDays(1),
+                        LocalDateTime.now()
+                                .plusDays(2),
+                        LocalDateTime.now()
+                                .plusDays(3),
+                        LocalDateTime.now()
+                                .plusDays(4),
+                        1L, 1L
+                )
+        );
+    }
+
+    @Test
+    void 수신자가_여러명일때_수신자가_제한_이하면_한_번만_호출된다() {
+        // given
+        var recipients = createRecipients(30);
+
+        // when
+        chunkingNotifier.sendEmails(recipients, payload);
+
+        // then
+        verify(delegate, times(1)).sendEmails(recipients, payload);
+    }
+
+    @Test
+    void 수신자가_여러명일때_수신자가_제한을_초과하면_분할되어_여러_번_호출된다() {
+        // given
+        var recipients = createRecipients(120);
+
+        // when
+        chunkingNotifier.sendEmails(recipients, payload);
+
+        // then
+        verify(delegate, times(3)).sendEmails(anyList(), eq(payload));
+    }
+
+    private List<OrganizationMember> createRecipients(int count) {
+        var org = Organization.create("이벤트 스페이스", "설명", "logo.png");
+        List<OrganizationMember> members = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            var member = Member.create("닉네임" + i, "user" + i + "@example.com", "pic.png");
+            members.add(OrganizationMember.create("닉네임" + i, member, org, OrganizationMemberRole.USER));
+        }
+        
+        return members;
+    }
+}

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/FailoverEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/FailoverEmailNotifierTest.java
@@ -10,7 +10,6 @@ import com.ahmadda.domain.organization.OrganizationMember;
 import com.ahmadda.domain.organization.OrganizationMemberRepository;
 import com.ahmadda.domain.organization.OrganizationMemberRole;
 import com.ahmadda.domain.organization.OrganizationRepository;
-import com.ahmadda.infra.notification.mail.SmtpEmailNotifier;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,11 +36,11 @@ class FailoverEmailNotifierTest {
     @Autowired
     private EmailNotifier sut;
 
-    @MockitoSpyBean(name = "gmailSmtpEmailNotifier")
-    private SmtpEmailNotifier gmailNotifier;
+    @MockitoSpyBean(name = "googleEmailNotifier")
+    private EmailNotifier gmailNotifier;
 
-    @MockitoSpyBean(name = "awsSmtpEmailNotifier")
-    private SmtpEmailNotifier awsNotifier;
+    @MockitoSpyBean(name = "awsEmailNotifier")
+    private EmailNotifier awsNotifier;
 
     @Autowired
     private MemberRepository memberRepository;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #741

## ✨ 작업 내용

- Gmail, AWS SES 환경별 BCC 최대 수신자 제한 정책 반영
  - Gmail: 최대 100명
  - AWS SES: 최대 50명
- BCC 수신자 수가 제한을 초과할 경우 자동으로 분할 발송하도록 데코레이터 패턴 적용
- 분할 발송 시 로그 기록 추가 (예: "총 253명 → 100/100/53명으로 분할 발송")

## 🙏 기타 참고 사항

기존에는 BCC 수신자 수가 제한을 초과하면 아래와 같은 예외로 전송이 실패했고,  
특히 AWS SES는 50명 제한으로 인해 빠르게 대응이 필요했습니다.  

- 실제 발생 예외
  - Gmail: `org.eclipse.angus.mail.smtp.SMTPAddressFailedException: 452-4.5.3 Your message has too many recipients.`
  - AWS SES: `org.eclipse.angus.mail.smtp.SMTPSendFailedException: 554 Transaction failed: Recipient count exceeds 50`

이번 작업에서는 이러한 문제를 해결하기 위해 **데코레이터 패턴**을 적용하여  
BCC 수신자 수를 자동으로 분할 처리하도록 개선했습니다.  
이를 통해 안정적으로 대량 메일 발송이 가능해졌으며,  
누구나 코드를 읽고 동작 방식을 쉽게 이해할 수 있도록 구조를 단순화했습니다.
