### PR TITLE
[BE] 이벤트 스페이스 구성원 최대 300명 제약 및 닉네임 제약조건 추가

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/organization/Organization.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/Organization.java
@@ -34,6 +34,7 @@ public class Organization extends BaseEntity {
     private static final int MAX_NAME_LENGTH = 30;
     private static final int MIN_DESCRIPTION_LENGTH = 1;
     private static final int MIN_NAME_LENGTH = 1;
+    private static final int MAX_ORGANIZATION_MEMBER_LENGTH = 300;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -84,12 +85,8 @@ public class Organization extends BaseEntity {
             final InviteCode inviteCode,
             final LocalDateTime now
     ) {
-        if (!inviteCode.matchesOrganization(this)) {
-            throw new UnprocessableEntityException("잘못된 초대코드입니다.");
-        }
-        if (inviteCode.isExpired(now)) {
-            throw new UnprocessableEntityException("초대코드가 만료되었습니다.");
-        }
+        validateInviteCode(inviteCode, now);
+        validateOrganizationMemberSize();
 
         return OrganizationMember.create(nickname, member, this, OrganizationMemberRole.USER);
     }
@@ -111,6 +108,21 @@ public class Organization extends BaseEntity {
         this.name = name;
         this.description = description;
         this.imageUrl = imageUrl;
+    }
+
+    private void validateOrganizationMemberSize() {
+        if (organizationMembers.size() == MAX_ORGANIZATION_MEMBER_LENGTH) {
+            throw new UnprocessableEntityException("이벤트 스페이스에 이미 정원이 가득차 참여할 수 없어요.");
+        }
+    }
+
+    private void validateInviteCode(InviteCode inviteCode, LocalDateTime now) {
+        if (!inviteCode.matchesOrganization(this)) {
+            throw new UnprocessableEntityException("잘못된 초대코드입니다.");
+        }
+        if (inviteCode.isExpired(now)) {
+            throw new UnprocessableEntityException("초대코드가 만료되었습니다.");
+        }
     }
 
     private void validateUpdatableBy(final OrganizationMember updatingOrganizationMember) {

--- a/server/src/main/java/com/ahmadda/domain/organization/Organization.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/Organization.java
@@ -112,7 +112,7 @@ public class Organization extends BaseEntity {
 
     private void validateOrganizationMemberSize() {
         if (organizationMembers.size() == MAX_ORGANIZATION_MEMBER_LENGTH) {
-            throw new UnprocessableEntityException("이벤트 스페이스에 이미 정원이 가득차 참여할 수 없어요.");
+            throw new UnprocessableEntityException("이벤트 스페이스에 이미 정원이 가득차 참여할 수 없습니다.");
         }
     }
 

--- a/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
@@ -2,6 +2,7 @@ package com.ahmadda.domain.organization;
 
 
 import com.ahmadda.common.exception.ForbiddenException;
+import com.ahmadda.common.exception.UnprocessableEntityException;
 import com.ahmadda.domain.BaseEntity;
 import com.ahmadda.domain.event.Event;
 import com.ahmadda.domain.member.Member;
@@ -30,6 +31,8 @@ import java.util.List;
 @SQLRestriction("deleted_at IS NULL")
 public class OrganizationMember extends BaseEntity {
 
+    private static final int MAX_NICKNAME_LENGTH = 10;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "organization_member_id")
@@ -56,6 +59,8 @@ public class OrganizationMember extends BaseEntity {
             final Organization organization,
             final OrganizationMemberRole role
     ) {
+        validateNickname(nickname);
+
         this.nickname = nickname;
         this.member = member;
         this.organization = organization;
@@ -104,6 +109,7 @@ public class OrganizationMember extends BaseEntity {
     }
 
     public void rename(final String newNickname) {
+        validateNickname(newNickname);
         this.nickname = newNickname;
     }
 
@@ -114,6 +120,12 @@ public class OrganizationMember extends BaseEntity {
 
         if (!operator.isAdmin()) {
             throw new ForbiddenException("관리자만 구성원의 권한을 변경할 수 있습니다.");
+        }
+    }
+
+    private void validateNickname(final String nickname) {
+        if (nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new UnprocessableEntityException("최대 닉네임 길이는 10자입니다.");
         }
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -254,6 +254,18 @@ public class OrganizationController {
                                                       "instance": "/api/organizations/{organizationId}/participation"
                                                     }
                                                     """
+                                    ),
+                                    @ExampleObject(
+                                            name = "이벤트 스페이스가 정원이 가득 찬 경우",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Unprocessable Entity",
+                                                      "status": 422,
+                                                      "detail": "이벤트 스페이스에 이미 정원이 가득차 참여할 수 없어요.",
+                                                      "instance": "/api/organizations/{organizationId}/participation"
+                                                    }
+                                                    """
                                     )
                             }
                     )

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -262,7 +262,7 @@ public class OrganizationController {
                                                       "type": "about:blank",
                                                       "title": "Unprocessable Entity",
                                                       "status": 422,
-                                                      "detail": "이벤트 스페이스에 이미 정원이 가득차 참여할 수 없어요.",
+                                                      "detail": "이벤트 스페이스에 이미 정원이 가득차 참여할 수 없습니다.",
                                                       "instance": "/api/organizations/{organizationId}/participation"
                                                     }
                                                     """

--- a/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventGuestServiceTest.java
@@ -206,7 +206,7 @@ class EventGuestServiceTest {
         var member1 = createAndSaveMember("name1", "email1@ahmadda.com");
         var member2 = createAndSaveMember("name2", "email2@ahmadda.com");
         var organizer = createAndSaveOrganizationMember("organizer", member1, organization);
-        var participant = createAndSaveOrganizationMember("participant", member2, organization);
+        var participant = createAndSaveOrganizationMember("parti", member2, organization);
 
         var question1 = Question.create("필수 질문", true, 0);
         var question2 = Question.create("선택 질문", false, 1);
@@ -240,7 +240,7 @@ class EventGuestServiceTest {
         var member1 = createAndSaveMember("name1", "email1@ahmadda.com");
         var member2 = createAndSaveMember("name2", "email2@ahmadda.com");
         var organizer = createAndSaveOrganizationMember("organizer", member1, organization);
-        var participant = createAndSaveOrganizationMember("participant", member2, organization);
+        var participant = createAndSaveOrganizationMember("parti", member2, organization);
 
         Question question1 = Question.create("필수 질문", true, 0);
         Question question2 = Question.create("선택 질문", false, 1);
@@ -257,12 +257,12 @@ class EventGuestServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.participantEvent(
-                                           event.getId(),
-                                           new LoginMember(member2.getId()),
-                                           event.getRegistrationStart(),
-                                           request
-                                   )
+                sut.participantEvent(
+                        event.getId(),
+                        new LoginMember(member2.getId()),
+                        event.getRegistrationStart(),
+                        request
+                )
         )
                 .isInstanceOf(UnprocessableEntityException.class)
                 .hasMessageContaining("필수 질문에 대한 답변이 누락되었습니다");
@@ -275,7 +275,7 @@ class EventGuestServiceTest {
         var member1 = createAndSaveMember("name1", "email1@ahmadda.com");
         var member2 = createAndSaveMember("name2", "email2@ahmadda.com");
         var organizer = createAndSaveOrganizationMember("organizer", member1, organization);
-        var participant = createAndSaveOrganizationMember("participant", member2, organization);
+        var participant = createAndSaveOrganizationMember("parti", member2, organization);
         var event = createAndSaveEvent(organizer, organization);
 
         var invalidQuestionId = 999L;
@@ -286,12 +286,12 @@ class EventGuestServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-                                   sut.participantEvent(
-                                           event.getId(),
-                                           new LoginMember(member2.getId()),
-                                           event.getRegistrationStart(),
-                                           request
-                                   )
+                sut.participantEvent(
+                        event.getId(),
+                        new LoginMember(member2.getId()),
+                        event.getRegistrationStart(),
+                        request
+                )
         )
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("존재하지 않는 질문입니다.");
@@ -305,11 +305,11 @@ class EventGuestServiceTest {
         var member2 = createAndSaveMember("test2", "ahmadda2@ahmadda.com");
         var member3 = createAndSaveMember("test3", "ahmadda3@ahmadda.com");
         var organizationMember1 =
-                createAndSaveOrganizationMember("organizationMember1", member1, organization);
+                createAndSaveOrganizationMember("orgMem1", member1, organization);
         var organizationMember2 =
-                createAndSaveOrganizationMember("organizationMember2", member2, organization);
+                createAndSaveOrganizationMember("orgMem2", member2, organization);
         var organizationMember3 =
-                createAndSaveOrganizationMember("organizationMember2", member3, organization);
+                createAndSaveOrganizationMember("orgMem2", member3, organization);
 
         var event = createAndSaveEvent(organizationMember1, organization);
         createAndSaveGuest(event, organizationMember2);
@@ -331,9 +331,9 @@ class EventGuestServiceTest {
         var member2 = createAndSaveMember("test2", "ahmadda2@ahmadda.com");
         var member3 = createAndSaveMember("test3", "ahmadda3@ahmadda.com");
         var organizationMember1 =
-                createAndSaveOrganizationMember("organizationMember1", member1, organization);
+                createAndSaveOrganizationMember("orgMem1", member1, organization);
         var organizationMember2 =
-                createAndSaveOrganizationMember("organizationMember2", member2, organization);
+                createAndSaveOrganizationMember("orgMem2", member2, organization);
 
         var event = createAndSaveEvent(organizationMember1, organization);
         createAndSaveGuest(event, organizationMember2);

--- a/server/src/test/java/com/ahmadda/application/OrganizationMemberServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationMemberServiceTest.java
@@ -53,10 +53,10 @@ class OrganizationMemberServiceTest {
             softly.assertThat(result.getId())
                     .isEqualTo(orgMember.getId());
             softly.assertThat(result.getMember()
-                                      .getId())
+                            .getId())
                     .isEqualTo(member.getId());
             softly.assertThat(result.getOrganization()
-                                      .getId())
+                            .getId())
                     .isEqualTo(org.getId());
         });
     }
@@ -285,6 +285,21 @@ class OrganizationMemberServiceTest {
         assertThatThrownBy(() -> sut.renameOrganizationMemberNickname(org.getId(), loginMember, myNickname))
                 .isInstanceOf(UnprocessableEntityException.class)
                 .hasMessage("현재 닉네임과 동일하여 변경할 수 없습니다.");
+    }
+
+    @Test
+    void 닉네임_변경시_새_닉네임의_길이가_10자를_초과하면_예외가_발생한다() {
+        // given
+        var org = createOrganization("우테코");
+        var member = createMember("홍길동", "hong1@email.com");
+        var loginMember = new LoginMember(member.getId());
+
+        var newNickname = "10자를 벗어나는 닉네임";
+
+        // when // then
+        assertThatThrownBy(() -> sut.renameOrganizationMemberNickname(org.getId(), loginMember, newNickname))
+                .isInstanceOf(UnprocessableEntityException.class)
+                .hasMessage("최대 닉네임 길이는 10자입니다.");
     }
 
     private Organization createOrganization(String name) {

--- a/server/src/test/java/com/ahmadda/application/OrganizationMemberServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationMemberServiceTest.java
@@ -292,8 +292,9 @@ class OrganizationMemberServiceTest {
         // given
         var org = createOrganization("우테코");
         var member = createMember("홍길동", "hong1@email.com");
-        var loginMember = new LoginMember(member.getId());
+        var orgMember1 = createOrganizationMember("닉네임1", member, org, OrganizationMemberRole.USER);
 
+        var loginMember = new LoginMember(member.getId());
         var newNickname = "10자를 벗어나는 닉네임";
 
         // when // then

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -126,7 +126,7 @@ class OrganizationServiceTest {
         var inviteCode = createInviteCode("code", organization, inviter, LocalDateTime.now());
 
         var loginMember = new LoginMember(member1.getId());
-        var request = new OrganizationParticipateRequest("new_nickname", inviteCode.getCode());
+        var request = new OrganizationParticipateRequest("nickname", inviteCode.getCode());
 
         // when
         var organizationMember = sut.participateOrganization(organization.getId(), loginMember, request);
@@ -401,7 +401,7 @@ class OrganizationServiceTest {
             sut.participateOrganization(
                     organization.getId(),
                     loginMember,
-                    new OrganizationParticipateRequest("participate" + i, inviteCode.getCode())
+                    new OrganizationParticipateRequest("parti" + i, inviteCode.getCode())
             );
         }
 
@@ -416,7 +416,7 @@ class OrganizationServiceTest {
                 new OrganizationParticipateRequest("cannotpar", inviteCode.getCode())
         ))
                 .isInstanceOf(UnprocessableEntityException.class)
-                .hasMessage("이벤트 스페이스에 이미 정원이 가득차 참여할 수 없어요.");
+                .hasMessage("이벤트 스페이스에 이미 정원이 가득차 참여할 수 없습니다.");
     }
 
     @Test
@@ -429,12 +429,12 @@ class OrganizationServiceTest {
         var inviteCode = createInviteCode("code", organization, inviter, LocalDateTime.now());
 
         var loginMember = new LoginMember(member1.getId());
-        var request = new OrganizationParticipateRequest("new_nickname", inviteCode.getCode());
+        var request = new OrganizationParticipateRequest("newname", inviteCode.getCode());
 
         sut.participateOrganization(organization.getId(), loginMember, request);
 
         var duplicateNameMember =
-                memberRepository.save(Member.create("duplicateNameMember", "user3@test.com", "testPicture"));
+                memberRepository.save(Member.create("dupliName", "user3@test.com", "testPicture"));
         var duplicateName = "surf";
         var duplicateNameRequest = new OrganizationParticipateRequest(duplicateName, inviteCode.getCode());
         var duplicateLoginMember = new LoginMember(duplicateNameMember.getId());

--- a/server/src/test/java/com/ahmadda/domain/event/EventTest.java
+++ b/server/src/test/java/com/ahmadda/domain/event/EventTest.java
@@ -476,7 +476,7 @@ class EventTest {
         var organization = Organization.create("우아한 테크코스", "woowahan-tech-course", "우아한 테크코스 6기");
         var member = Member.create("박찬양", "creator.chanyang@woowahan.com", "testPicture");
         var organizationMember =
-                OrganizationMember.create("이벤트_개설자_닉네임", member, organization, OrganizationMemberRole.USER);
+                OrganizationMember.create("개설자_닉네임", member, organization, OrganizationMemberRole.USER);
 
 
         var member2 = Member.create("김참가", "participant.kim@woowahan.com", "testPicture");

--- a/server/src/test/java/com/ahmadda/domain/organization/OrganizationTest.java
+++ b/server/src/test/java/com/ahmadda/domain/organization/OrganizationTest.java
@@ -162,16 +162,16 @@ class OrganizationTest {
 
         for (int i = 0; i < 299; i++) {
             var member = Member.create("일반회원" + i, "email" + i + "@gmail.com", "profile.img");
-            sut.participate(member, "membername" + i, inviteCode, LocalDateTime.now());
+            sut.participate(member, "nick" + i, inviteCode, LocalDateTime.now());
         }
 
         // when // then
         assertThatThrownBy(() -> {
-            var cannotParticipateMember = Member.create("참여불가능한회원", "email300@gmail.com", "profile.img");
-            sut.participate(cannotParticipateMember, "cannotparticipate", inviteCode, LocalDateTime.now());
+            var cannotParticipateMember = Member.create("참여불가능한회원", "cannotpart@gmail.com", "profile.img");
+            sut.participate(cannotParticipateMember, "cannotpart", inviteCode, LocalDateTime.now());
         })
                 .isInstanceOf(UnprocessableEntityException.class)
-                .hasMessage("이벤트 스페이스에 이미 정원이 가득차 참여할 수 없어요.");
+                .hasMessage("이벤트 스페이스에 이미 정원이 가득차 참여할 수 없습니다.");
     }
 
     private Event createEventForTest(

--- a/server/src/test/java/com/ahmadda/domain/organization/OrganizationTest.java
+++ b/server/src/test/java/com/ahmadda/domain/organization/OrganizationTest.java
@@ -155,6 +155,25 @@ class OrganizationTest {
                 .hasMessage("이벤트 스페이스에 속한 구성원만 수정이 가능합니다.");
     }
 
+    @Test
+    void 이벤트_스페이스에_참여시_이미_정원이_찬_경우_예외가_발생한다() {
+        // given
+        var inviteCode = InviteCode.create("code", sut, organizer, LocalDateTime.now());
+
+        for (int i = 0; i < 299; i++) {
+            var member = Member.create("일반회원" + i, "email" + i + "@gmail.com", "profile.img");
+            sut.participate(member, "membername" + i, inviteCode, LocalDateTime.now());
+        }
+
+        // when // then
+        assertThatThrownBy(() -> {
+            var cannotParticipateMember = Member.create("참여불가능한회원", "email300@gmail.com", "profile.img");
+            sut.participate(cannotParticipateMember, "cannotparticipate", inviteCode, LocalDateTime.now());
+        })
+                .isInstanceOf(UnprocessableEntityException.class)
+                .hasMessage("이벤트 스페이스에 이미 정원이 가득차 참여할 수 없어요.");
+    }
+
     private Event createEventForTest(
             String title,
             LocalDateTime registrationStart,


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #756 

## ✨ 작업 내용
- 이벤트 스페이스 구성원이 최대 300명을 넘어설 수 없도록 제약조건을 추가하였습니다
- 닉네임 제약조건 10자를 추가하였습니다

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항
- 이벤트스페이스 구성원이 300명이 넘어갈 가능성이 낮다는 의견을 반영하여 최대 300명으로 제한하였습니다 

<!-- 없다면 적지 않으셔도 됩니다. -->
