### PR TITLE
과거 이벤트 조회 정책 수정

### DIFF
--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -50,6 +50,7 @@ public class EventService {
 
     private static final int REMINDER_LIMIT_DURATION_MINUTES = 30;
     private static final int MAX_REMINDER_COUNT_IN_DURATION = 10;
+    private static final long PAST_EVENT_PAGE_SIZE = 10;
 
     private final MemberRepository memberRepository;
     private final EventRepository eventRepository;
@@ -174,14 +175,17 @@ public class EventService {
     public List<Event> getPastEvents(
             final Long organizationId,
             final LoginMember loginMember,
-            final LocalDateTime compareDateTime
+            final LocalDateTime compareDateTime,
+            final Long lastEventId
     ) {
         Organization organization = getOrganization(organizationId);
         validateOrganizationAccess(organizationId, loginMember.memberId());
 
-        return eventRepository.findAllByOrganizationAndEventOperationPeriodEventPeriodEndBefore(
+        return eventRepository.findPastEventByOrganizationAndWithCursor(
                 organization,
-                compareDateTime
+                compareDateTime,
+                lastEventId,
+                PAST_EVENT_PAGE_SIZE
         );
     }
 

--- a/server/src/main/java/com/ahmadda/application/EventService.java
+++ b/server/src/main/java/com/ahmadda/application/EventService.java
@@ -32,6 +32,7 @@ import com.ahmadda.domain.organization.OrganizationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,7 +51,7 @@ public class EventService {
 
     private static final int REMINDER_LIMIT_DURATION_MINUTES = 30;
     private static final int MAX_REMINDER_COUNT_IN_DURATION = 10;
-    private static final long PAST_EVENT_PAGE_SIZE = 10;
+    private static final int PAST_EVENT_PAGE_SIZE = 10;
 
     private final MemberRepository memberRepository;
     private final EventRepository eventRepository;
@@ -181,11 +182,13 @@ public class EventService {
         Organization organization = getOrganization(organizationId);
         validateOrganizationAccess(organizationId, loginMember.memberId());
 
+        Pageable pageable = Pageable.ofSize(PAST_EVENT_PAGE_SIZE);
+
         return eventRepository.findPastEventByOrganizationAndWithCursor(
                 organization,
                 compareDateTime,
                 lastEventId,
-                PAST_EVENT_PAGE_SIZE
+                pageable
         );
     }
 

--- a/server/src/main/java/com/ahmadda/domain/event/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/event/Event.java
@@ -453,4 +453,8 @@ public class Event extends BaseEntity {
         return eventOperationPeriod.getEventPeriod()
                 .end();
     }
+
+    public boolean isBeforeEventEnd(final LocalDateTime currentDateTime) {
+        return eventOperationPeriod.isBeforeEventEnd(currentDateTime);
+    }
 }

--- a/server/src/main/java/com/ahmadda/domain/event/EventOperationPeriod.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventOperationPeriod.java
@@ -110,4 +110,8 @@ public class EventOperationPeriod {
 
         return cancelParticipationTime.isAfter(cancelAvailableTime);
     }
+
+    public boolean isBeforeEventEnd(final LocalDateTime currentDateTime) {
+        return eventPeriod.isBeforeEnd(currentDateTime);
+    }
 }

--- a/server/src/main/java/com/ahmadda/domain/event/EventRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventRepository.java
@@ -2,6 +2,7 @@ package com.ahmadda.domain.event;
 
 import com.ahmadda.domain.organization.Organization;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,13 +14,20 @@ public interface EventRepository extends JpaRepository<Event, Long> {
             final LocalDateTime to
     );
 
-    List<Event> findAllByOrganizationAndEventOperationPeriodEventPeriodEndBefore(
-            final Organization organization,
-            final LocalDateTime now
-    );
-
     List<Event> findAllByEventOperationPeriodEventPeriodStartBetween(
             final LocalDateTime from,
             final LocalDateTime to
+    );
+
+    @Query("SELECT e FROM Event e " +
+            "WHERE e.organization = :organization AND e.eventOperationPeriod.eventPeriod.end < :compareDateTime " +
+            "AND e.id < :lastEventId " +
+            "ORDER BY e.eventOperationPeriod.eventPeriod.end DESC " +
+            "LIMIT :size")
+    List<Event> findPastEventByOrganizationAndWithCursor(
+            final Organization organization,
+            final LocalDateTime compareDateTime,
+            final Long lastEventId,
+            final Long size
     );
 }

--- a/server/src/main/java/com/ahmadda/domain/event/EventRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventRepository.java
@@ -1,8 +1,10 @@
 package com.ahmadda.domain.event;
 
 import com.ahmadda.domain.organization.Organization;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,14 +22,14 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     );
 
     @Query("SELECT e FROM Event e " +
-            "WHERE e.organization = :organization AND e.eventOperationPeriod.eventPeriod.end < :compareDateTime " +
-            "AND e.id > :lastEventId " +
-            "ORDER BY e.eventOperationPeriod.eventPeriod.end DESC " +
-            "LIMIT :size")
+            "WHERE e.organization = :organization " +
+            "AND e.eventOperationPeriod.eventPeriod.end < :compareDateTime " +
+            "AND e.id < :lastEventId " +
+            "ORDER BY e.eventOperationPeriod.eventPeriod.end DESC, e.id DESC")
     List<Event> findPastEventByOrganizationAndWithCursor(
-            final Organization organization,
-            final LocalDateTime compareDateTime,
-            final Long lastEventId,
-            final Long size
+            @Param("organization") final Organization organization,
+            @Param("compareDateTime") final LocalDateTime compareDateTime,
+            @Param("lastEventId") final Long lastEventId,
+            Pageable pageable
     );
 }

