### PR TITLE
[BE] DB 다중화를 위한 애플리케이션 설정

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventGuestService.java
+++ b/server/src/main/java/com/ahmadda/application/EventGuestService.java
@@ -33,6 +33,7 @@ public class EventGuestService {
     private final QuestionRepository questionRepository;
     private final OrganizationMemberRepository organizationMemberRepository;
 
+    @Transactional(readOnly = true)
     public List<Guest> getGuests(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
         Organization organization = event.getOrganization();
@@ -41,6 +42,7 @@ public class EventGuestService {
         return event.getGuests();
     }
 
+    @Transactional(readOnly = true)
     public List<OrganizationMember> getNonGuestOrganizationMembers(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
         Organization organization = event.getOrganization();
@@ -84,6 +86,7 @@ public class EventGuestService {
         guestRepository.deleteByEventAndOrganizationMember(event, organizationMember);
     }
 
+    @Transactional(readOnly = true)
     public boolean isGuest(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
         Organization organization = event.getOrganization();
@@ -92,6 +95,7 @@ public class EventGuestService {
         return event.hasGuest(organizationMember);
     }
 
+    @Transactional(readOnly = true)
     public List<Answer> getAnswers(final Long eventId, final Long guestId, final LoginMember organizerLoginMember) {
         Event event = getEvent(eventId);
         Organization organization = event.getOrganization();

--- a/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationOptOutService.java
@@ -60,6 +60,7 @@ public class EventNotificationOptOutService {
         optOutRepository.delete(optOut);
     }
 
+    @Transactional(readOnly = true)
     public OrganizationMemberWithOptStatus getMemberWithOptStatus(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
         OrganizationMember organizationMember = getOrganizationMember(
@@ -75,6 +76,7 @@ public class EventNotificationOptOutService {
         );
     }
 
+    @Transactional(readOnly = true)
     public List<GuestWithOptStatus> mapGuests(final List<Guest> guests) {
         return guests.stream()
                 .map(guest -> {
@@ -88,6 +90,7 @@ public class EventNotificationOptOutService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public List<OrganizationMemberWithOptStatus> mapOrganizationMembers(
             final Long eventId,
             final List<OrganizationMember> members

--- a/server/src/main/java/com/ahmadda/application/EventNotificationService.java
+++ b/server/src/main/java/com/ahmadda/application/EventNotificationService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +41,7 @@ public class EventNotificationService {
     private final EventNotificationOptOutRepository eventNotificationOptOutRepository;
     private final ReminderHistoryRepository reminderHistoryRepository;
 
+    @Transactional(readOnly = true)
     public void notifySelectedOrganizationMembers(
             final Long eventId,
             final SelectedOrganizationMembersNotificationRequest request,

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -162,6 +162,7 @@ public class EventService {
         return event;
     }
 
+    @Transactional(readOnly = true)
     public boolean isOrganizer(final Long eventId, final LoginMember loginMember) {
         Event event = getEvent(eventId);
         Member member = getMember(loginMember.memberId());
@@ -169,6 +170,7 @@ public class EventService {
         return event.isOrganizer(member);
     }
 
+    @Transactional(readOnly = true)
     public List<Event> getPastEvents(
             final Long organizationId,
             final LoginMember loginMember,
@@ -183,6 +185,7 @@ public class EventService {
         );
     }
 
+    @Transactional(readOnly = true)
     public List<Event> getActiveEvents(final Long organizationId, final LoginMember loginMember) {
         Organization organization = getOrganization(organizationId);
 

--- a/server/src/main/java/com/ahmadda/application/EventStatisticService.java
+++ b/server/src/main/java/com/ahmadda/application/EventStatisticService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +25,7 @@ public class EventStatisticService {
     private final OrganizationMemberRepository organizationMemberRepository;
     private final EventRepository eventRepository;
 
+    @Transactional(readOnly = true)
     public List<EventViewMetric> getEventStatistic(final Long eventId, final LoginMember loginMember) {
         EventStatistic eventStatistic = getEventStatistic(eventId);
         Event event = getEvent(eventId);

--- a/server/src/main/java/com/ahmadda/application/EventTemplateService.java
+++ b/server/src/main/java/com/ahmadda/application/EventTemplateService.java
@@ -38,6 +38,7 @@ public class EventTemplateService {
         return eventTemplate;
     }
 
+    @Transactional(readOnly = true)
     public EventTemplate getTemplate(final LoginMember loginMember, final Long templateId) {
         Member member = getMember(loginMember);
 
@@ -46,6 +47,7 @@ public class EventTemplateService {
         return getTemplate(templateId);
     }
 
+    @Transactional(readOnly = true)
     public List<EventTemplate> getTemplates(final LoginMember loginMember) {
         Member member = getMember(loginMember);
 

--- a/server/src/main/java/com/ahmadda/application/MemberService.java
+++ b/server/src/main/java/com/ahmadda/application/MemberService.java
@@ -6,6 +6,7 @@ import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    @Transactional(readOnly = true)
     public Member getMember(final LoginMember loginMember) {
         return memberRepository.findById(loginMember.memberId())
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));

--- a/server/src/main/java/com/ahmadda/application/OrganizationGroupService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationGroupService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ public class OrganizationGroupService {
 
     private final OrganizationGroupRepository organizationGroupRepository;
 
+    @Transactional(readOnly = true)
     public List<OrganizationGroup> findAll() {
         return organizationGroupRepository.findAll();
     }

--- a/server/src/main/java/com/ahmadda/application/OrganizationInviteCodeService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationInviteCodeService.java
@@ -39,6 +39,7 @@ public class OrganizationInviteCodeService {
         return findOrCreateInviteCode(inviter, organization, now);
     }
 
+    @Transactional(readOnly = true)
     public Organization getOrganizationByCode(final String code) {
         InviteCode inviteCode = inviteCodeRepository.findByCode(code)
                 .orElseThrow(() -> new UnprocessableEntityException("유효하지 않은 초대코드입니다."));

--- a/server/src/main/java/com/ahmadda/application/OrganizationMemberService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationMemberService.java
@@ -27,6 +27,7 @@ public class OrganizationMemberService {
     private final OrganizationRepository organizationRepository;
     private final OrganizationGroupRepository organizationGroupRepository;
 
+    @Transactional(readOnly = true)
     public OrganizationMember getOrganizationMember(final Long organizationId, final LoginMember loginMember) {
         return organizationMemberRepository.findByOrganizationIdAndMemberId(organizationId, loginMember.memberId())
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 구성원입니다."));
@@ -85,11 +86,13 @@ public class OrganizationMemberService {
 
         organizationMember.update(request.nickname(), organizationGroup);
     }
-  
+
+    @Transactional(readOnly = true)
     public boolean isOrganizationMember(final Long organizationId, final LoginMember loginMember) {
         return organizationMemberRepository.existsByOrganizationIdAndMemberId(organizationId, loginMember.memberId());
     }
 
+    @Transactional(readOnly = true)
     public List<OrganizationMember> getAllOrganizationMembers(
             final Long organizationId,
             final LoginMember loginMember

--- a/server/src/main/java/com/ahmadda/application/OrganizationService.java
+++ b/server/src/main/java/com/ahmadda/application/OrganizationService.java
@@ -69,6 +69,7 @@ public class OrganizationService {
         return organization;
     }
 
+    @Transactional(readOnly = true)
     public Organization getOrganizationById(final Long organizationId) {
         return getOrganization(organizationId);
     }
@@ -119,6 +120,7 @@ public class OrganizationService {
         );
     }
 
+    @Transactional(readOnly = true)
     public List<Organization> getParticipatingOrganizations(final LoginMember loginMember) {
         Member member = getMember(loginMember);
 

--- a/server/src/main/java/com/ahmadda/application/ReminderHistoryService.java
+++ b/server/src/main/java/com/ahmadda/application/ReminderHistoryService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class ReminderHistoryService {
     private final OrganizationMemberRepository organizationMemberRepository;
     private final ReminderHistoryRepository reminderHistoryRepository;
 
+    @Transactional(readOnly = true)
     public List<ReminderHistory> getNotifyHistory(
             final Long eventId,
             final LoginMember loginMember

--- a/server/src/main/java/com/ahmadda/infra/database/DataSourceConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/database/DataSourceConfig.java
@@ -1,0 +1,57 @@
+package com.ahmadda.infra.database;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DataSourceConfig {
+
+    @Bean
+    @ConfigurationProperties("spring.datasource.writer")
+    @ConditionalOnProperty(
+            prefix = "spring.datasource.replication",
+            name = "enabled",
+            havingValue = "true"
+    )
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean
+    @ConfigurationProperties("spring.datasource.reader")
+    @ConditionalOnProperty(
+            prefix = "spring.datasource.replication",
+            name = "enabled",
+            havingValue = "true"
+    )
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+            prefix = "spring.datasource.replication",
+            name = "enabled",
+            havingValue = "true"
+    )
+    public DataSource routingDataSource(
+            @Qualifier("writerDataSource") DataSource writer,
+            @Qualifier("readerDataSource") DataSource reader
+    ) {
+        Map<Object, Object> targetDataSources = new HashMap<>();
+        targetDataSources.put("writer", writer);
+        targetDataSources.put("reader", reader);
+
+        ReplicationRoutingDataSource routing = new ReplicationRoutingDataSource();
+        routing.setDefaultTargetDataSource(writer);
+        routing.setTargetDataSources(targetDataSources);
+        return routing;
+    }
+}

--- a/server/src/main/java/com/ahmadda/infra/database/DataSourceConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/database/DataSourceConfig.java
@@ -1,5 +1,6 @@
 package com.ahmadda.infra.database;
 
+import com.zaxxer.hikari.HikariDataSource;
 import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -43,7 +44,9 @@ public class DataSourceConfig {
             havingValue = "true"
     )
     public DataSource writerDataSource() {
-        return DataSourceBuilder.create().build();
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
     }
 
     @Bean
@@ -54,6 +57,8 @@ public class DataSourceConfig {
             havingValue = "true"
     )
     public DataSource readerDataSource() {
-        return DataSourceBuilder.create().build();
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/database/DataSourceConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/database/DataSourceConfig.java
@@ -11,6 +11,7 @@ import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
 @Configuration
 public class DataSourceConfig {
@@ -33,7 +34,9 @@ public class DataSourceConfig {
         ReplicationRoutingDataSource routing = new ReplicationRoutingDataSource();
         routing.setDefaultTargetDataSource(writer);
         routing.setTargetDataSources(targetDataSources);
-        return routing;
+        routing.afterPropertiesSet();
+
+        return new LazyConnectionDataSourceProxy(routing);
     }
 
     @Bean

--- a/server/src/main/java/com/ahmadda/infra/database/ReplicationRoutingDataSource.java
+++ b/server/src/main/java/com/ahmadda/infra/database/ReplicationRoutingDataSource.java
@@ -1,0 +1,15 @@
+package com.ahmadda.infra.database;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return "reader";
+        }
+        return "writer";
+    }
+}

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -2,16 +2,14 @@ spring:
   datasource:
     replication:
       enabled: true
-
     writer:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      url: jdbc:mysql://${db.prod.writer.host}:${db.prod.writer.port}/${db.prod.writer.name}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      jdbc-url: jdbc:mysql://${db.prod.writer.host}:${db.prod.writer.port}/${db.prod.writer.name}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       username: ${db.prod.writer.username}
       password: ${db.prod.writer.password}
-
     reader:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      url: jdbc:mysql://${db.prod.reader.host}:${db.prod.reader.port}/${db.prod.reader.name}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      jdbc-url: jdbc:mysql://${db.prod.reader.host}:${db.prod.reader.port}/${db.prod.reader.name}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       username: ${db.prod.reader.username}
       password: ${db.prod.reader.password}
 

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -1,13 +1,24 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${db.prod.host}:${db.prod.port}/${db.prod.name}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${db.prod.username}
-    password: ${db.prod.password}
+    replication:
+      enabled: true
+
+    writer:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://${db.prod.writer.host}:${db.prod.writer.port}/${db.prod.writer.name}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      username: ${db.prod.writer.username}
+      password: ${db.prod.writer.password}
+
+    reader:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://${db.prod.reader.host}:${db.prod.reader.port}/${db.prod.reader.name}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      username: ${db.prod.reader.username}
+      password: ${db.prod.reader.password}
 
   flyway:
-    baseline-on-migrate: true
-    baseline-version: 1
+    url: jdbc:mysql://${db.prod.writer.host}:${db.prod.writer.port}/${db.prod.name}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    user: ${db.prod.writer.username}
+    password: ${db.prod.writer.password}
 
   jpa:
     hibernate:

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -16,7 +16,7 @@ spring:
       password: ${db.prod.reader.password}
 
   flyway:
-    url: jdbc:mysql://${db.prod.writer.host}:${db.prod.writer.port}/${db.prod.name}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://${db.prod.writer.host}:${db.prod.writer.port}/${db.prod.writer.name}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     user: ${db.prod.writer.username}
     password: ${db.prod.writer.password}
 


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #809

## ✨ 작업 내용

- 서비스 메서드들에 `@Transactional(readOnly = true)` 일괄 적용
- Writer / Reader `DataSource` 분리 설정 추가
- `AbstractRoutingDataSource` 기반 라우팅 구현
- readOnly 트랜잭션 시 Reader로 라우팅되도록 설정
- 라우팅 DataSource를 기본 트랜잭션 매니저에 연결

## 🙏 기타 참고 사항

- 우선은 prod AWS에서 **사용하지 않는 EC2**에 서버 띄워서 먼저 테스트해보면 좋을 것 같아요~~
- 추후 장애 상황에서 Reader fallback 전략도 같이 논의해보면 좋겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 프로덕션에 데이터베이스 읽기/쓰기 분리(리더/라이터) 도입으로 조회 성능과 확장성 향상, 응답성 개선.
* Refactor
  * 다수의 조회 기능을 읽기 전용 트랜잭션으로 전환하여 일관된 읽기 동작과 리소스 경합 감소.
* Chores
  * 프로덕션 환경설정 업데이트(복제 구성 및 마이그레이션 연결 정리).
  * 보안 하위 모듈 커밋 갱신.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->