### PR TITLE
[BE] ThreadPoolTaskScheduler의 thread 설정 변경 및 graceful shutdown 고려

### DIFF
--- a/server/src/main/java/com/ahmadda/infra/config/SchedulingConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/config/SchedulingConfig.java
@@ -3,6 +3,7 @@ package com.ahmadda.infra.config;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -14,6 +15,12 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import javax.sql.DataSource;
 
 @Configuration
+@ConditionalOnProperty(
+        prefix = "spring.scheduling",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true
+)
 @EnableScheduling
 @EnableSchedulerLock(defaultLockAtMostFor = "5m")
 public class SchedulingConfig implements SchedulingConfigurer {

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/config/MailConfig.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/config/MailConfig.java
@@ -21,8 +21,8 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
-@EnableConfigurationProperties({NotificationProperties.class, SmtpProperties.class})
 @Configuration
+@EnableConfigurationProperties({NotificationProperties.class, SmtpProperties.class})
 public class MailConfig {
 
     @Bean

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -7,6 +7,9 @@ spring:
       ddl-auto: create-drop
     show-sql: true
 
+  scheduling:
+    enabled: false
+
   cloud:
     aws:
       s3:


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #821

## ✨ 작업 내용

- ThreadPoolTaskScheduler의 pool size 계산식 개선
  - CPU 활용률 최적화보다는 스케줄 작업의 정시 실행과 병렬성 확보에 초점을 맞춤
  - 하나의 작업이 DB I/O 등으로 지연되더라도 다른 예약 작업이 밀리지 않도록 Threads = max(Cores, 2)로 설정
  - 저사양 환경(1코어)에서도 최소 두 개의 워커 스레드를 유지해 병렬 스케줄링 보장
- **graceful shutdown 처리 강화**  
  - `setWaitForTasksToCompleteOnShutdown(true)` 및  
    `setAwaitTerminationSeconds(60)` 적용  
  - 종료 시 남은 작업이 안전하게 마무리되도록 보장  
- **예외 처리 전략 확인**  
  - `ErrorHandler` 미설정 시, Spring의 기본 예외 처리기(`TaskUtils.LOG_AND_SUPPRESS_ERROR_HANDLER`) 사용  
  - 현재 수준에서는 추가 커스터마이징 불필요

## 🙏 기타 참고 사항



설정 메서드 | 설명
-- | --
setPoolSize(int poolSize) | 스케줄러에서 사용할 스레드 수 지정
setThreadNamePrefix(String prefix) | 스레드 이름 접두사 지정
setWaitForTasksToCompleteOnShutdown(boolean waitFor) | 애플리케이션 종료 시 스케줄러가 실행 중인 작업을 완료할지 대기할 지 여부
setAwaitTerminationSeconds(int seconds) | 종료 시 최대 대기 시간 (초단위)
setErrorHandler(ErrorHandler errorHandler) | 작업 실행 중 예외가 발생했을 때 처리할 핸들러 설정
setRemoveOnCancelPolicy(boolean removeOnCancel) | 취소된 작업을 큐에서 바로 제거할지 여부
setContinueExistingPeriodicTasksAfterShutdownPolicy(boolean continueTasks) | 종료 시에도 반복작업을 계속 유지할지 여부
setExecuteExistingDelayedTasksAfterShutdownPolicy(boolean executeDelayedTasks) | 종료 시 지연된 작업도 실행하도록 허용할지 여부
setThreadFactory(ThreadFactory threadFactory) | 스레드 생성 방식 사용자 정의
setRejectedExecutionHandler(RejectedExecutionHandler handler) | 내부 ScheduledExecutorService의 거부 정책 설정
cancelRemainingTask(Runnable task) (protected) | 종료 시 남은 작업을 취소하는 메서드
getScheduledExecutor() / getScheduledThreadPoolExecutor() | 내부 스케줄러 객체 접근


<!-- notionvc: e787f8f1-e722-43ac-8235-f1740f3aa463 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 백그라운드 작업 스케줄러가 도입되어 시스템 코어 수에 따라 동적으로 동시성을 조절합니다(최소 2개).
* 버그 수정
  * 종료 시 진행 중인 작업을 대기하도록 처리해 작업 유실을 방지합니다.
  * 일정 시간 내 정상 종료를 보장하는 타임아웃을 적용합니다.
  * 취소된 작업을 큐에서 제거해 불필요한 리소스 점유를 줄입니다.
  * 종료 과정에서 기존 대기 작업 처리 정책을 명확히 해 예측 가능한 동작을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->