### PR TITLE
[FE] 이벤트 신청 종료일 항상 시작 시간에 동기화

### DIFF
--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -315,9 +315,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
       return;
     }
 
-    const currentRegistrationEndTime =
-      parseInputDate(basicEventForm.registrationEnd) || finalStartTime;
-    const newRegistrationEnd = applyTimeToDate(startDate, currentRegistrationEndTime);
+    const newRegistrationEnd = applyTimeToDate(startDate, finalStartTime);
     const finalRegistrationEnd =
       newRegistrationEnd.getTime() > finalStartTime.getTime() ? finalStartTime : newRegistrationEnd;
 


### PR DESCRIPTION
## 관련 이슈

close #823 

## ✨ 작업 내용

- 이벤트 생성 시 초기 1회 설정에서는 시작 시간과 신청 종료일이 정상 동기화되었으나, 이후 시작 시간을 변경하면 신청 종료일이 동기화되지 않는 문제가 있어 시작 시간 변경 시 신청 종료일도 항상 동일한 시간으로 동기화되도록 수정했습니다.

## 🙏 기타 참고 사항

https://github.com/user-attachments/assets/46bf8d00-ac46-4df3-a21c-0e37c253efab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * 이벤트 생성 폼에서 날짜 범위를 선택할 때, 등록 마감 시간이 이전 값에 영향을 받지 않고 이벤트 시작 날짜를 기준으로 일관되게 자동 계산되도록 수정했습니다.
  * 날짜를 다시 선택하거나 수정하는 경우에도 예기치 않은 마감 시간 유지/반영 문제를 방지해, 등록 마감 시간이 예측 가능하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->