### PR TITLE
[FE] 이벤트 생성 및 수정 시 입력한 시간과 다르게 출력되는 문제 해결

### DIFF
--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -198,9 +198,9 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
       ...basicEventForm,
       eventOrganizerIds: basicEventForm.eventOrganizerIds ?? [],
       questions,
-      eventStart: parseInputDate(basicEventForm.eventStart)?.toISOString() ?? '',
-      eventEnd: parseInputDate(basicEventForm.eventEnd)?.toISOString() ?? '',
-      registrationEnd: parseInputDate(basicEventForm.registrationEnd)?.toISOString() ?? '',
+      eventStart: basicEventForm.eventStart,
+      eventEnd: basicEventForm.eventEnd,
+      registrationEnd: basicEventForm.registrationEnd,
     };
 
     if (!isEdit) {


### PR DESCRIPTION
## 관련 이슈

close #825 

## ✨ 작업 내용

- 입력한 시간보다 9시간 전으로 당겨져 보이던 문제를 해결했습니다.
- `toISOString()` 호출(UTC 변환)을 제거하고, 입력값을 그대로 저장/전달하도록 변경하였습니다.

## 🙏 기타 참고 사항

https://github.com/user-attachments/assets/ae71c6af-8c9a-4ba5-9353-953313397909



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 이벤트 생성 폼에서 입력한 날짜/시간이 변환 없이 그대로 제출되도록 조정했습니다. 이로써 사용자가 입력한 형식이 유지되어 일정 정보의 표시와 검증이 더 일관되게 동작합니다. 일부 시간대 관련 표시 차이가 개선될 수 있습니다.
  * 제출된 이벤트의 시작/종료 및 등록 마감 시간이 화면에서 보던 값과 불일치하던 사례가 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->