### PR TITLE
[FE] 스페이스원이 아닌 경우 스페이스 참여 링크로 유도

### DIFF
--- a/client/src/features/Event/Detail/components/info/EventActionButton.tsx
+++ b/client/src/features/Event/Detail/components/info/EventActionButton.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+
+import { Button } from '@/shared/components/Button';
+import { Flex } from '@/shared/components/Flex';
+import { IconButton } from '@/shared/components/IconButton';
+
+type EventActionButtonProps = {
+  onEditEvent: VoidFunction;
+  onShareEvent: VoidFunction;
+};
+export const EventActionButton = ({ onEditEvent, onShareEvent }: EventActionButtonProps) => {
+  return (
+    <>
+      <DesktopButtonContainer alignItems="center" gap="8px">
+        <Button color="secondary" onClick={onShareEvent}>
+          공유하기
+        </Button>
+        <Button color="primary" onClick={onEditEvent}>
+          수정
+        </Button>
+      </DesktopButtonContainer>
+
+      <MobileFButtonContainer alignItems="center" gap="8px">
+        <IconButton name="share" onClick={onShareEvent} />
+        <IconButton name="edit" onClick={onEditEvent} />
+      </MobileFButtonContainer>
+    </>
+  );
+};
+
+const DesktopButtonContainer = styled(Flex)`
+  @media (max-width: 768px) {
+    display: none;
+  }
+`;
+
+const MobileFButtonContainer = styled(Flex)`
+  display: none;
+
+  @media (max-width: 768px) {
+    display: flex;
+  }
+`;

--- a/client/src/features/Event/Detail/components/info/EventActionButton.tsx
+++ b/client/src/features/Event/Detail/components/info/EventActionButton.tsx
@@ -20,10 +20,10 @@ export const EventActionButton = ({ onEditEvent, onShareEvent }: EventActionButt
         </Button>
       </DesktopButtonContainer>
 
-      <MobileFButtonContainer alignItems="center" gap="8px">
+      <MobileButtonContainer alignItems="center" gap="8px">
         <IconButton name="share" onClick={onShareEvent} />
         <IconButton name="edit" onClick={onEditEvent} />
-      </MobileFButtonContainer>
+      </MobileButtonContainer>
     </>
   );
 };
@@ -34,7 +34,7 @@ const DesktopButtonContainer = styled(Flex)`
   }
 `;
 
