### PR TITLE
[BE] 리마인더 메일 발송 로직의 트랜잭션 경계 개선

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/notification/EmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/domain/notification/EmailNotifier.java
@@ -1,10 +1,6 @@
 package com.ahmadda.domain.notification;
 
-import com.ahmadda.domain.organization.OrganizationMember;
-
-import java.util.List;
-
 public interface EmailNotifier {
 
-    void sendEmails(final List<OrganizationMember> recipients, final EventEmailPayload eventEmailPayload);
+    void sendEmail(final ReminderEmail reminderEmail);
 }

--- a/server/src/main/java/com/ahmadda/domain/notification/EmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/domain/notification/EmailNotifier.java
@@ -2,5 +2,5 @@ package com.ahmadda.domain.notification;
 
 public interface EmailNotifier {
 
-    void sendEmail(final ReminderEmail reminderEmail);
+    void remind(final ReminderEmail reminderEmail);
 }

--- a/server/src/main/java/com/ahmadda/domain/notification/EventEmailPayload.java
+++ b/server/src/main/java/com/ahmadda/domain/notification/EventEmailPayload.java
@@ -1,10 +1,10 @@
 package com.ahmadda.domain.notification;
 
-import java.time.LocalDateTime;
-import java.util.stream.Collectors;
-
 import com.ahmadda.domain.event.Event;
 import com.ahmadda.domain.event.EventOrganizer;
