### PR TITLE
[FE] suspense fallback 적용, 코드 스플리팅 수정

### DIFF
--- a/client/src/features/Event/Detail/pages/EventDetailPage.tsx
+++ b/client/src/features/Event/Detail/pages/EventDetailPage.tsx
@@ -69,7 +69,7 @@ export const EventDetailPage = () => {
           }
           right={
             <Button size="sm" onClick={() => navigate(`/${organizationId}/event/my`)}>
-              내 이벤트
+              마이 페이지
             </Button>
           }
         />

--- a/client/src/features/Event/Manage/pages/EventManagePage.tsx
+++ b/client/src/features/Event/Manage/pages/EventManagePage.tsx
@@ -71,7 +71,7 @@ export const EventManagePage = () => {
             }
             right={
               <Button size="sm" onClick={() => navigate(`/${organizationId}/event/my`)}>
-                내 이벤트
+                마이 페이지
               </Button>
             }
           />

--- a/client/src/features/Event/My/components/EventTabs.tsx
+++ b/client/src/features/Event/My/components/EventTabs.tsx
@@ -50,9 +50,11 @@ export const EventTabs = () => {
           </Flex>
         ) : (
           <Flex dir="column" width="100%" gap="20px">
-            {groupedHostEvents.map(({ label, events }) => (
-              <EventSection key={label} date={label} events={events} cardType={TAB_VALUES.HOST} />
-            ))}
+            {groupedHostEvents
+              .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+              .map(({ label, events }) => (
+                <EventSection key={label} date={label} events={events} cardType={TAB_VALUES.HOST} />
+              ))}
           </Flex>
         )}
       </Tabs.Content>
@@ -71,14 +73,16 @@ export const EventTabs = () => {
           </Flex>
         ) : (
           <Flex dir="column" width="100%" gap="20px">
-            {groupedParticipateEvents.map(({ label, events }) => (
-              <EventSection
-                key={label}
-                date={label}
-                events={events}
-                cardType={TAB_VALUES.PARTICIPATE}
-              />
-            ))}
+            {groupedParticipateEvents
+              .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+              .map(({ label, events }) => (
+                <EventSection
+                  key={label}
+                  date={label}
+                  events={events}
+                  cardType={TAB_VALUES.PARTICIPATE}
+                />
+              ))}
           </Flex>
         )}
       </Tabs.Content>