-const MobileFButtonContainer = styled(Flex)`
+const MobileButtonContainer = styled(Flex)`
   display: none;
 
   @media (max-width: 768px) {

--- a/client/src/features/Event/Overview/components/PastEventList.tsx
+++ b/client/src/features/Event/Overview/components/PastEventList.tsx
@@ -1,10 +1,8 @@
-import { css } from '@emotion/react';
-
 import { Flex } from '@/shared/components/Flex';
-import { theme } from '@/shared/styles/theme';
 
 import { EventCard } from '../../components/EventCard';
 import { Event } from '../../types/Event';
+import { groupEventsByDate } from '../../utils/groupEventsByDate';
 
 import { EventGrid } from './CurrentEventList';
 import { EventSection } from './EventSection';
@@ -14,21 +12,15 @@ type PastEventListProps = {
 };
 
 export const PastEventList = ({ events }: PastEventListProps) => {
+  const groupedEvents = groupEventsByDate(events);
+  console.log('groupedEvents', groupedEvents);
+
   return (
-    <>
-      <Flex
-        width="100%"
-        justifyContent="flex-start"
-        alignItems="center"
-        gap="5px"
-        margin="10px 0"
-        css={css`
-          border-radius: 8px;
-          background-color: ${theme.colors.primary50};
-        `}
-      >
-        {events.map((event) => (
-          <EventSection key={event.eventId} title={event.title}>
+    <Flex dir="column" width="100%" gap="20px">
+      {groupedEvents
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+        .map(({ label, events }) => (
+          <EventSection key={label} title={label}>
             <EventGrid>
               {events.map((event, index) => (
                 <EventCard key={index} {...event} cardType="default" />
@@ -36,7 +28,6 @@ export const PastEventList = ({ events }: PastEventListProps) => {
             </EventGrid>
           </EventSection>
         ))}
-      </Flex>
-    </>
+    </Flex>
   );
 };

--- a/client/src/features/Event/Overview/components/PastEventList.tsx
+++ b/client/src/features/Event/Overview/components/PastEventList.tsx
@@ -13,7 +13,6 @@ type PastEventListProps = {
 
 export const PastEventList = ({ events }: PastEventListProps) => {
   const groupedEvents = groupEventsByDate(events);
-  console.log('groupedEvents', groupedEvents);
 
   return (
     <Flex dir="column" width="100%" gap="20px">

--- a/client/src/router/InviteRedirect.tsx
+++ b/client/src/router/InviteRedirect.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+
+import { organizationQueryOptions } from '@/api/queries/organization';
+
+export const InviteRedirect = () => {
+  const { organizationId, eventId } = useParams();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const inviteCode = searchParams.get('code');
+  const { data: isMember, error } = useQuery({
+    ...organizationQueryOptions.profile(Number(organizationId)),
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (isMember) {
+      const eventRedirectTo = `/${organizationId}/event/${eventId}`;
+      navigate(eventRedirectTo);
+    } else if (error?.message === '존재하지 않는 구성원입니다.') {
+      const inviteRedirect = `/invite?code=${inviteCode}`;
+      navigate(inviteRedirect);
+    }
+  }, [eventId, organizationId, navigate, isMember, inviteCode, error]);
+
+  return null;
+};

--- a/client/src/router/route.tsx
+++ b/client/src/router/route.tsx
@@ -14,6 +14,7 @@ import { OrganizationSelectPage } from '@/features/Organization/Select/pages/Sel
 import { ProfilePage } from '@/features/Profile/pages/ProfilePage';
 
 import { AuthCallback } from './AuthCallback';
+import { InviteRedirect } from './InviteRedirect';
 import { ProtectRoute } from './ProtectRoute';
 
 export const router = createBrowserRouter(
@@ -61,6 +62,10 @@ export const router = createBrowserRouter(
             {
               path: 'manage/:eventId',
               Component: EventManagePage,
+            },
+            {
+              path: ':eventId/invite',
+              Component: InviteRedirect,
             },
           ],
         },

--- a/client/src/shared/components/Icon/assets/edit.tsx
+++ b/client/src/shared/components/Icon/assets/edit.tsx
@@ -1,0 +1,27 @@
+import { SVGProps } from 'react';
+
+export const Edit = ({ width, height, color, ...props }: SVGProps<SVGSVGElement>) => (
+  <svg
+    width={width ?? 24}
+    height={height ?? 24}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M7 7H6C5.46957 7 4.96086 7.21071 4.58579 7.58579C4.21071 7.96086 4 8.46957 4 9V18C4 18.5304 4.21071 19.0391 4.58579 19.4142C4.96086 19.7893 5.46957 20 6 20H15C15.5304 20 16.0391 19.7893 16.4142 19.4142C16.7893 19.0391 17 18.5304 17 18V17"
+      stroke={color ?? '#1B1B1C'}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16 4.99998L19 7.99998M20.385 6.58499C20.7788 6.19114 21.0001 5.65697 21.0001 5.09998C21.0001 4.543 20.7788 4.00883 20.385 3.61498C19.9912 3.22114 19.457 2.99988 18.9 2.99988C18.343 2.99988 17.8088 3.22114 17.415 3.61498L9 12V15H12L20.385 6.58499Z"
+      stroke={color ?? '#1B1B1C'}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/client/src/shared/components/Icon/assets/index.ts
+++ b/client/src/shared/components/Icon/assets/index.ts
@@ -7,6 +7,7 @@ import { Close } from './close';
 import { Delete } from './delete';
 import { DropdownDown } from './dropdownDown';
 import { DropdownUp } from './dropdownUp';
+import { Edit } from './edit';
 import { Location } from './location';
 import { Logo } from './logo';
 import { Next } from './next';
@@ -23,6 +24,7 @@ export const Icons = {
   clock: Clock,
   close: Close,
   delete: Delete,
+  edit: Edit,
   location: Location,
   logo: Logo,
   plus: Plus,


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #752  #753 

## ✨ 작업 내용
- 마감된 이벤트조회시 디자인이 깨지는 문제가 있어 수정 진행했습니다. 추가적으로 날짜에 따른 그룹화도 진행했습니다.

![Sep-22-2025 19-26-43](https://github.com/user-attachments/assets/9e58c8e7-64e1-4654-ab61-bda54caead8f)

- 스페이스원이 아닌 경우 스페이스 참여를 유도하기 위해 중간 라우터를 추가했습니다. 현재는 `profile` api를 활용해 조직원 여부를 검사하고 있으며, 조직원이 아닐 경우 404 에러를 반환해 초대 링크 페이지로 유도하도록 처리했습니다. 추후, 조직원 여부 확인 전용 api 개발완료 되면 해당 로직으로 수정할 예정입니다.

- 모바일 환경에서 수정하기/공유하기 버튼을 아이콘 버튼으로 변경하여 공간 활용을 개선했습니다.
![Sep-22-2025 19-40-57](https://github.com/user-attachments/assets/693e0a28-d686-4aa7-b623-d6dfa42cd948)

**스페이스원이 아닌 경우**
![Sep-22-2025 19-36-34](https://github.com/user-attachments/assets/f688f4b9-698b-4205-93fb-0b8ec7524caf)


**스페이스원인 경우**
![Sep-22-2025 19-36-42](https://github.com/user-attachments/assets/9b74a1ed-5052-46ea-997b-ad001ec754c2)


- edit 버튼 추가했습니다. 추가된 버튼은 스토리북에서 확인 가능합니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 이벤트 상세: 공유/수정 액션 버튼 추가(데스크톱/모바일 대응).
  - 초대 코드 생성 및 초대 링크 모달 제공.
  - 과거 이벤트를 날짜별 섹션으로 그룹화해 가독성 개선.
  - 초대 링크 접근 시 멤버십 여부에 따라 이벤트 화면 또는 초대 페이지로 자동 이동.
  - 라우트 확장으로 초대 리디렉션 흐름 추가.
  - 편집 아이콘 추가로 아이콘 세트 확장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->