+
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
 
 public record EventEmailPayload(
         Subject subject,
@@ -61,7 +61,6 @@ public record EventEmailPayload(
             Long organizationId,
             Long eventId
     ) {
-
 
     }
 

--- a/server/src/main/java/com/ahmadda/domain/notification/Reminder.java
+++ b/server/src/main/java/com/ahmadda/domain/notification/Reminder.java
@@ -21,7 +21,7 @@ public class Reminder {
             final String content
     ) {
         ReminderEmail reminderEmail = ReminderEmail.of(recipients, event, content);
-        emailNotifier.sendEmail(reminderEmail);
+        emailNotifier.remind(reminderEmail);
 
         PushNotificationPayload pushPayload = PushNotificationPayload.of(event, content);
         pushNotifier.sendPushs(recipients, pushPayload);

--- a/server/src/main/java/com/ahmadda/domain/notification/Reminder.java
+++ b/server/src/main/java/com/ahmadda/domain/notification/Reminder.java
@@ -20,8 +20,8 @@ public class Reminder {
             final Event event,
             final String content
     ) {
-        EventEmailPayload emailPayload = EventEmailPayload.of(event, content);
-        emailNotifier.sendEmails(recipients, emailPayload);
+        ReminderEmail reminderEmail = ReminderEmail.of(recipients, event, content);
+        emailNotifier.sendEmail(reminderEmail);
 
         PushNotificationPayload pushPayload = PushNotificationPayload.of(event, content);
         pushNotifier.sendPushs(recipients, pushPayload);

--- a/server/src/main/java/com/ahmadda/domain/notification/ReminderEmail.java
+++ b/server/src/main/java/com/ahmadda/domain/notification/ReminderEmail.java
@@ -1,0 +1,33 @@
+package com.ahmadda.domain.notification;
+
+import com.ahmadda.domain.event.Event;
+import com.ahmadda.domain.member.Member;
+import com.ahmadda.domain.organization.OrganizationMember;
+
+import java.util.List;
+
+public record ReminderEmail(
+        List<String> recipientEmails,
+        EventEmailPayload payload
+) {
+
+    public ReminderEmail {
+        recipientEmails = List.copyOf(recipientEmails);
+    }
+
+    public static ReminderEmail of(
+            final List<OrganizationMember> recipients,
+            final Event event,
+            final String content
+    ) {
+        EventEmailPayload payload = EventEmailPayload.of(event, content);
+
+        List<String> emails = recipients.stream()
+                .map(OrganizationMember::getMember)
+                .map(Member::getEmail)
+                .toList();
+
+        return new ReminderEmail(emails, payload);
+    }
+
+}

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifier.java
@@ -2,7 +2,7 @@ package com.ahmadda.infra.notification.mail;
 
 import com.ahmadda.domain.notification.EmailNotifier;
 import com.ahmadda.domain.notification.EventEmailPayload;
-import com.ahmadda.domain.organization.OrganizationMember;
+import com.ahmadda.domain.notification.ReminderEmail;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -14,12 +14,15 @@ public class BccChunkingEmailNotifier implements EmailNotifier {
     private final int maxBcc;
 
     @Override
-    public void sendEmails(final List<OrganizationMember> recipients, final EventEmailPayload payload) {
-        for (int i = 0; i < recipients.size(); i += maxBcc) {
-            int end = Math.min(i + maxBcc, recipients.size());
-            List<OrganizationMember> chunk = recipients.subList(i, end);
+    public void sendEmail(final ReminderEmail reminderEmail) {
+        List<String> recipientEmails = reminderEmail.recipientEmails();
+        EventEmailPayload payload = reminderEmail.payload();
 
-            delegate.sendEmails(chunk, payload);
+        for (int i = 0; i < recipientEmails.size(); i += maxBcc) {
+            int end = Math.min(i + maxBcc, recipientEmails.size());
+            List<String> chunk = recipientEmails.subList(i, end);
+
+            delegate.sendEmail(new ReminderEmail(chunk, payload));
         }
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifier.java
@@ -14,7 +14,7 @@ public class BccChunkingEmailNotifier implements EmailNotifier {
     private final int maxBcc;
 
     @Override
-    public void sendEmail(final ReminderEmail reminderEmail) {
+    public void remind(final ReminderEmail reminderEmail) {
         List<String> recipientEmails = reminderEmail.recipientEmails();
         EventEmailPayload payload = reminderEmail.payload();
 
@@ -22,7 +22,7 @@ public class BccChunkingEmailNotifier implements EmailNotifier {
             int end = Math.min(i + maxBcc, recipientEmails.size());
             List<String> chunk = recipientEmails.subList(i, end);
 
-            delegate.sendEmail(new ReminderEmail(chunk, payload));
+            delegate.remind(new ReminderEmail(chunk, payload));
         }
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/FailoverEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/FailoverEmailNotifier.java
@@ -1,16 +1,11 @@
 package com.ahmadda.infra.notification.mail;
 
 import com.ahmadda.domain.notification.EmailNotifier;
-import com.ahmadda.domain.notification.EventEmailPayload;
-import com.ahmadda.domain.organization.OrganizationMember;
+import com.ahmadda.domain.notification.ReminderEmail;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -18,35 +13,21 @@ public class FailoverEmailNotifier implements EmailNotifier {
 
     private final EmailNotifier primaryNotifier;
     private final EmailNotifier secondaryNotifier;
-    private final EntityManager em;
 
     @Override
     @Async
-    @Transactional(readOnly = true)
     @CircuitBreaker(name = "primaryEmail", fallbackMethod = "sendEmailsWithSecondary")
-    public void sendEmails(
-            final List<OrganizationMember> recipients,
-            final EventEmailPayload payload
-    ) {
-        List<OrganizationMember> mergedRecipients = recipients.stream()
-                .map(em::merge)
-                .toList();
-
-        primaryNotifier.sendEmails(mergedRecipients, payload);
+    public void sendEmail(final ReminderEmail reminderEmail) {
+        primaryNotifier.sendEmail(reminderEmail);
     }
 
-    public void sendEmailsWithSecondary(
-            final List<OrganizationMember> recipients,
-            final EventEmailPayload payload,
-            final Throwable cause
-    ) {
+    public void sendEmailsWithSecondary(final ReminderEmail reminderEmail, final Throwable cause) {
         log.warn(
-                "failoverEmailNotifierFallback - recipients: {},  subject: {}, cause: {}",
-                recipients.size(),
-                payload.subject(),
+                "failoverEmailNotifierFallback - reminderEmail: {}, cause: {}",
+                reminderEmail,
                 cause.getMessage(),
                 cause
         );
-        secondaryNotifier.sendEmails(recipients, payload);
+        secondaryNotifier.sendEmail(reminderEmail);
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/FailoverEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/FailoverEmailNotifier.java
@@ -17,8 +17,8 @@ public class FailoverEmailNotifier implements EmailNotifier {
     @Override
     @Async
     @CircuitBreaker(name = "primaryEmail", fallbackMethod = "sendEmailsWithSecondary")
-    public void sendEmail(final ReminderEmail reminderEmail) {
-        primaryNotifier.sendEmail(reminderEmail);
+    public void remind(final ReminderEmail reminderEmail) {
+        primaryNotifier.remind(reminderEmail);
     }
 
     public void sendEmailsWithSecondary(final ReminderEmail reminderEmail, final Throwable cause) {
@@ -28,6 +28,6 @@ public class FailoverEmailNotifier implements EmailNotifier {
                 cause.getMessage(),
                 cause
         );
-        secondaryNotifier.sendEmail(reminderEmail);
+        secondaryNotifier.remind(reminderEmail);
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/NoopEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/NoopEmailNotifier.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NoopEmailNotifier implements EmailNotifier {
 
     @Override
-    public void sendEmail(final ReminderEmail reminderEmail) {
+    public void remind(final ReminderEmail reminderEmail) {
         log.info("[Noop Email] reminderEmail: {}", reminderEmail);
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/NoopEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/NoopEmailNotifier.java
@@ -1,25 +1,14 @@
 package com.ahmadda.infra.notification.mail;
 
 import com.ahmadda.domain.notification.EmailNotifier;
-import com.ahmadda.domain.notification.EventEmailPayload;
-import com.ahmadda.domain.organization.OrganizationMember;
+import com.ahmadda.domain.notification.ReminderEmail;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
 
 @Slf4j
 public class NoopEmailNotifier implements EmailNotifier {
 
     @Override
-    public void sendEmails(
-            final List<OrganizationMember> recipients,
-            final EventEmailPayload eventEmailPayload
-    ) {
-        log.info(
-                "[Noop Email] To: {} | Subject: {} | Body: {}",
-                recipients,
-                eventEmailPayload.subject(),
-                eventEmailPayload.body()
-        );
+    public void sendEmail(final ReminderEmail reminderEmail) {
+        log.info("[Noop Email] reminderEmail: {}", reminderEmail);
     }
 }

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/RetryableEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/RetryableEmailNotifier.java
@@ -1,8 +1,7 @@
 package com.ahmadda.infra.notification.mail;
 
 import com.ahmadda.domain.notification.EmailNotifier;
-import com.ahmadda.domain.notification.EventEmailPayload;
-import com.ahmadda.domain.organization.OrganizationMember;
+import com.ahmadda.domain.notification.ReminderEmail;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
@@ -10,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.net.SocketTimeoutException;
 import java.time.Duration;
-import java.util.List;
 
 @Slf4j
 public class RetryableEmailNotifier implements EmailNotifier {
@@ -38,20 +36,19 @@ public class RetryableEmailNotifier implements EmailNotifier {
     }
 
     @Override
-    public void sendEmails(final List<OrganizationMember> recipients, final EventEmailPayload payload) {
+    public void sendEmail(final ReminderEmail reminderEmail) {
         Runnable runnable = Retry.decorateRunnable(
                 retry,
-                () -> delegate.sendEmails(recipients, payload)
+                () -> delegate.sendEmail(reminderEmail)
         );
 
         try {
             runnable.run();
         } catch (Exception ex) {
             log.error(
-                    "mailRetryError - name: {}, recipients: {}, subject: {}, cause: {}",
+                    "mailRetryError - name: {}, reminderEmail: {}, cause: {}",
                     retry.getName(),
-                    recipients.size(),
-                    payload.subject(),
+                    reminderEmail,
                     ex.getMessage(),
                     ex
             );

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/RetryableEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/RetryableEmailNotifier.java
@@ -36,10 +36,10 @@ public class RetryableEmailNotifier implements EmailNotifier {
     }
 
     @Override
-    public void sendEmail(final ReminderEmail reminderEmail) {
+    public void remind(final ReminderEmail reminderEmail) {
         Runnable runnable = Retry.decorateRunnable(
                 retry,
-                () -> delegate.sendEmail(reminderEmail)
+                () -> delegate.remind(reminderEmail)
         );
 
         try {

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
@@ -2,7 +2,7 @@ package com.ahmadda.infra.notification.mail;
 
 import com.ahmadda.domain.notification.EmailNotifier;
 import com.ahmadda.domain.notification.EventEmailPayload;
-import com.ahmadda.domain.organization.OrganizationMember;
+import com.ahmadda.domain.notification.ReminderEmail;
 import com.ahmadda.infra.notification.config.NotificationProperties;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -26,8 +26,10 @@ public class SmtpEmailNotifier implements EmailNotifier {
     private final NotificationProperties notificationProperties;
 
     @Override
-    public void sendEmails(final List<OrganizationMember> recipients, final EventEmailPayload eventEmailPayload) {
-        List<String> recipientEmails = getRecipientEmails(recipients);
+    public void sendEmail(final ReminderEmail reminderEmail) {
+        List<String> recipientEmails = reminderEmail.recipientEmails();
+        EventEmailPayload eventEmailPayload = reminderEmail.payload();
+
         if (recipientEmails.isEmpty()) {
             return;
         }
@@ -37,13 +39,6 @@ public class SmtpEmailNotifier implements EmailNotifier {
 
         MimeMessage mimeMessage = createMimeMessageWithBcc(recipientEmails, subject, text);
         javaMailSender.send(mimeMessage);
-    }
-
-    private List<String> getRecipientEmails(List<OrganizationMember> recipients) {
-        return recipients.stream()
-                .map(organizationMember -> organizationMember.getMember()
-                        .getEmail())
-                .toList();
     }
 
     private String createSubject(final EventEmailPayload.Subject subject) {

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/SmtpEmailNotifier.java
@@ -26,7 +26,7 @@ public class SmtpEmailNotifier implements EmailNotifier {
     private final NotificationProperties notificationProperties;
 
     @Override
-    public void sendEmail(final ReminderEmail reminderEmail) {
+    public void remind(final ReminderEmail reminderEmail) {
         List<String> recipientEmails = reminderEmail.recipientEmails();
         EventEmailPayload eventEmailPayload = reminderEmail.payload();
 

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/config/MailConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/config/MailConfig.java
@@ -10,8 +10,6 @@ import com.ahmadda.infra.notification.mail.RetryableEmailNotifier;
 import com.ahmadda.infra.notification.mail.SmtpEmailNotifier;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.retry.RetryRegistry;
-import jakarta.persistence.EntityManager;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -30,8 +28,7 @@ public class MailConfig {
             final SmtpProperties smtpProperties,
             final TemplateEngine templateEngine,
             final NotificationProperties notificationProperties,
-            final RetryRegistry retryRegistry,
-            final EntityManager em
+            final RetryRegistry retryRegistry
     ) {
         EmailNotifier googleEmailNotifier = createEmailNotifier(
                 smtpProperties.getGoogle(),
@@ -53,7 +50,7 @@ public class MailConfig {
                 3
         );
 
-        return new FailoverEmailNotifier(googleEmailNotifier, awsEmailNotifier, em);
+        return new FailoverEmailNotifier(googleEmailNotifier, awsEmailNotifier);
     }
 
     @Bean

--- a/server/src/test/java/com/ahmadda/domain/notification/ReminderTest.java
+++ b/server/src/test/java/com/ahmadda/domain/notification/ReminderTest.java
@@ -23,8 +23,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 @IntegrationTest
@@ -66,14 +65,9 @@ class ReminderTest {
         var organization = organizationRepository.save(Organization.create("우테코", "설명", "img.png"));
         var organizerMember = memberRepository.save(Member.create("주최자", "host@example.com", "pic"));
         var group = createOrganizationGroup();
-        var organizer =
-                organizationMemberRepository.save(OrganizationMember.create(
-                        "host",
-                        organizerMember,
-                        organization,
-                        OrganizationMemberRole.USER,
-                        group
-                ));
+        var organizer = organizationMemberRepository.save(
+                OrganizationMember.create("host", organizerMember, organization, OrganizationMemberRole.USER, group)
+        );
 
         var now = LocalDateTime.now();
         var event = eventRepository.save(Event.create(
@@ -109,16 +103,10 @@ class ReminderTest {
         sut.remind(recipients, event, content);
 
         // then
-        verify(emailNotifier).sendEmails(
-                eq(recipients),
-                argThat(payload -> payload != null && payload.body()
-                        .eventId()
-                        .equals(event.getId()))
-        );
+        verify(emailNotifier).sendEmail(any(ReminderEmail.class));
         verify(pushNotifier).sendPushs(
-                eq(recipients),
-                argThat(payload -> payload != null && payload.eventId()
-                        .equals(event.getId()))
+                any(List.class),
+                any(PushNotificationPayload.class)
         );
     }
 
@@ -127,14 +115,15 @@ class ReminderTest {
         // given
         var organization = organizationRepository.save(Organization.create("우테코", "설명", "img.png"));
         var organizerMember = memberRepository.save(Member.create("주최자", "host@example.com", "pic"));
-        var organizer =
-                organizationMemberRepository.save(OrganizationMember.create(
+        var organizer = organizationMemberRepository.save(
+                OrganizationMember.create(
                         "host",
                         organizerMember,
                         organization,
                         OrganizationMemberRole.USER,
                         createOrganizationGroup()
-                ));
+                )
+        );
 
         var now = LocalDateTime.now();
         var event = eventRepository.save(Event.create(

--- a/server/src/test/java/com/ahmadda/domain/notification/ReminderTest.java
+++ b/server/src/test/java/com/ahmadda/domain/notification/ReminderTest.java
@@ -103,7 +103,7 @@ class ReminderTest {
         sut.remind(recipients, event, content);
 
         // then
-        verify(emailNotifier).sendEmail(any(ReminderEmail.class));
+        verify(emailNotifier).remind(any(ReminderEmail.class));
         verify(pushNotifier).sendPushs(
                 any(List.class),
                 any(PushNotificationPayload.class)

--- a/server/src/test/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifierTest.java
@@ -54,10 +54,10 @@ class BccChunkingEmailNotifierTest {
         var reminderEmail = new ReminderEmail(recipients, payload);
 
         // when
-        sut.sendEmail(reminderEmail);
+        sut.remind(reminderEmail);
 
         // then
-        verify(delegate, times(1)).sendEmail(reminderEmail);
+        verify(delegate, times(1)).remind(reminderEmail);
     }
 
     @Test
@@ -67,10 +67,10 @@ class BccChunkingEmailNotifierTest {
         var reminderEmail = new ReminderEmail(recipients, payload);
 
         // when
-        sut.sendEmail(reminderEmail);
+        sut.remind(reminderEmail);
 
         // then
-        verify(delegate, times(3)).sendEmail(any(ReminderEmail.class));
+        verify(delegate, times(3)).remind(any(ReminderEmail.class));
     }
 
     private List<String> createRecipientEmails(int count) {

--- a/server/src/test/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/infra/notification/mail/BccChunkingEmailNotifierTest.java
@@ -1,12 +1,8 @@
 package com.ahmadda.infra.notification.mail;
 
-import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.notification.EmailNotifier;
 import com.ahmadda.domain.notification.EventEmailPayload;
-import com.ahmadda.domain.organization.Organization;
-import com.ahmadda.domain.organization.OrganizationGroup;
-import com.ahmadda.domain.organization.OrganizationMember;
-import com.ahmadda.domain.organization.OrganizationMemberRole;
+import com.ahmadda.domain.notification.ReminderEmail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,8 +10,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.Mockito.anyList;
-import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,7 +18,6 @@ import static org.mockito.Mockito.verify;
 class BccChunkingEmailNotifierTest {
 
     private BccChunkingEmailNotifier sut;
-
     private EmailNotifier delegate;
     private EventEmailPayload payload;
 
@@ -54,38 +48,36 @@ class BccChunkingEmailNotifierTest {
     }
 
     @Test
-    void 수신자가_여러명일때_수신자가_제한_이하면_한_번만_호출된다() {
+    void 수신자가_여러명일때_제한_이하면_한번만_호출된다() {
         // given
-        var recipients = createRecipients(30);
+        var recipients = createRecipientEmails(30);
+        var reminderEmail = new ReminderEmail(recipients, payload);
 
         // when
-        sut.sendEmails(recipients, payload);
+        sut.sendEmail(reminderEmail);
 
         // then
-        verify(delegate, times(1)).sendEmails(recipients, payload);
+        verify(delegate, times(1)).sendEmail(reminderEmail);
     }
 
     @Test
-    void 수신자가_여러명일때_수신자가_제한을_초과하면_분할되어_여러_번_호출된다() {
+    void 수신자가_여러명일때_제한을_초과하면_분할되어_여러번_호출된다() {
         // given
-        var recipients = createRecipients(120);
+        var recipients = createRecipientEmails(120);
+        var reminderEmail = new ReminderEmail(recipients, payload);
 
         // when
-        sut.sendEmails(recipients, payload);
+        sut.sendEmail(reminderEmail);
 
         // then
-        verify(delegate, times(3)).sendEmails(anyList(), eq(payload));
+        verify(delegate, times(3)).sendEmail(any(ReminderEmail.class));
     }
 
-    private List<OrganizationMember> createRecipients(int count) {
-        OrganizationGroup group = OrganizationGroup.create("기타");
-        var org = Organization.create("이벤트 스페이스", "설명", "logo.png");
-        List<OrganizationMember> members = new ArrayList<>();
+    private List<String> createRecipientEmails(int count) {
+        var emails = new ArrayList<String>();
         for (int i = 0; i < count; i++) {
-            var member = Member.create("닉네임" + i, "user" + i + "@example.com", "pic.png");
-            members.add(OrganizationMember.create("닉네임" + i, member, org, OrganizationMemberRole.USER, group));
+            emails.add("user" + i + "@example.com");
         }
-
-        return members;
+        return emails;
     }
 }

--- a/server/src/test/java/com/ahmadda/infra/notification/mail/RetryableEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/infra/notification/mail/RetryableEmailNotifierTest.java
@@ -64,10 +64,10 @@ class RetryableEmailNotifierTest {
     @Test
     void 첫번째_시도에_성공하면_재시도하지_않는다() {
         // when
-        sut.sendEmail(reminderEmail);
+        sut.remind(reminderEmail);
 
         // then
-        verify(delegate, times(1)).sendEmail(reminderEmail);
+        verify(delegate, times(1)).remind(reminderEmail);
     }
 
     @Test
@@ -79,13 +79,13 @@ class RetryableEmailNotifierTest {
         doThrow(ex)
                 .doNothing()
                 .when(delegate)
-                .sendEmail(reminderEmail);
+                .remind(reminderEmail);
 
         // when
-        sut.sendEmail(reminderEmail);
+        sut.remind(reminderEmail);
 
         // then
-        verify(delegate, times(2)).sendEmail(reminderEmail);
+        verify(delegate, times(2)).remind(reminderEmail);
     }
 
     @Test
@@ -96,12 +96,12 @@ class RetryableEmailNotifierTest {
 
         doThrow(ex)
                 .when(delegate)
-                .sendEmail(reminderEmail);
+                .remind(reminderEmail);
 
         // when & then
-        assertThatThrownBy(() -> sut.sendEmail(reminderEmail))
+        assertThatThrownBy(() -> sut.remind(reminderEmail))
                 .isInstanceOf(MailSendException.class);
 
-        verify(delegate, times(3)).sendEmail(reminderEmail);
+        verify(delegate, times(3)).remind(reminderEmail);
     }
 }

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/FailoverEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/FailoverEmailNotifierTest.java
@@ -48,12 +48,12 @@ class FailoverEmailNotifierTest {
         var payload = createPayload("테스트 이벤트 스페이스", "테스트 이벤트", "주최자닉네임");
         var reminderEmail = new ReminderEmail(List.of("test@example.com"), payload);
 
-        sut.sendEmail(reminderEmail);
+        sut.remind(reminderEmail);
 
         await().atMost(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> verify(primaryNotifier, times(1)).sendEmail(any(ReminderEmail.class)));
+                .untilAsserted(() -> verify(primaryNotifier, times(1)).remind(any(ReminderEmail.class)));
         await().atMost(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> verify(secondaryNotifier, times(0)).sendEmail(any(ReminderEmail.class)));
+                .untilAsserted(() -> verify(secondaryNotifier, times(0)).remind(any(ReminderEmail.class)));
     }
 
     @Test
@@ -63,14 +63,14 @@ class FailoverEmailNotifierTest {
 
         doThrow(new MailSendException("primary 실패"))
                 .when(primaryNotifier)
-                .sendEmail(any(ReminderEmail.class));
+                .remind(any(ReminderEmail.class));
 
-        sut.sendEmail(reminderEmail);
+        sut.remind(reminderEmail);
 
         await().atMost(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> verify(primaryNotifier, times(1)).sendEmail(any(ReminderEmail.class)));
+                .untilAsserted(() -> verify(primaryNotifier, times(1)).remind(any(ReminderEmail.class)));
         await().atMost(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> verify(secondaryNotifier, times(1)).sendEmail(any(ReminderEmail.class)));
+                .untilAsserted(() -> verify(secondaryNotifier, times(1)).remind(any(ReminderEmail.class)));
     }
 
     @Test
@@ -80,23 +80,23 @@ class FailoverEmailNotifierTest {
 
         doThrow(new MailSendException("primary 실패"))
                 .when(primaryNotifier)
-                .sendEmail(any(ReminderEmail.class));
+                .remind(any(ReminderEmail.class));
 
         // 3번 실패 → CircuitBreaker OPEN
         for (int i = 0; i < 3; i++) {
             try {
-                sut.sendEmail(reminderEmail);
+                sut.remind(reminderEmail);
                 Thread.sleep(7000);
             } catch (Exception ignored) {
             }
         }
 
-        sut.sendEmail(reminderEmail);
+        sut.remind(reminderEmail);
 
         await().atMost(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> verify(primaryNotifier, times(3)).sendEmail(any(ReminderEmail.class)));
+                .untilAsserted(() -> verify(primaryNotifier, times(3)).remind(any(ReminderEmail.class)));
         await().atMost(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> verify(secondaryNotifier, times(4)).sendEmail(any(ReminderEmail.class)));
+                .untilAsserted(() -> verify(secondaryNotifier, times(4)).remind(any(ReminderEmail.class)));
     }
 
     private EventEmailPayload createPayload(

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/SmtpEmailNotifierTest.java
@@ -98,7 +98,7 @@ class SmtpEmailNotifierTest {
         );
 
         // when // then
-        sut.sendEmail(reminderEmail);
+        sut.remind(reminderEmail);
     }
 
     // Gmail: BCC 최대 100명
@@ -139,6 +139,6 @@ class SmtpEmailNotifierTest {
         var reminderEmail = new ReminderEmail(recipients, payload);
 
         // when // then
-        sut.sendEmail(reminderEmail);
+        sut.remind(reminderEmail);
     }
 }


### PR DESCRIPTION


## 관련 이슈
close #816

## ✨ 작업 내용
- 메일 발송 로직에서 불필요하게 트랜잭션을 유지하는 부분 확인  
- 트랜잭션 경계를 도메인 저장/변경 시점으로 한정하도록 수정  
- 발송 로직은 트랜잭션 외부 비동기 처리로 분리  
- `@Transactional(readOnly = true)` 검토 및 적용  

## 🙏 기타 참고 사항
- 기존 구조에서는 메일 발송 과정이 DB 트랜잭션 안에서 실행되어 커넥션을 장시간(최대 10초 이상) 점유할 위험이 있었습니다.  
- 이번 변경으로 메일 발송 로직**은 `ReminderEmail` 를 생성하여 **트랜잭션 외부 비동기 처리**로 분리하였습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 이메일 알림 전송을 “단일 전송 단위” 기반으로 단순화하여 수신자와 콘텐츠를 함께 처리합니다.
  - 청크 전송, 재시도, 페일오버 흐름을 새 전송 모델에 맞춰 정리했습니다.
  - 인프라 구성에서 불필요한 영속성 의존성을 제거해 결합도를 낮췄습니다.
- Tests
  - 변경된 전송 모델에 맞춰 단위/통합 테스트를 전면 갱신하고, 회로차단·페일오버 시나리오 검증을 강화했습니다.
- Chores
  - 불필요한 임포트와 설정을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->