### PR TITLE
[BE] ThreadPoolTaskExecutor의 thread 설정 변경 및 graceful shutdown 고려

### DIFF
--- a/server/src/main/java/com/ahmadda/domain/event/Event.java
+++ b/server/src/main/java/com/ahmadda/domain/event/Event.java
@@ -51,16 +51,6 @@ public class Event extends BaseEntity {
     @Column(name = "event_id")
     private Long id;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "event")
-    private final List<Guest> guests = new ArrayList<>();
-
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "event_id", nullable = false)
-    private final List<Question> questions = new ArrayList<>();
-
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<EventOrganizer> eventOrganizers = new ArrayList<>();
-
     @Column(nullable = false)
     private String title;
 
@@ -78,8 +68,18 @@ public class Event extends BaseEntity {
     @Embedded
     private EventOperationPeriod eventOperationPeriod;
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "event")
+    private final List<Guest> guests = new ArrayList<>();
+
     @Column(nullable = false)
     private int maxCapacity;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "event_id", nullable = false)
+    private final List<Question> questions = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<EventOrganizer> eventOrganizers = new ArrayList<>();
 
     @Column(nullable = false)
     private boolean isApprovalRequired;


### PR DESCRIPTION
## 관련 이슈

close #820

## ✨ 작업 내용

- ThreadPoolTaskExecutor의 core/max thread 설정 값 점검 및 조정  
- queueCapacity 및 rejectionPolicy 적절히 설정  
- graceful shutdown 시 task drain 및 awaitTermination 시간 확보  
- shutdown hook에서 남은 작업 처리 방식 검토  

## 🙏 기타 참고 사항
이슈의 코멘트들을 참고하면 이해에 도움될거에요~

이 PR의 설정은 **공통 비동기 처리 풀(asyncExecutor)** 의 크기와 동작 특성에 초점을 맞춘 설계입니다.  
따라서 현재 단계에서는 **신뢰성(resilience)**, **재시도 정책(retry)**, **예외 격리(isolation)**, **모니터링(metrics)** 등의 운영 관점 요소는 고려하지 않았습니다.  

---

### 참고한 공식 문서
아래 공식 문서들을 기반으로 각 외부 서비스의 처리 특성을 확인했습니다.  
다만 대부분의 서비스가 **지연 시간(latency)** 에 대한 구체적인 수치를 제공하지 않기 때문에,  
**팀 내부의 실측 데이터**를 바탕으로 설정값을 조정했습니다.

- [Firebase Cloud Messaging Status](https://status.firebase.google.com/cloud-messaging/)  
- [Google Workspace SLA](https://workspace.google.com/terms/sla/)  
- [AWS S3 SLA](https://aws.amazon.com/ko/s3/sla/?did=sla_card&trk=sla_card)  
- [AWS Pinpoint SLA](https://aws.amazon.com/ko/pinpoint/sla/?did=sla_card&trk=sla_card)  

---

### 설정 기준
스레드풀 크기 계산은  
**브라이언 괴츠(Brian Goetz)** 가 『*Java Concurrency in Practice*』에서 제시한 추정식을 참고했습니다!
```
Threads = Cores × TargetUtilization × (1 + Wait / Service)
```

현재 인스턴스 환경은 **t4g.small (2 vCPU, 2GB RAM)** 기준이며,  
I/O 대기 시간이 긴 FCM/SMTP/Slack 비동기 작업의 특성을 반영하여  
**core=20, max=50, queue=100** 으로 설정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * 이벤트 데이터 연관 처리 로직을 재구성하여 생성·수정·삭제 시 일관성 및 예측 가능한 동작을 보장합니다.
  * 불필요한 전파/고아 객체 동작을 정비해 데이터 무결성과 안정성을 강화했습니다.
* Chores
  * 비동기 처리 설정을 고도화했습니다: 스레드 풀 크기, 큐 용량, 유지시간, 거부 정책, 종료 대기 설정을 최적화하여 고부하 상황에서도 처리량과 응답 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->