### PR TITLE
[FE] 공동 주최자 모달의 영역 밖으로 구성원 리스트가 벗어나는 문제 해결

### DIFF
--- a/client/src/features/Event/New/components/CoHostSelectModal.tsx
+++ b/client/src/features/Event/New/components/CoHostSelectModal.tsx
@@ -137,69 +137,77 @@ export const CoHostSelectModal = ({
           {title}
         </Text>
 
-        <Tabs defaultValue={String(tabs[0]?.id ?? '')}>
-          <Tabs.List
-            css={css`
-              --tabs-gap: 12px;
-              display: flex;
-              overflow-x: auto;
-              white-space: nowrap;
-              padding: 0 4px;
-              column-gap: var(--tabs-gap);
-              margin-top: 12px;
+        <Flex
+          dir="column"
+          css={{
+            minHeight: 0,
+          }}
+        >
+          <Tabs defaultValue={String(tabs[0]?.id ?? '')} css={{ minHeight: 0 }}>
+            <Tabs.List
+              css={css`
+                --tabs-gap: 12px;
+                display: flex;
+                overflow-x: auto;
+                white-space: nowrap;
+                padding: 0 4px;
+                column-gap: var(--tabs-gap);
+                margin-top: 12px;
+                min-height: 35px;
 
-              @media (max-width: 480px) {
-                --tabs-gap: 8px;
-                padding: 0 2px;
-              }
-            `}
-          >
-            {tabs.map((t) => (
-              <Tabs.Trigger
-                key={t.id}
-                value={String(t.id)}
-                css={css`
-                  margin: 0;
-                  padding: 6px 10px;
+                @media (max-width: 480px) {
+                  --tabs-gap: 8px;
+                  padding: 0 2px;
+                }
+              `}
+            >
+              {tabs.map((t) => (
+                <Tabs.Trigger
+                  key={t.id}
+                  value={String(t.id)}
+                  css={css`
+                    margin: 0;
+                    padding: 6px 10px;
 
-                  @media (max-width: 500px) {
-                    padding: 3px 6px;
-                    font-size: 13px;
-                  }
-                `}
-              >
-                {t.name}
-              </Tabs.Trigger>
-            ))}
-          </Tabs.List>
+                    @media (max-width: 500px) {
+                      padding: 3px 6px;
+                      font-size: 13px;
+                    }
+                  `}
+                >
+                  {t.name}
+                </Tabs.Trigger>
+              ))}
+            </Tabs.List>
 
-          {tabs.map((t) => {
-            const guests = guestsOfTab(t.id);
-            const ids = idsOfTab(t.id);
-            const emptyMsg =
-              t.id === 'HOST'
-                ? '선택된 공동 주최자가 없어요.'
-                : '이 그룹에 속해있는 구성원이 없어요.';
+            {tabs.map((t) => {
+              const guests = guestsOfTab(t.id);
+              const ids = idsOfTab(t.id);
+              const emptyMsg =
+                t.id === 'HOST'
+                  ? '선택된 공동 주최자가 없어요.'
+                  : '이 그룹에 속해있는 구성원이 없어요.';
 
-            return (
-              <Tabs.Content key={`${t.id}`} value={String(t.id)}>
-                <ScrollArea>
-                  {guests.length === 0 ? (
-                    <EmptyState>{emptyMsg}</EmptyState>
-                  ) : (
-                    <GuestList
-                      title={`${title} (${totalSelected}명)`}
-                      titleColor={theme.colors.gray700}
-                      guests={guests}
-                      onGuestChecked={onGuestChecked}
-                      onAllGuestChecked={() => onAllGuestCheckedFor(ids)}
-                    />
-                  )}
-                </ScrollArea>
-              </Tabs.Content>
-            );
-          })}
-        </Tabs>
+              return (
+                <TabPanel key={`${t.id}`} value={String(t.id)}>
+                  <ScrollArea>
+                    {guests.length === 0 ? (
+                      <EmptyState>{emptyMsg}</EmptyState>
+                    ) : (
+                      <GuestList
+                        title={`${title} (${totalSelected}명)`}
+                        titleColor={theme.colors.gray700}
+                        guests={guests}
+                        onGuestChecked={onGuestChecked}
+                        onAllGuestChecked={() => onAllGuestCheckedFor(ids)}
+                      />
+                    )}
+                  </ScrollArea>
+                </TabPanel>
+              );
+            })}
+          </Tabs>
+        </Flex>
 
         <StickyFooter>
           <Text type="Label" color={theme.colors.gray500} css={{ marginBottom: 12 }}>
