### PR TITLE
[BE] 구성원이 자신의 프로필을 조회할때 그룹 정보도 조회되도록 변경

### DIFF
--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizationGroupResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizationGroupResponse.java
@@ -1,8 +1,13 @@
 package com.ahmadda.presentation.dto;
 
+import com.ahmadda.domain.organization.OrganizationGroup;
+
 public record OrganizationGroupResponse(
         Long groupId,
         String name
 ) {
 
+    public static OrganizationGroupResponse from(final OrganizationGroup organizationGroup) {
+        return new OrganizationGroupResponse(organizationGroup.getId(), organizationGroup.getName());
+    }
 }

--- a/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberResponse.java
+++ b/server/src/main/java/com/ahmadda/presentation/dto/OrganizationMemberResponse.java
@@ -5,14 +5,16 @@ import com.ahmadda.domain.organization.OrganizationMember;
 public record OrganizationMemberResponse(
         Long organizationMemberId,
         String nickname,
-        boolean isAdmin
+        boolean isAdmin,
+        OrganizationGroupResponse group
 ) {
 
     public static OrganizationMemberResponse from(final OrganizationMember organizationMember) {
         return new OrganizationMemberResponse(
                 organizationMember.getId(),
                 organizationMember.getNickname(),
-                organizationMember.isAdmin()
+                organizationMember.isAdmin(),
+                OrganizationGroupResponse.from(organizationMember.getGroup())
         );
     }
 }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #772 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
구성원이 자신의 프로필을 조회할때 그룹 정보도 조회되도록 해주었습니다~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 조직 구성원 조회 결과에 ‘그룹’ 정보가 추가되어, 구성원 목록/상세 화면에서 소속 그룹(그룹 ID, 이름)을 함께 확인할 수 있습니다.
  - 그룹 정보를 일관된 형식으로 제공하도록 응답이 정리되어, 그룹 표시의 정확성과 일관성이 향상되었습니다.
  - 그룹 기준의 탐색, 필터링, 정렬 등 사용 시나리오가 보다 수월해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->