### PR TITLE
[FE] 이벤트 상세조회 페이지 참여현황 그룹화

### DIFF
--- a/client/src/features/Event/Detail/components/guest/AttendanceOverview.tsx
+++ b/client/src/features/Event/Detail/components/guest/AttendanceOverview.tsx
@@ -1,14 +1,33 @@
-import { useSuspenseQueries } from '@tanstack/react-query';
+import { useSuspenseQueries, useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
 
 import { eventQueryOptions } from '@/api/queries/event';
+import { organizationQueryOptions } from '@/api/queries/organization';
 import { Flex } from '@/shared/components/Flex';
 import { theme } from '@/shared/styles/theme';
 
 import { GuestList } from './GuestList';
 
 export const AttendanceOverview = ({ eventId }: { eventId: number }) => {
+  const { organizationId } = useParams();
+
   const [{ data: guests = [] }, { data: nonGuests = [] }] = useSuspenseQueries({
     queries: [eventQueryOptions.guests(eventId), eventQueryOptions.nonGuests(eventId)],
+  });
+
+  const { data: members = [] } = useQuery({
+    ...organizationQueryOptions.members(Number(organizationId)),
+    enabled: !!organizationId,
+  });
+
+  const memberIdToGroup = new Map<number, { groupId: number; name: string }>();
+  members.forEach((m) => {
+    if (m?.group?.groupId != null) {
+      memberIdToGroup.set(m.organizationMemberId, {
+        groupId: m.group.groupId,
+        name: m.group.name,
+      });
+    }
   });
 
   return (
@@ -18,12 +37,14 @@ export const AttendanceOverview = ({ eventId }: { eventId: number }) => {
         title={`신청 완료 (${guests.length}명)`}
         titleColor={theme.colors.primary600}
         guests={guests}
+        memberIdToGroup={memberIdToGroup}
       />
       <GuestList
         eventId={eventId}
         title={`미신청 (${nonGuests.length}명)`}
         titleColor={theme.colors.red600}
         guests={nonGuests}
+        memberIdToGroup={memberIdToGroup}
       />
     </Flex>
   );

--- a/client/src/features/Event/Detail/components/guest/GuestList.tsx
+++ b/client/src/features/Event/Detail/components/guest/GuestList.tsx
@@ -8,7 +8,7 @@ import { Text } from '@/shared/components/Text';
 import { useModal } from '@/shared/hooks/useModal';
 import { theme } from '@/shared/styles/theme';
 
-import { Guest, NonGuest } from '../../../Manage/types';
+import type { Guest, NonGuest } from '../../../Manage/types';
 
 import { PokeModal } from './PokeModal';
 
@@ -16,10 +16,17 @@ type GuestListProps = {
   eventId: number;
   title: string;
   titleColor: string;
-  guests: Guest[] | NonGuest[];
+  guests: (Guest | NonGuest)[];
+  memberIdToGroup: Map<number, { groupId: number; name: string }>;
 };
 
-export const GuestList = ({ eventId, title, titleColor, guests }: GuestListProps) => {
+export const GuestList = ({
+  eventId,
+  title,
+  titleColor,
+  guests,
+  memberIdToGroup,
+}: GuestListProps) => {
   const { isOpen, open, close } = useModal();
   const [receiverGuest, setReceiverGuest] = useState<NonGuest | null>(null);
 
@@ -27,6 +34,30 @@ export const GuestList = ({ eventId, title, titleColor, guests }: GuestListProps
     setReceiverGuest(guest);
     open();
   };
+
+  const grouped = (() => {
+    if (memberIdToGroup.size === 0) return [];
+
+    type GuestItem = Guest | NonGuest;
+    const groupMap = new Map<string, { name: string; id: number; members: GuestItem[] }>();
+
+    for (const guest of guests) {
+      const info = memberIdToGroup.get(guest.organizationMemberId);
+      if (!info) continue;
+      const { groupId, name } = info;
+
+      if (!groupMap.has(name)) groupMap.set(name, { name, id: groupId, members: [] });
+      groupMap.get(name)!.members.push(guest);
+    }
+
+    const groupArr = Array.from(groupMap.values());
+    groupArr.sort((g1, g2) => g1.id - g2.id);
+    groupArr.forEach((group) =>
+      group.members.sort((m1, m2) => (m1.nickname ?? '').localeCompare(m2.nickname ?? '', 'ko'))
+    );
+
+    return groupArr;
+  })();
 
   return (
     <>
@@ -36,20 +67,42 @@ export const GuestList = ({ eventId, title, titleColor, guests }: GuestListProps
             {title}
           </Text>
         </Flex>
-        <Flex
-          as="ul"
-          dir="row"
-          alignItems="flex-start"
-          gap="8px"
-          css={css`
-            flex-wrap: wrap;
-            list-style: none;
-          `}
-        >
-          {guests.map((guest) => (
-            <GuestBadge key={guest.organizationMemberId} onClick={() => handleGuestClick(guest)}>
-              {guest.nickname}
-            </GuestBadge>
+
+        <Flex dir="column" gap="20px">
+          {grouped.map((group) => (
+            <section key={`${group.id}:${group.name}`}>
+              <Text
+                as="h3"
+                type="Body"
+                weight="semibold"
+                color={theme.colors.gray700}
+                css={css`
+                  margin: 4px 0 10px;
+                `}
+              >
+                {group.name}
+              </Text>
+
+              <Flex
+                as="ul"
+                dir="row"
+                alignItems="flex-start"
+                gap="8px"
+                css={css`
+                  flex-wrap: wrap;
+                  list-style: none;
+                `}
+              >
+                {group.members.map((guest) => (
+                  <GuestBadge
+                    key={guest.organizationMemberId}
+                    onClick={() => handleGuestClick(guest)}
+                  >
+                    {guest.nickname}
+                  </GuestBadge>
+                ))}
+              </Flex>
+            </section>
           ))}
         </Flex>
       </Flex>
@@ -77,4 +130,8 @@ const GuestBadge = styled.li`
   cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
+
+  &:hover {
+    background-color: ${theme.colors.gray200};
+  }
 `;


### PR DESCRIPTION
## 관련 이슈

close #836 

## ✨ 작업 내용

- 이벤트 상세조회 페이지 참여현황 탭에서도 그룹별로 구성원을 보여주도록 수정하였습니다.
- 그룹은 groupId 오름차순, 각 그룹 내 닉네임은 사전순으로 정렬했습니다.

## 🙏 기타 참고 사항

https://github.com/user-attachments/assets/e787df15-91bf-44ba-b2e9-6471d185f2ca




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 게스트 목록을 멤버 소속 그룹 기준으로 자동 그룹화하여 섹션 헤더와 함께 표시합니다.
  - 참석자 개요에서 조직 멤버 정보를 불러와 그룹 매핑을 적용, 두 게스트 목록 모두에 반영합니다.
  - 그룹은 ID 순으로, 그룹 내 게스트는 닉네임(로케일 고려) 기준으로 정렬됩니다.
- UI/UX
  - 게스트 배지에 호버 시 시각적 피드백을 추가했습니다.
  - 목록을 가로 래핑으로 표시해 많은 게스트도 한눈에 보기 쉽습니다.
  - 기존 게스트 상세/포크 모달 동작은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->