--- a/server/src/main/java/com/ahmadda/domain/event/EventRepository.java
+++ b/server/src/main/java/com/ahmadda/domain/event/EventRepository.java
@@ -21,7 +21,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Query("SELECT e FROM Event e " +
             "WHERE e.organization = :organization AND e.eventOperationPeriod.eventPeriod.end < :compareDateTime " +
-            "AND e.id < :lastEventId " +
+            "AND e.id > :lastEventId " +
             "ORDER BY e.eventOperationPeriod.eventPeriod.end DESC " +
             "LIMIT :size")
     List<Event> findPastEventByOrganizationAndWithCursor(

--- a/server/src/main/java/com/ahmadda/domain/organization/Organization.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/Organization.java
@@ -75,7 +75,7 @@ public class Organization extends BaseEntity {
 
     public List<Event> getActiveEvents(final LocalDateTime currentDateTime) {
         return events.stream()
-                .filter((event) -> event.isRegistrationEnd(currentDateTime))
+                .filter((event) -> event.isBeforeEventEnd(currentDateTime))
                 .toList();
     }
 

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -47,6 +47,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrganizationEventController {
 
+    private static final String DEFAULT_GET_PAST_EVENT_CURSOR = "9223372036854775807"; // Long.MAX_VALUE
+
     private final OrganizationMemberEventService organizationMemberEventService;
     private final EventService eventService;
 
@@ -182,7 +184,7 @@ public class OrganizationEventController {
     public ResponseEntity<List<MainEventResponse>> getPastEvents(
             @PathVariable final Long organizationId,
             @AuthMember final LoginMember loginMember,
-            @RequestParam(defaultValue = "0") final Long lastEventId
+            @RequestParam(defaultValue = DEFAULT_GET_PAST_EVENT_CURSOR) final Long lastEventId
     ) {
         List<Event> organizationEvents =
                 eventService.getPastEvents(organizationId, loginMember, LocalDateTime.now(), lastEventId);

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationEventController.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
@@ -180,9 +181,11 @@ public class OrganizationEventController {
     @GetMapping("/{organizationId}/events/past")
     public ResponseEntity<List<MainEventResponse>> getPastEvents(
             @PathVariable final Long organizationId,
-            @AuthMember final LoginMember loginMember
+            @AuthMember final LoginMember loginMember,
+            @RequestParam(defaultValue = "0") final Long lastEventId
     ) {
-        List<Event> organizationEvents = eventService.getPastEvents(organizationId, loginMember, LocalDateTime.now());
+        List<Event> organizationEvents =
+                eventService.getPastEvents(organizationId, loginMember, LocalDateTime.now(), lastEventId);
 
         List<MainEventResponse> eventResponses = organizationEvents.stream()
                 .map(event -> MainEventResponse.from(event, loginMember))

--- a/server/src/main/resources/db/migration/V202510021723__add_event_past_event_index.sql
+++ b/server/src/main/resources/db/migration/V202510021723__add_event_past_event_index.sql
@@ -1,2 +1,2 @@
 create index idx_event_id__org__event_end
-    on event (organization_id, event_end DESC, event_id DESC);
+    on event (organization_id, event_end, event_id);

--- a/server/src/main/resources/db/migration/V202510021723__add_event_past_event_index.sql
+++ b/server/src/main/resources/db/migration/V202510021723__add_event_past_event_index.sql
@@ -1,0 +1,2 @@
+create index idx_event_id__org__event_end
+    on event (organization_id, event_end DESC, event_id DESC);

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -848,7 +848,8 @@ class EventServiceTest {
         var pastEvents = sut.getPastEvents(
                 organization.getId(),
                 loginMember,
-                now
+                now,
+                0L
         );
 
         // then
@@ -881,7 +882,7 @@ class EventServiceTest {
         var loginMember = createLoginMember(member);
 
         //when // then
-        assertThatThrownBy(() -> sut.getPastEvents(organization.getId(), loginMember, LocalDateTime.now()))
+        assertThatThrownBy(() -> sut.getPastEvents(organization.getId(), loginMember, LocalDateTime.now(), lastEventId))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("이벤트 스페이스에 소속되지 않아 권한이 없습니다.");
     }

--- a/server/src/test/java/com/ahmadda/application/EventServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/EventServiceTest.java
@@ -1017,10 +1017,34 @@ class EventServiceTest {
                 ));
 
         var now = LocalDateTime.now();
-        eventRepository.save(createEvent(orgMemberA, orgA, "EventA1", now.plusDays(1), now.plusDays(2)));
-        eventRepository.save(createEvent(orgMemberA, orgA, "EventA2", now.plusDays(2), now.plusDays(3)));
-        eventRepository.save(createEvent(orgMemberA, orgA, "EventA3", now.minusDays(2), now.minusDays(1))); // inactive
-        eventRepository.save(createEvent(orgMemberB, orgB, "EventB1", now.plusDays(1), now.plusDays(2)));
+        eventRepository.save(createEvent(
+                orgMemberA,
+                orgA,
+                "registrationNotEndEvent",
+                now.plusDays(1),
+                now.plusDays(2)
+        )); //마감전 이벤트
+        eventRepository.save(createEvent(
+                orgMemberA,
+                orgA,
+                "registrationNotEndEvent",
+                now.plusDays(2),
+                now.plusDays(3)
+        )); //마감전 이벤트
+        eventRepository.save(createEvent(
+                orgMemberA,
+                orgA,
+                "endedEvent",
+                now.minusDays(2),
+                now.minusDays(1)
+        )); //inactive
+        eventRepository.save(createEvent(
+                orgMemberB,
+                orgB,
+                "currentProceedEvent",
+                now.minusDays(1L),
+                now
+        )); //진행중인 이벤트
 
         // when
         var events = sut.getActiveEvents(orgA.getId(), loginMember);

--- a/server/src/test/java/com/ahmadda/domain/event/EventOperationEventPeriodTest.java
+++ b/server/src/test/java/com/ahmadda/domain/event/EventOperationEventPeriodTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import java.time.LocalDateTime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -136,5 +137,37 @@ class EventOperationEventPeriodTest {
                 .isInstanceOf(UnprocessableEntityException.class)
                 .hasMessage("신청 기간은 이벤트 기간보다 앞서야 합니다.");
 
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "2025-07-23T07:59:59, true",
+            "2025-07-23T08:00:00, false",
+            "2025-07-23T08:00:01, false"
+    })
+    void 이벤트_종료_시간_이전인지_확인한다(LocalDateTime now, boolean expected) {
+        // given
+        var currentTime = LocalDateTime.of(2025, 7, 16, 8, 0);
+        var registrationPeriod = EventPeriod.create(
+                currentTime.plusDays(1),
+                currentTime.plusDays(5)
+        );
+        var eventPeriod = EventPeriod.create(
+                currentTime.plusDays(6),
+                currentTime.plusDays(7)
+        );
+        var eventOperationPeriod = EventOperationPeriod.create(
+                registrationPeriod.start(),
+                registrationPeriod.end(),
+                eventPeriod.start(),
+                eventPeriod.end(),
+                currentTime
+        );
+
+        // when
+        var result = eventOperationPeriod.isBeforeEventEnd(now);
+
+        // then
+        assertThat(result).isEqualTo(expected);
     }
 }

--- a/server/src/test/java/com/ahmadda/domain/organization/OrganizationTest.java
+++ b/server/src/test/java/com/ahmadda/domain/organization/OrganizationTest.java
@@ -35,17 +35,17 @@ class OrganizationTest {
     void 활성화된_이벤트_목록을_조회한다() {
         // given
         var now = LocalDateTime.now();
-        var pastEvent = createEventForTest(
+        var pastEvent = createEvent(
                 "과거 이벤트",
                 now.minusDays(3), now.minusDays(2),
-                now.minusDays(1), now.plusDays(1)
+                now.minusDays(2), now.minusDays(1)
         );
-        var activeEvent1 = createEventForTest(
+        var activeEvent1 = createEvent(
                 "활성 이벤트 1",
                 now.minusDays(1), now.plusDays(1),
                 now.plusDays(2), now.plusDays(3)
         );
-        var activeEvent2 = createEventForTest(
+        var activeEvent2 = createEvent(
                 "활성 이벤트 2",
                 now.minusDays(1), now.plusDays(1),
                 now.plusDays(2), now.plusDays(3)
@@ -217,7 +217,7 @@ class OrganizationTest {
         return OrganizationGroup.create("백엔드");
     }
 
-    private Event createEventForTest(
+    private Event createEvent(
             String title,
             LocalDateTime registrationStart,
             LocalDateTime registrationEnd,


### PR DESCRIPTION
## 관련 이슈

close #827

## ✨ 작업 내용
- 과거 이벤트 조회 시 가장 최근에 생성된 이벤트부터 조회하도록 인덱스를 추가하고 정렬 조건을 변경했습니다.
- 변경된 조회 조건에 맞춰 테스트 코드를 수정했습니다.
- 활성화된 이벤트도 정책 변경에 맞춰 수정하였습니다.

## 🙏 기타 참고 사항
### 왜 인덱스에 정렬과 일치하는 DESC를 걸지 않았나요?
- MySQL 8.0이상 버전에서는 인덱스 역방향 스캔을 지원함
* 정렬순서는 매우 쉽게 바뀔 수 있는 기능

범용적인 인덱스 설계 필요하다고 판단하였습니다.


### 쿼리 설명
```
@Query("SELECT e FROM Event e " +
            "WHERE e.organization = :organization " +
            "AND e.eventOperationPeriod.eventPeriod.end < :compareDateTime " +
            "AND e.id < :lastEventId " +
            "ORDER BY e.eventOperationPeriod.eventPeriod.end DESC, e.id DESC")
    List<Event> findPastEventByOrganizationAndWithCursor(
            @Param("organization") final Organization organization,
            @Param("compareDateTime") final LocalDateTime compareDateTime,
            @Param("lastEventId") final Long lastEventId,
            Pageable pageable
    );
```

#### WHERE 절 (데이터 필터링)
e.organization = :organization: 특정 조직에 속한 이벤트만 선택합니다.

e.eventOperationPeriod.eventPeriod.end < :compareDateTime: 이벤트 종료 시간이 특정 시간(compareDateTime, 보통 현재 시간)보다 이전인, 즉 이미 종료된 이벤트만 필터링합니다.

e.id < :lastEventId: 이전에 불러온 마지막 이벤트의 ID보다 작은 ID를 가진 이벤트만 조회합니다. 이것이 바로 '커서'의 역할을 하여 다음 페이지의 시작점을 알려줍니다.

#### ORDER BY 절 (데이터 정렬)

e.eventOperationPeriod.eventPeriod.end DESC: 이벤트를 종료 시간이 최신인 순서대로 정렬합니다.

e.id DESC: 만약 종료 시간이 완전히 동일한 이벤트가 여러 개 있을 경우, ID를 기준으로 내림차순 정렬하여 항상 일관된 순서를 보장합니다. 이는 페이징 시 데이터가 누락되거나 중복되는 것을 방지하는 매우 중요한 부분입니다.

pageable: 한 번에 가져올 데이터의 개수(LIMIT)를 지정합니다. Pageable.ofSize(10)와 같이 사용합니다.

### 컨트롤러에 왜 Long이 아닌 String으로 상수 관리하나요?

`private static final String DEFAULT_GET_PAST_EVENT_CURSOR = "9223372036854775807"; // Long.MAX_VALUE`

위 상수는 페이징시에 기준으로할 default 커서입니다.
const여야해서 String.valueOf(Long.MAX_VALUE)를 사용할 수 없어 위와 같이 직접 하드코딩하였습니다.

Optional, null처리로 대체할 수 있으나 NPE 위험보다 위 방식이 낫다고 판단했습니다.