### PR TITLE
[FE] 이벤트 임시저장 버튼 없애고 자동 저장 방식으로 전환

### DIFF
--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -14,7 +14,6 @@ import type { EventTemplateAPIResponse, TemplateDetailAPIResponse } from '@/api/
 import type { OrganizationMember } from '@/api/types/organizations';
 import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
-import { IconButton } from '@/shared/components/IconButton';
 import { Input } from '@/shared/components/Input';
 import { Text } from '@/shared/components/Text';
 import { Textarea } from '@/shared/components/Textarea';
@@ -236,6 +235,31 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
     restoredOnceRef.current = true;
   }, [isEdit, eventDetail, restore, loadFormData, loadQuestions]);
 
+  const lastSavedSnapshotRef = useRef<string>('');
+  const latestGetterRef = useRef<
+    () => { basicEventForm: typeof basicEventForm; questions: typeof questions }
+  >(() => ({ basicEventForm, questions }));
+
+  useEffect(() => {
+    latestGetterRef.current = () => ({ basicEventForm, questions });
+  }, [basicEventForm, questions]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const current = latestGetterRef.current();
+      const snapshot = JSON.stringify(current);
+
+      if (snapshot !== lastSavedSnapshotRef.current) {
+        const ok = save();
+        if (ok) {
+          lastSavedSnapshotRef.current = snapshot;
+        }
+      }
+    }, 5000);
+
+    return () => clearInterval(id);
+  }, [save]);
+
   const submitCreate = (payload: ReturnType<typeof buildPayload>) => {
     addEvent(payload, {
       onSuccess: ({ eventId }) => {
@@ -362,29 +386,6 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
             {isEdit ? '이벤트 수정' : '이벤트 생성하기'}
           </Text>
           <Flex gap="8px">
-            <Button
-              size="sm"
-              onClick={save}
-              css={css`
-                @media (max-width: 480px) {
-                  display: none;
-                }
-              `}
-            >
-              임시저장
-            </Button>
-
-            <IconButton
-              name="save"
-              onClick={save}
-              aria-label="임시저장"
-              css={css`
-                display: none;
-                @media (max-width: 480px) {
-                  display: inline-flex;
-                }
-              `}
-            />
             <Button size="sm" onClick={templateModalOpen}>
               불러오기
             </Button>

--- a/client/src/shared/hooks/useAutoSessionSave.ts
+++ b/client/src/shared/hooks/useAutoSessionSave.ts
@@ -15,6 +15,7 @@ export function useAutoSessionSave<T>({ key, getData }: UseAutoSessionSaveParams
     const ok = safeSessionStorage.set(key, draft);
     if (ok) success('😀 임시 저장에 성공했어요!');
     else error('❌ 임시 저장에 실패했어요!');
+    return ok;
   };
 
   const restore = (): T | null => {

--- a/client/src/shared/hooks/useAutoSessionSave.ts
+++ b/client/src/shared/hooks/useAutoSessionSave.ts
@@ -13,7 +13,7 @@ export function useAutoSessionSave<T>({ key, getData }: UseAutoSessionSaveParams
   const save = () => {
     const draft = getData();
     const ok = safeSessionStorage.set(key, draft);
-    if (ok) success('😀 임시 저장에 성공했어요!');
+    if (ok) success('😀 임시 저장되었어요!');
     else error('❌ 임시 저장에 실패했어요!');
     return ok;
   };


### PR DESCRIPTION
## 관련 이슈

close #814 

## ✨ 작업 내용

- 이벤트 임시저장 버튼을 없애고 자동 저장 방식으로 전환했습니다.
- 변경 사항이 있을 때만 5초마다 자동 저장이 되며, 저장되었음을 알리기 위해 토스트를 띄웠습니다.

## 🙏 기타 참고 사항

https://github.com/user-attachments/assets/f83f994e-74cb-486f-9384-859b88e1f19d