--- a/client/src/features/Event/My/components/Info.tsx
+++ b/client/src/features/Event/My/components/Info.tsx
@@ -20,7 +20,7 @@ export const Info = () => {
     >
       <Flex dir="column" gap="8px">
         <Text as="h1" type="Display" weight="bold" color="gray900">
-          내 이벤트
+          마이 페이지
         </Text>
         <Text as="h2" type="Body" weight="medium" color="gray700">
           내가 주최하고, 참여한 이벤트를 확인해보세요.

--- a/client/src/features/Event/My/constants/index.ts
+++ b/client/src/features/Event/My/constants/index.ts
@@ -1,5 +1,5 @@
 export const UI_LABELS = {
-  PAGE_TITLE: '내 이벤트',
+  PAGE_TITLE: '마이 페이지',
 
   HOST_TAB: '주최 이벤트',
   PARTICIPATE_TAB: '참여 이벤트',

--- a/client/src/features/Event/My/pages/MyEventPage.tsx
+++ b/client/src/features/Event/My/pages/MyEventPage.tsx
@@ -29,7 +29,7 @@ export const MyEventPage = () => {
           }
           right={
             <Button size="sm" onClick={() => navigate(`/${organizationId}/event/my`)}>
-              내 이벤트
+              마이 페이지
             </Button>
           }
         />

--- a/client/src/features/Event/New/pages/NewEventPage.tsx
+++ b/client/src/features/Event/New/pages/NewEventPage.tsx
@@ -30,7 +30,7 @@ export const NewEventPage = () => {
           }
           right={
             <Button size="sm" onClick={() => navigate(`/${organizationId}/event/my`)}>
-              내 이벤트
+              마이 페이지
             </Button>
           }
         />

--- a/client/src/features/Event/Overview/components/OrganizationInfo.tsx
+++ b/client/src/features/Event/Overview/components/OrganizationInfo.tsx
@@ -43,6 +43,8 @@ export const OrganizationInfo = ({ name, description, imageUrl }: OrganizationPr
             <ThumbImg
               src={src}
               alt={alt}
+              width={THUMB_MAX_PX}
+              height={THUMB_MAX_PX}
               decoding="async"
               fetchPriority="high"
               onError={(e) => {

--- a/client/src/features/Event/Overview/pages/OverviewPage.tsx
+++ b/client/src/features/Event/Overview/pages/OverviewPage.tsx
@@ -66,7 +66,7 @@ export const OverviewPage = () => {
             }
             right={
               <Button size="sm" onClick={goMyEvents}>
-                내 이벤트
+                마이 페이지
               </Button>
             }
           />

--- a/client/src/features/Profile/pages/ProfilePage.tsx
+++ b/client/src/features/Profile/pages/ProfilePage.tsx
@@ -35,7 +35,7 @@ export const ProfilePage = () => {
           }
           right={
             <Button size="sm" onClick={() => navigate(`/${organizationId}/event/my`)}>
-              내 이벤트
+              마이 페이지
             </Button>
           }
         />

--- a/client/src/router/route.tsx
+++ b/client/src/router/route.tsx
@@ -8,6 +8,7 @@ import { MyEventPage } from '@/features/Event/My/pages/MyEventPage';
 import { OverviewPage } from '@/features/Event/Overview/pages/OverviewPage';
 import { HomePage } from '@/features/Home/page/HomePage';
 import { OrganizationSelectPage } from '@/features/Organization/Select/pages/SelectOrganizationPage';
+import { Flex } from '@/shared/components/Flex';
 import { Loading } from '@/shared/components/Loading';
 
 import { AuthCallback } from './AuthCallback';
@@ -61,7 +62,13 @@ const ProfilePage = lazy(() =>
 );
 
 const withSuspense = (Component: React.ComponentType) => (
-  <Suspense fallback={<Loading />}>
+  <Suspense
+    fallback={
+      <Flex width="100%" height="100vh" alignItems="center" justifyContent="center">
+        <Loading />
+      </Flex>
+    }
+  >
     <Component />
   </Suspense>
 );

--- a/client/src/router/route.tsx
+++ b/client/src/router/route.tsx
@@ -64,7 +64,7 @@ const ProfilePage = lazy(() =>
 const withSuspense = (Component: React.ComponentType) => (
   <Suspense
     fallback={
-      <Flex width="100%" height="100vh" alignItems="center" justifyContent="center">
+      <Flex width="100%" height="100dvh" alignItems="center" justifyContent="center">
         <Loading />
       </Flex>
     }
@@ -85,7 +85,7 @@ export const router = createBrowserRouter(
         },
         {
           path: '/invite',
-          Component: InvitePage,
+          element: withSuspense(InvitePage),
         },
         {
           path: '/auth',
@@ -121,7 +121,7 @@ export const router = createBrowserRouter(
             },
             {
               path: ':eventId/invite',
-              element: withSuspense(InviteRedirect),
+              Component: InviteRedirect,
             },
           ],
         },

--- a/client/src/router/route.tsx
+++ b/client/src/router/route.tsx
@@ -3,8 +3,12 @@ import { lazy, Suspense } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
 import { App } from '@/App';
+import { EventDetailPage } from '@/features/Event/Detail/pages/EventDetailPage';
+import { MyEventPage } from '@/features/Event/My/pages/MyEventPage';
 import { OverviewPage } from '@/features/Event/Overview/pages/OverviewPage';
 import { HomePage } from '@/features/Home/page/HomePage';
+import { OrganizationSelectPage } from '@/features/Organization/Select/pages/SelectOrganizationPage';
+import { Loading } from '@/shared/components/Loading';
 
 import { AuthCallback } from './AuthCallback';
 import { InviteRedirect } from './InviteRedirect';
@@ -17,48 +21,26 @@ const ErrorPage = lazy(() =>
 );
 
 const InvitePage = lazy(() =>
-  import('@/features/Invite/page/InvitePage').then((module) => ({
-    default: module.InvitePage,
-  }))
+  import(/* webpackChunkName: "invite-pages" */ '@/features/Invite/page/InvitePage').then(
+    (module) => ({
+      default: module.InvitePage,
+    })
+  )
 );
 
 const NewEventPage = lazy(() =>
-  import(/* webpackChunkName: "event-pages" */ '@/features/Event/New/pages/NewEventPage').then(
+  import(/* webpackChunkName: "new-event-pages" */ '@/features/Event/New/pages/NewEventPage').then(
     (module) => ({
       default: module.NewEventPage,
     })
   )
 );
 
-const EventDetailPage = lazy(() =>
-  import(
-    /* webpackChunkName: "event-pages" */ '@/features/Event/Detail/pages/EventDetailPage'
-  ).then((module) => ({
-    default: module.EventDetailPage,
-  }))
-);
-
-const MyEventPage = lazy(() =>
-  import(/* webpackChunkName: "event-pages" */ '@/features/Event/My/pages/MyEventPage').then(
-    (module) => ({
-      default: module.MyEventPage,
-    })
-  )
-);
-
 const EventManagePage = lazy(() =>
   import(
-    /* webpackChunkName: "event-pages" */ '@/features/Event/Manage/pages/EventManagePage'
+    /* webpackChunkName: "event-manage-pages" */ '@/features/Event/Manage/pages/EventManagePage'
   ).then((module) => ({
     default: module.EventManagePage,
-  }))
-);
-
-const OrganizationSelectPage = lazy(() =>
-  import(
-    /* webpackChunkName: "organization-pages" */ '@/features/Organization/Select/pages/SelectOrganizationPage'
-  ).then((module) => ({
-    default: module.OrganizationSelectPage,
   }))
 );
 
@@ -79,7 +61,7 @@ const ProfilePage = lazy(() =>
 );
 
 const withSuspense = (Component: React.ComponentType) => (
-  <Suspense>
+  <Suspense fallback={<Loading />}>
     <Component />
   </Suspense>
 );
@@ -96,7 +78,7 @@ export const router = createBrowserRouter(
         },
         {
           path: '/invite',
-          element: withSuspense(InvitePage),
+          Component: InvitePage,
         },
         {
           path: '/auth',
@@ -120,11 +102,11 @@ export const router = createBrowserRouter(
             },
             {
               path: 'my',
-              element: withSuspense(MyEventPage),
+              Component: MyEventPage,
             },
             {
               path: ':eventId',
-              element: withSuspense(EventDetailPage),
+              Component: EventDetailPage,
             },
             {
               path: 'manage/:eventId',
@@ -132,7 +114,7 @@ export const router = createBrowserRouter(
             },
             {
               path: ':eventId/invite',
-              Component: InviteRedirect,
+              element: withSuspense(InviteRedirect),
             },
           ],
         },
@@ -142,7 +124,7 @@ export const router = createBrowserRouter(
           children: [
             {
               index: true,
-              element: withSuspense(OrganizationSelectPage),
+              Component: OrganizationSelectPage,
             },
             {
               path: 'new',

--- a/client/src/shared/components/Loading/Loading.stories.tsx
+++ b/client/src/shared/components/Loading/Loading.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Loading } from './Loading';
+
+const meta = {
+  title: 'components/Loading',
+  component: Loading,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The Loading component provides a visual indication that content is being loaded, enhancing user experience during wait times.',
+      },
+    },
+  },
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+type Story = StoryObj<typeof Loading>;
+
+export const Basic: Story = {
+  render: () => <Loading />,
+};

--- a/client/src/shared/components/Loading/Loading.styled.ts
+++ b/client/src/shared/components/Loading/Loading.styled.ts
@@ -1,0 +1,34 @@
+import { css, keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+const bounce = keyframes`
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+`;
+
+const pulse = keyframes`
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+`;
+
+export const StyledLoadingText = styled.span<{ delay: number }>`
+  display: inline-block;
+  animation: ${bounce} 1s infinite;
+  animation-delay: ${({ delay }) => delay}ms;
+  font-size: 48px;
+  font-weight: bold;
+`;
+
+export const StyledLoadingDots = css`
+  display: inline-block;
+  margin-left: 4px;
+  animation: ${pulse} 1s infinite;
+`;

--- a/client/src/shared/components/Loading/Loading.tsx
+++ b/client/src/shared/components/Loading/Loading.tsx
@@ -1,0 +1,14 @@
+import { StyledLoadingText } from './Loading.styled';
+
+export const Loading = () => {
+  const text = 'Loading';
+  return (
+    <>
+      {text.split('').map((char, i) => (
+        <StyledLoadingText delay={i * 100} key={i}>
+          {char}
+        </StyledLoadingText>
+      ))}
+    </>
+  );
+};

--- a/client/src/shared/components/Loading/index.ts
+++ b/client/src/shared/components/Loading/index.ts
@@ -1,0 +1,1 @@
+export { Loading } from './Loading';


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #790

## ✨ 작업 내용

- [코드 스플리팅 관련 문서](https://www.notion.so/277f55e0580c807798acc78ae0c2bfc4?source=copy_link) 정리했습니다. lazy를 적용했을 때, 화면 진입 시 잠시 흰 화면이 나타난 뒤 데이터가 로드되는 현상을 확인했습니다. 이에 따라 코드 스플리팅은 꼭 필요한 구간에만 최소한으로 적용하고, 해당 구간에는 Loading 컴포넌트를 활용해 폴백 UI를 제공하도록 했습니다.
- Loading 컴포넌트 구현했습니다.
- 내 이벤트 -> 마이 페이지로 워딩 변경했습니다.
- 주최/참여 이벤트 조회시 최신순 정렬 진행했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 페이지 전환 시 일관된 로딩 애니메이션 화면 추가
* Refactor
  * 라우팅 구조 개선 및 지연 로딩 처리 통합으로 탐색 안정성·응답성 향상
  * 내 이벤트 탭을 최신순(내림차순) 정렬로 변경해 가독성 개선
* Style
  * 조직 썸네일 이미지 크기 고정으로 레이아웃 일관성 강화
  * 여러 페이지의 버튼/제목 문구를 “마이 페이지”로 통일
* Documentation
  * 로딩 컴포넌트용 스토리북 스토리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->