### PR TITLE
[BE] infra 계층 Bean 등록 방식 및 Mock 클래스 네이밍 개선

### DIFF
--- a/server/src/main/java/com/ahmadda/infra/image/NoopOrganizationImageUploader.java
+++ b/server/src/main/java/com/ahmadda/infra/image/NoopOrganizationImageUploader.java
@@ -5,11 +5,11 @@ import com.ahmadda.domain.organization.OrganizationImageUploader;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class MockOrganizationImageUploader implements OrganizationImageUploader {
+public class NoopOrganizationImageUploader implements OrganizationImageUploader {
 
     @Override
     public String upload(final OrganizationImageFile file) {
-        log.info("[Mock ImageUploader] uploading file {}", file.getFileName());
+        log.info("[Noop ImageUploader] uploading file {}", file.getFileName());
 
         return file.getFileName();
     }

--- a/server/src/main/java/com/ahmadda/infra/image/config/ImageUploaderConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/image/config/ImageUploaderConfig.java
@@ -2,7 +2,7 @@ package com.ahmadda.infra.image.config;
 
 import com.ahmadda.domain.organization.OrganizationImageUploader;
 import com.ahmadda.infra.image.AwsS3OrganizationImageUploader;
-import com.ahmadda.infra.image.MockOrganizationImageUploader;
+import com.ahmadda.infra.image.NoopOrganizationImageUploader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -14,15 +14,15 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class ImageUploaderConfig {
 
     @Bean
-    @ConditionalOnProperty(name = "aws.s3.mock", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnProperty(name = "aws.s3.noob", havingValue = "false", matchIfMissing = true)
     public OrganizationImageUploader awsS3ImageUploader(final S3Client s3Client,
                                                         final AwsS3Properties awsS3Properties) {
         return new AwsS3OrganizationImageUploader(s3Client, awsS3Properties);
     }
 
     @Bean
-    @ConditionalOnProperty(name = "aws.s3.mock", havingValue = "true")
-    public OrganizationImageUploader mockImageUploader() {
-        return new MockOrganizationImageUploader();
+    @ConditionalOnProperty(name = "aws.s3.noob", havingValue = "true")
+    public OrganizationImageUploader noobImageUploader() {
+        return new NoopOrganizationImageUploader();
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/image/config/ImageUploaderConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/image/config/ImageUploaderConfig.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
@@ -14,13 +15,12 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class ImageUploaderConfig {
 
     @Bean
-    @ConditionalOnProperty(name = "aws.s3.noob", havingValue = "false", matchIfMissing = true)
-    public OrganizationImageUploader awsS3ImageUploader(final S3Client s3Client,
-                                                        final AwsS3Properties awsS3Properties) {
+    public OrganizationImageUploader awsS3ImageUploader(final S3Client s3Client, final AwsS3Properties awsS3Properties) {
         return new AwsS3OrganizationImageUploader(s3Client, awsS3Properties);
     }
 
     @Bean
+    @Primary
     @ConditionalOnProperty(name = "aws.s3.noob", havingValue = "true")
     public OrganizationImageUploader noobImageUploader() {
         return new NoopOrganizationImageUploader();

--- a/server/src/main/java/com/ahmadda/infra/image/exception/AwsImageUploadException.java
+++ b/server/src/main/java/com/ahmadda/infra/image/exception/AwsImageUploadException.java
@@ -2,7 +2,7 @@ package com.ahmadda.infra.image.exception;
 
 public class AwsImageUploadException extends RuntimeException {
 
-    public AwsImageUploadException(String message, Throwable cause) {
+    public AwsImageUploadException(final String message, final Throwable cause) {
         super(message, cause);
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/GmailQuotaCircuitBreakerHandler.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/GmailQuotaCircuitBreakerHandler.java
@@ -21,9 +21,8 @@ public class GmailQuotaCircuitBreakerHandler {
         circuitBreaker.getEventPublisher()
                 .onError(event -> {
                     Throwable cause = event.getThrowable();
-                    if (cause != null && cause.getMessage() != null &&
-                            cause.getMessage()
-                                    .contains(DAILY_LIMIT_EXCEEDED_CODE)) {
+                    if (cause.getMessage() != null && cause.getMessage()
+                            .contains(DAILY_LIMIT_EXCEEDED_CODE)) {
                         circuitBreaker.transitionToOpenStateFor(Duration.ofHours(6));
                     }
                 });

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/NoopEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/NoopEmailNotifier.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 
 @Slf4j
-public class MockEmailNotifier implements EmailNotifier {
+public class NoopEmailNotifier implements EmailNotifier {
 
     @Override
     public void sendEmails(
@@ -16,7 +16,7 @@ public class MockEmailNotifier implements EmailNotifier {
             final EventEmailPayload eventEmailPayload
     ) {
         log.info(
-                "[Mock Email] To: {} | Subject: {} | Body: {}",
+                "[Noop Email] To: {} | Subject: {} | Body: {}",
                 recipients,
                 eventEmailPayload.subject(),
                 eventEmailPayload.body()

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/config/MailConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/config/MailConfig.java
@@ -5,7 +5,7 @@ import com.ahmadda.infra.notification.config.NotificationProperties;
 import com.ahmadda.infra.notification.mail.BccChunkingEmailNotifier;
 import com.ahmadda.infra.notification.mail.FailoverEmailNotifier;
 import com.ahmadda.infra.notification.mail.GmailQuotaCircuitBreakerHandler;
-import com.ahmadda.infra.notification.mail.MockEmailNotifier;
+import com.ahmadda.infra.notification.mail.NoopEmailNotifier;
 import com.ahmadda.infra.notification.mail.RetryableEmailNotifier;
 import com.ahmadda.infra.notification.mail.SmtpEmailNotifier;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
@@ -26,14 +26,14 @@ import org.thymeleaf.TemplateEngine;
 public class MailConfig {
 
     @Bean
-    @ConditionalOnProperty(name = "mail.mock", havingValue = "true")
-    public EmailNotifier mockEmailNotifier() {
-        return new MockEmailNotifier();
+    @ConditionalOnProperty(name = "mail.noob", havingValue = "true")
+    public EmailNotifier noobEmailNotifier() {
+        return new NoopEmailNotifier();
     }
 
     @Bean
     @Primary
-    @ConditionalOnProperty(name = "mail.mock", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnProperty(name = "mail.noob", havingValue = "false", matchIfMissing = true)
     public EmailNotifier failoverEmailNotifier(
             @Qualifier("googleEmailNotifier") final EmailNotifier primaryNotifier,
             @Qualifier("awsEmailNotifier") final EmailNotifier secondaryNotifier,
@@ -43,13 +43,13 @@ public class MailConfig {
     }
 
     @Bean
-    @ConditionalOnProperty(name = "mail.mock", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnProperty(name = "mail.noob", havingValue = "false", matchIfMissing = true)
     public GmailQuotaCircuitBreakerHandler gmailQuotaCircuitBreakerHandler(final CircuitBreakerRegistry circuitBreakerRegistry) {
         return new GmailQuotaCircuitBreakerHandler(circuitBreakerRegistry);
     }
 
     @Bean
-    @ConditionalOnProperty(name = "mail.mock", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnProperty(name = "mail.noob", havingValue = "false", matchIfMissing = true)
     public EmailNotifier googleEmailNotifier(
             final SmtpProperties smtpProperties,
             final TemplateEngine templateEngine,
@@ -68,7 +68,7 @@ public class MailConfig {
     }
 
     @Bean
-    @ConditionalOnProperty(name = "mail.mock", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnProperty(name = "mail.noob", havingValue = "false", matchIfMissing = true)
     public EmailNotifier awsEmailNotifier(
             final SmtpProperties smtpProperties,
             final TemplateEngine templateEngine,

--- a/server/src/main/java/com/ahmadda/infra/notification/push/NoopPushNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/NoopPushNotifier.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 
 @Slf4j
-public class MockPushNotifier implements PushNotifier {
+public class NoopPushNotifier implements PushNotifier {
 
     @Override
     public void sendPushs(
@@ -28,7 +28,7 @@ public class MockPushNotifier implements PushNotifier {
             final PushNotificationPayload pushNotificationPayload
     ) {
         log.info(
-                "[Mock Push] To: {} | Title: {} | Body: {} | Event ID: {}",
+                "[Noop Push] To: {} | Title: {} | Body: {} | Event ID: {}",
                 recipients,
                 pushNotificationPayload.title(),
                 pushNotificationPayload.body(),

--- a/server/src/main/java/com/ahmadda/infra/notification/push/config/PushConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/config/PushConfig.java
@@ -5,7 +5,7 @@ import com.ahmadda.infra.notification.config.NotificationProperties;
 import com.ahmadda.infra.notification.push.FcmPushErrorHandler;
 import com.ahmadda.infra.notification.push.FcmPushNotifier;
 import com.ahmadda.infra.notification.push.FcmRegistrationTokenRepository;
-import com.ahmadda.infra.notification.push.MockPushNotifier;
+import com.ahmadda.infra.notification.push.NoopPushNotifier;
 import jakarta.persistence.EntityManager;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -17,13 +17,13 @@ import org.springframework.context.annotation.Configuration;
 public class PushConfig {
 
     @Bean
-    @ConditionalOnProperty(name = "push.mock", havingValue = "true")
-    public PushNotifier mockPushNotifier() {
-        return new MockPushNotifier();
+    @ConditionalOnProperty(name = "push.noob", havingValue = "true")
+    public PushNotifier noobPushNotifier() {
+        return new NoopPushNotifier();
     }
 
     @Bean
-    @ConditionalOnProperty(name = "push.mock", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnProperty(name = "push.noob", havingValue = "false", matchIfMissing = true)
     public PushNotifier fcmPushNotifier(
             final FcmRegistrationTokenRepository fcmRegistrationTokenRepository,
             final NotificationProperties notificationProperties,

--- a/server/src/main/java/com/ahmadda/infra/notification/push/config/PushConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/config/PushConfig.java
@@ -11,19 +11,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 @EnableConfigurationProperties(NotificationProperties.class)
 @Configuration
 public class PushConfig {
 
     @Bean
-    @ConditionalOnProperty(name = "push.noob", havingValue = "true")
-    public PushNotifier noobPushNotifier() {
-        return new NoopPushNotifier();
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "push.noob", havingValue = "false", matchIfMissing = true)
     public PushNotifier fcmPushNotifier(
             final FcmRegistrationTokenRepository fcmRegistrationTokenRepository,
             final NotificationProperties notificationProperties,
@@ -35,5 +29,12 @@ public class PushConfig {
                 notificationProperties,
                 em
         );
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(name = "push.noob", havingValue = "true")
+    public PushNotifier noobPushNotifier() {
+        return new NoopPushNotifier();
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/slack/NoopSlackAlarm.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/slack/NoopSlackAlarm.java
@@ -4,10 +4,10 @@ import com.ahmadda.application.dto.MemberCreateAlarmPayload;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class MockSlackAlarm implements SlackAlarm {
+public class NoopSlackAlarm implements SlackAlarm {
 
     @Override
     public void alarmMemberCreation(final MemberCreateAlarmPayload memberCreateAlarmPayload) {
-        log.info("회원가입 유저 정보 : {} 프로덕션이 아니어서 슬랙으로 알람 보내지 않음", memberCreateAlarmPayload.toString());
+        log.info("[Noop Slack] Member: {}", memberCreateAlarmPayload);
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/slack/config/SlackAlarmConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/slack/config/SlackAlarmConfig.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.web.client.RestClient;
 
 @Configuration
@@ -14,17 +15,17 @@ import org.springframework.web.client.RestClient;
 public class SlackAlarmConfig {
 
     @Bean
-    @ConditionalOnProperty(name = "slack.noob", havingValue = "true")
-    public SlackAlarm noobSlackAlarm() {
-        return new NoopSlackAlarm();
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "slack.noob", havingValue = "false", matchIfMissing = true)
     public SlackAlarm asyncSlackAlarm(
             final RestClient.Builder restClientBuilder,
             final SlackAlarmProperties slackAlarmProperties
     ) {
         return new AsyncSlackAlarm(restClientBuilder, slackAlarmProperties);
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(name = "slack.noob", havingValue = "true")
+    public SlackAlarm noobSlackAlarm() {
+        return new NoopSlackAlarm();
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/slack/config/SlackAlarmConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/slack/config/SlackAlarmConfig.java
@@ -1,7 +1,7 @@
 package com.ahmadda.infra.notification.slack.config;
 
 import com.ahmadda.infra.notification.slack.AsyncSlackAlarm;
-import com.ahmadda.infra.notification.slack.MockSlackAlarm;
+import com.ahmadda.infra.notification.slack.NoopSlackAlarm;
 import com.ahmadda.infra.notification.slack.SlackAlarm;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -14,13 +14,13 @@ import org.springframework.web.client.RestClient;
 public class SlackAlarmConfig {
 
     @Bean
-    @ConditionalOnProperty(name = "slack.mock", havingValue = "true")
-    public SlackAlarm mockSlackAlarm() {
-        return new MockSlackAlarm();
+    @ConditionalOnProperty(name = "slack.noob", havingValue = "true")
+    public SlackAlarm noobSlackAlarm() {
+        return new NoopSlackAlarm();
     }
 
     @Bean
-    @ConditionalOnProperty(name = "slack.mock", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnProperty(name = "slack.noob", havingValue = "false", matchIfMissing = true)
     public SlackAlarm asyncSlackAlarm(
             final RestClient.Builder restClientBuilder,
             final SlackAlarmProperties slackAlarmProperties

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -45,16 +45,16 @@ notification:
   redirect-url-prefix: http://localhost:5173/
 
 mail:
-  mock: true
+  noob: true
 
 push:
-  mock: true
+  noob: true
 
 slack:
-  mock: true
+  noob: true
 
 aws:
   s3:
-    mock: true
+    noob: true
     bucket: ${aws.local.s3.bucket}
     folder: ${aws.local.s3.folder}

--- a/server/src/test/java/com/ahmadda/learning/infra/image/AwsS3OrganizationImageUploaderTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/image/AwsS3OrganizationImageUploaderTest.java
@@ -14,7 +14,7 @@ import java.io.InputStream;
 @Disabled
 @LearningTest
 @TestPropertySource(properties = {
-        "aws.s3.mock=false",
+        "aws.s3.noob=false",
         "aws.s3.region=${aws.dev.s3.region}",
         "aws.s3.bucket=${aws.dev.s3.bucket}",
         "aws.s3.folder=${aws.dev.s3.folder}"

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/FcmPushNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/FcmPushNotifierTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Disabled
 @LearningTest
-@TestPropertySource(properties = "push.mock=false")
+@TestPropertySource(properties = "push.noob=false")
 class FcmPushNotifierTest {
 
     @Autowired

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/SlackAlarmTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/SlackAlarmTest.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.TestPropertySource;
 
 @Disabled
 @LearningTest
-@TestPropertySource(properties = "slack.mock=false")
+@TestPropertySource(properties = "slack.noob=false")
 class SlackAlarmTest {
 
     @Autowired

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 @Disabled
 @LearningTest
-@TestPropertySource(properties = "mail.mock=false")
+@TestPropertySource(properties = "mail.noob=false")
 class SmtpEmailNotifierTest {
 
     private SmtpEmailNotifier sut;

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -38,16 +38,16 @@ notification:
   redirect-url-prefix: http://localhost:5173/
 
 mail:
-  mock: true
+  noob: true
 
 push:
-  mock: true
+  noob: true
 
 slack:
-  mock: true
+  noob: true
 
 aws:
   s3:
-    mock: true
+    noob: true
     bucket: ${aws.local.s3.bucket}
     folder: ${aws.local.s3.folder}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #751

## ✨ 작업 내용

- 기존 `@ConditionalOnProperty` 기반의 mock=false 시 등록 방식은 prod가 주가 되어야 함에도, 부가적인 느낌을 주어 코드 가독성이 떨어진다고 판단함. 이를 해결하기 위해 prod 방식을 기본 등록으로 두고, mock 클래스가 동작할 경우 `@Primary`로 지정하여 대체되도록 변경  
  - 기존 방식은 mock=true 시 불필요한 bean 등록을 줄일 수 있으나, prod 기준에서는 무조건 등록이 필요하므로 큰 이점이 없다고 판단함  
- 실제 클래스의 동작을 막기 위해 사용했던 Mock prefix 네이밍은 용어가 모호하다고 판단함. Mock은 테스트 용어와 겹쳐 의도가 불분명하게 읽힐 수 있었음  
  - 불필요한 동작을 막는 대체 클래스임을 명확히 드러내기 위해 Noop으로 더 직관적인 이름으로 변경  

## 🙏 기타 참고 사항

코드를 읽는 입장에서 냉정하게 보니 흐름이 앞뒤가 바뀐 느낌이 있었습니다 ㅠㅠ
관점을 다시 정리하면서 훨씬 명확해졌다고 생각합니다!
제가 주도했던 아키텍처라 책임지고 손봤는데, 기존 대비해서 훨씬 좋아진 것 같아 뿌듯하네요~~
