### PR TITLE
[BE] 리마인더/포키 푸시 발송 로직의 트랜잭션 경계 개선

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/notification/Poke.java
+++ b/server/src/main/java/com/ahmadda/domain/notification/Poke.java
@@ -103,13 +103,7 @@ public class Poke {
     ) {
         String sendMessage = pokeMessage.getMessage(sendOrganizationMember.getNickname());
 
-        pushNotifier.sendPush(
-                receiveOrganizationMember,
-                PushNotificationPayload.of(
-                        event,
-                        sendMessage
-                )
-        );
+        pushNotifier.poke(receiveOrganizationMember, PushNotificationPayload.of(event, sendMessage));
     }
 
     private void validateReceiveOrganizationMember(

--- a/server/src/main/java/com/ahmadda/domain/notification/PushNotifier.java
+++ b/server/src/main/java/com/ahmadda/domain/notification/PushNotifier.java
@@ -6,10 +6,7 @@ import java.util.List;
 
 public interface PushNotifier {
 
-    void sendPushs(final List<OrganizationMember> recipients, final PushNotificationPayload pushNotificationPayload);
+    void remind(final List<OrganizationMember> recipients, final PushNotificationPayload pushNotificationPayload);
 
-    void sendPush(
-            final OrganizationMember recipient,
-            final PushNotificationPayload pushNotificationPayload
-    );
+    void poke(final OrganizationMember recipient, final PushNotificationPayload pushNotificationPayload);
 }

--- a/server/src/main/java/com/ahmadda/domain/notification/Reminder.java
+++ b/server/src/main/java/com/ahmadda/domain/notification/Reminder.java
@@ -24,7 +24,7 @@ public class Reminder {
         emailNotifier.sendEmails(recipients, emailPayload);
 
         PushNotificationPayload pushPayload = PushNotificationPayload.of(event, content);
-        pushNotifier.sendPushs(recipients, pushPayload);
+        pushNotifier.remind(recipients, pushPayload);
 
         return ReminderHistory.createNow(event, content, recipients);
     }

--- a/server/src/main/java/com/ahmadda/infra/notification/push/FcmPushErrorHandler.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/FcmPushErrorHandler.java
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.SendResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +28,7 @@ public class FcmPushErrorHandler {
 
     private final FcmRegistrationTokenRepository fcmRegistrationTokenRepository;
 
+    @Transactional
     public void handleFailures(final BatchResponse response, final List<String> registrationTokens) {
         List<SendResponse> responses = response.getResponses();
         List<String> deletableTokens = new ArrayList<>();

--- a/server/src/main/java/com/ahmadda/infra/notification/push/FcmPushNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/FcmPushNotifier.java
@@ -13,7 +13,6 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -27,7 +26,6 @@ public class FcmPushNotifier implements PushNotifier {
     private final EntityManager em;
 
     @Async
-    @Transactional
     @Override
     public void sendPushs(
             final List<OrganizationMember> recipients,
@@ -36,21 +34,15 @@ public class FcmPushNotifier implements PushNotifier {
         if (recipients.isEmpty()) {
             return;
         }
-        List<OrganizationMember> mergedRecipients = recipients.stream()
-                .map(em::merge)
-                .toList();
 
-        List<String> registrationTokens = getRegistrationTokens(mergedRecipients);
+        List<String> registrationTokens = getRegistrationTokens(recipients);
         sendMulticast(pushNotificationPayload, registrationTokens);
     }
 
     @Async
-    @Transactional
     @Override
     public void sendPush(final OrganizationMember recipient, final PushNotificationPayload pushNotificationPayload) {
-        OrganizationMember mergedRecipient = em.merge(recipient);
-
-        List<String> registrationTokens = getRegistrationTokens(mergedRecipient);
+        List<String> registrationTokens = getRegistrationTokens(recipient);
         sendMulticast(pushNotificationPayload, registrationTokens);
     }
 

--- a/server/src/main/java/com/ahmadda/infra/notification/push/FcmPushNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/FcmPushNotifier.java
@@ -27,7 +27,7 @@ public class FcmPushNotifier implements PushNotifier {
 
     @Async
     @Override
-    public void sendPushs(
+    public void remind(
             final List<OrganizationMember> recipients,
             final PushNotificationPayload pushNotificationPayload
     ) {
@@ -41,7 +41,7 @@ public class FcmPushNotifier implements PushNotifier {
 
     @Async
     @Override
-    public void sendPush(final OrganizationMember recipient, final PushNotificationPayload pushNotificationPayload) {
+    public void poke(final OrganizationMember recipient, final PushNotificationPayload pushNotificationPayload) {
         List<String> registrationTokens = getRegistrationTokens(recipient);
         sendMulticast(pushNotificationPayload, registrationTokens);
     }

--- a/server/src/main/java/com/ahmadda/infra/notification/push/FcmPushNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/FcmPushNotifier.java
@@ -9,7 +9,6 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -23,7 +22,6 @@ public class FcmPushNotifier implements PushNotifier {
     private final FcmRegistrationTokenRepository fcmRegistrationTokenRepository;
     private final FcmPushErrorHandler fcmPushErrorHandler;
     private final NotificationProperties notificationProperties;
-    private final EntityManager em;
 
     @Async
     @Override

--- a/server/src/main/java/com/ahmadda/infra/notification/push/NoopPushNotifier.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/NoopPushNotifier.java
@@ -1,8 +1,8 @@
 package com.ahmadda.infra.notification.push;
 
-import com.ahmadda.domain.organization.OrganizationMember;
 import com.ahmadda.domain.notification.PushNotificationPayload;
 import com.ahmadda.domain.notification.PushNotifier;
+import com.ahmadda.domain.organization.OrganizationMember;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -11,7 +11,7 @@ import java.util.List;
 public class NoopPushNotifier implements PushNotifier {
 
     @Override
-    public void sendPushs(
+    public void remind(
             final List<OrganizationMember> recipients,
             final PushNotificationPayload pushNotificationPayload
     ) {
@@ -19,7 +19,7 @@ public class NoopPushNotifier implements PushNotifier {
     }
 
     @Override
-    public void sendPush(final OrganizationMember recipient, final PushNotificationPayload pushNotificationPayload) {
+    public void poke(final OrganizationMember recipient, final PushNotificationPayload pushNotificationPayload) {
         pushLogging(recipient, pushNotificationPayload);
     }
 

--- a/server/src/main/java/com/ahmadda/infra/notification/push/config/PushConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/config/PushConfig.java
@@ -6,7 +6,6 @@ import com.ahmadda.infra.notification.push.FcmPushErrorHandler;
 import com.ahmadda.infra.notification.push.FcmPushNotifier;
 import com.ahmadda.infra.notification.push.FcmRegistrationTokenRepository;
 import com.ahmadda.infra.notification.push.NoopPushNotifier;
-import jakarta.persistence.EntityManager;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -21,14 +20,12 @@ public class PushConfig {
     public PushNotifier fcmPushNotifier(
             final FcmRegistrationTokenRepository fcmRegistrationTokenRepository,
             final FcmPushErrorHandler fcmPushErrorHandler,
-            final NotificationProperties notificationProperties,
-            final EntityManager em
+            final NotificationProperties notificationProperties
     ) {
         return new FcmPushNotifier(
                 fcmRegistrationTokenRepository,
                 fcmPushErrorHandler,
-                notificationProperties,
-                em
+                notificationProperties
         );
     }
 

--- a/server/src/main/java/com/ahmadda/infra/notification/push/config/PushConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/push/config/PushConfig.java
@@ -20,15 +20,21 @@ public class PushConfig {
     @Bean
     public PushNotifier fcmPushNotifier(
             final FcmRegistrationTokenRepository fcmRegistrationTokenRepository,
+            final FcmPushErrorHandler fcmPushErrorHandler,
             final NotificationProperties notificationProperties,
             final EntityManager em
     ) {
         return new FcmPushNotifier(
                 fcmRegistrationTokenRepository,
-                new FcmPushErrorHandler(fcmRegistrationTokenRepository),
+                fcmPushErrorHandler,
                 notificationProperties,
                 em
         );
+    }
+
+    @Bean
+    public FcmPushErrorHandler fcmPushErrorHandler(final FcmRegistrationTokenRepository fcmRegistrationTokenRepository) {
+        return new FcmPushErrorHandler(fcmRegistrationTokenRepository);
     }
 
     @Bean

--- a/server/src/test/java/com/ahmadda/domain/notification/PokeTest.java
+++ b/server/src/test/java/com/ahmadda/domain/notification/PokeTest.java
@@ -77,7 +77,7 @@ class PokeTest {
         sut.doPoke(sender, recipient, PokeMessage.ARRIVED, event, sentAt);
 
         // then
-        verify(pushNotifier).sendPush(
+        verify(pushNotifier).poke(
                 eq(recipient),
                 eq(PushNotificationPayload.of(
                         event,

--- a/server/src/test/java/com/ahmadda/domain/notification/ReminderTest.java
+++ b/server/src/test/java/com/ahmadda/domain/notification/ReminderTest.java
@@ -115,7 +115,7 @@ class ReminderTest {
                         .eventId()
                         .equals(event.getId()))
         );
-        verify(pushNotifier).sendPushs(
+        verify(pushNotifier).remind(
                 eq(recipients),
                 argThat(payload -> payload != null && payload.eventId()
                         .equals(event.getId()))

--- a/server/src/test/java/com/ahmadda/domain/notification/ReminderTest.java
+++ b/server/src/test/java/com/ahmadda/domain/notification/ReminderTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 @IntegrationTest
@@ -103,12 +105,7 @@ class ReminderTest {
         sut.remind(recipients, event, content);
 
         // then
-        verify(emailNotifier).sendEmails(
-                eq(recipients),
-                argThat(payload -> payload != null && payload.body()
-                        .eventId()
-                        .equals(event.getId()))
-        );
+        verify(emailNotifier).remind(any(ReminderEmail.class));
         verify(pushNotifier).remind(
                 eq(recipients),
                 argThat(payload -> payload != null && payload.eventId()

--- a/server/src/test/java/com/ahmadda/learning/infra/notification/FcmPushNotifierTest.java
+++ b/server/src/test/java/com/ahmadda/learning/infra/notification/FcmPushNotifierTest.java
@@ -63,7 +63,7 @@ class FcmPushNotifierTest {
         );
 
         // when // then
-        sut.sendPushs(List.of(organizationMember), payload);
+        sut.remind(List.of(organizationMember), payload);
     }
 
     @Test
@@ -97,6 +97,6 @@ class FcmPushNotifierTest {
         );
 
         // when // then
-        sut.sendPush(organizationMember, payload);
+        sut.poke(organizationMember, payload);
     }
 }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #818

## ✨ 작업 내용

- 푸시 발송 로직에서 불필요하게 트랜잭션을 유지하는 부분 확인  
- 트랜잭션 경계를 도메인 저장/변경 시점으로 한정하도록 수정  
- 발송 로직은 트랜잭션 외부 비동기 처리로 분리  
- `@Transactional(readOnly = true)` 검토 및 적용  

## 🙏 기타 참고 사항

- FCM `send()` / `sendEachForMulticast()` API는 **동기 호출**이며, 내부적으로 네트워크 I/O를 포함하기 때문에 평균 수백 ms ~ 수 초의 지연이 발생할 수 있습니다.  
- 현재 구조에서는 DB 트랜잭션이 푸시 발송 지연 시간 동안 열린 상태로 유지되며, 이로 인해 **커넥션 풀 고갈 및 잠금 경합 위험**이 발생할 수 있었습니다.  
- 이메일 발송은 `ReminderEmail` VO로 추상화할 수 있었지만, **푸시는 수신자 토큰 구조가 다양하고 추상화하기가 어렵다**는 이유로 VO로 풀지 않았습니다.  
- 대신 **문제 해결을 위한 최소 변경**으로 `infra` 계층에서 트랜잭션 어노테이션만 제거하여 발송 로직을 트랜잭션 외부로 꺼냈습니다.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 개선
  - 푸시 알림 실패 처리의 트랜잭션 경계를 정비해 안정성과 신뢰성을 향상했습니다.
- 리팩터
  - 알림 전송 도메인의 명명과 책임을 일관되게 정리해 가독성과 유지보수성을 높였습니다.
  - 비동기 알림 전송 경로에서 불필요한 병합/래핑을 제거해 경량화했습니다.
- 작업
  - 알림 에러 처리 컴포넌트를 구성에 분리해 의존성 주입으로 관리하도록 변경했습니다.
- 테스트
  - 변경된 알림 전송 명세에 맞춰 단위 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->