@@ -223,6 +231,12 @@ export const CoHostSelectModal = ({
 const ModalBody = styled(Flex)`
   width: clamp(200px, 85vw, 500px);
   height: clamp(300px, 80vh, 450px);
+  min-height: 0;
+`;
+
+const TabPanel = styled(Tabs.Content)`
+  display: flex;
+  flex: 1 1 auto;
   min-height: 0;
 `;
 

--- a/client/src/features/Event/New/components/CoHostSelectModal.tsx
+++ b/client/src/features/Event/New/components/CoHostSelectModal.tsx
@@ -139,11 +139,16 @@ export const CoHostSelectModal = ({
 
         <Flex
           dir="column"
-          css={{
-            minHeight: 0,
-          }}
+          css={css`
+            min-height: 0;
+          `}
         >
-          <Tabs defaultValue={String(tabs[0]?.id ?? '')} css={{ minHeight: 0 }}>
+          <Tabs
+            defaultValue={String(tabs[0]?.id ?? '')}
+            css={css`
+              min-height: 0;
+            `}
+          >
             <Tabs.List
               css={css`
                 --tabs-gap: 12px;
@@ -210,7 +215,13 @@ export const CoHostSelectModal = ({
         </Flex>
 
         <StickyFooter>
-          <Text type="Label" color={theme.colors.gray500} css={{ marginBottom: 12 }}>
+          <Text
+            type="Label"
+            color={theme.colors.gray500}
+            css={css`
+              margin-bottom: 12px;
+            `}
+          >
             공동 주최자는 이벤트 편집 권한을 공유합니다.
           </Text>
 


### PR DESCRIPTION
## 관련 이슈

close #791 

## ✨ 작업 내용

- 구성원 리스트가 많아지는 경우, 리스트가 모달 영역 밖으로 벗어나는 문제가 있었고 스크롤이 정상 동작하지 않았습니다.
- 문제 상황 요약
  - 기본 flex 컨테이너에서 자식의 `min-height` 기본값이 auto라서, 자식이 콘텐츠 높이만큼 커지려는 성질이 있음
  -> 스크롤 시키고 싶은 손자 요소에 이르는 조상 flex 컨테이너에 `min-height:0`을 적용해줌 (`min-height:0`은 flex의 기본 오버플로우 확장 성질을 꺾어 자식이 남은 높이를 정확히 받도록 보장함)

## 🙏 기타 참고 사항

문제 상황 스크린샷
<img width="340" height="660" alt="image" src="https://github.com/user-attachments/assets/cc24fd2d-335f-49cb-9630-b66f6525c1bf" />


해결 후

https://github.com/user-attachments/assets/0bb81698-6995-4a08-9116-5c7d91197a26



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 탭 기반 공동 진행자 선택 화면의 UI 레이아웃을 재구성하여 가독성과 일관성을 향상.
* 버그 수정
  * 탭 전환 시 레이아웃 흔들림을 줄여 안정성을 개선.
* 스타일
  * 최소 높이 적용으로 콘텐츠 높이 변화에 따른 화면 점프 현상 완화.
  * 작은 화면에서의 반응형 동작을 보강하여 스크롤/배치 품질 개선.
* 리팩터
  * 탭 콘텐츠 구조를 단순화하고 구성 요소를 분리해 유지보수성을 향상(기존 선택 및 전체 선택 동작은 동일).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->