### PR TITLE
[FE] 공동 주최자 표시 방식 통일

### DIFF
--- a/client/src/features/Event/Detail/components/info/EventDetails.tsx
+++ b/client/src/features/Event/Detail/components/info/EventDetails.tsx
@@ -75,9 +75,9 @@ export const EventDetails = ({
             주최자
           </Text>
           <Text>
-            {organizerNicknames.length > 1
-              ? `${organizerNicknames[0]} 외 ${organizerNicknames.length - 1}명`
-              : organizerNicknames[0]}
+            {organizerNicknames.length <= 3
+              ? organizerNicknames.join(', ')
+              : `${organizerNicknames.slice(0, 3).join(', ')} 외 ${organizerNicknames.length - 3}명`}
           </Text>
         </Flex>
       </Flex>

--- a/client/src/features/Event/Manage/components/EventInfoSection.tsx
+++ b/client/src/features/Event/Manage/components/EventInfoSection.tsx
@@ -72,9 +72,9 @@ export const EventInfoSection = ({ event, statistics }: EventInfoSectionProps) =
           <Text type="Heading" weight="bold" color={theme.colors.gray800}>
             주최자
           </Text>
-          {event.organizerNicknames.length > 1
-            ? `${event.organizerNicknames[0]} 외 ${event.organizerNicknames.length - 1}명`
-            : event.organizerNicknames[0]}
+          {event.organizerNicknames.length <= 3
+            ? event.organizerNicknames.join(', ')
+            : `${event.organizerNicknames.slice(0, 3).join(', ')} 외 ${event.organizerNicknames.length - 3}명`}
         </Flex>
       </Flex>
 

--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -615,11 +615,11 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
                     주최자
                   </Text>
                   <Text as="span" type="Body" color="#4b5563" data-role="value">
-                    {selectedNames.length > 0
-                      ? `${selectedNames.slice(0, 1).join(', ')}${
-                          selectedNames.length > 1 ? ` 외 ${selectedNames.length - 1}명` : ''
-                        } ✎`
-                      : '미선택 ✎'}
+                    {selectedNames.length === 0
+                      ? '미선택 ✎'
+                      : selectedNames.length <= 3
+                        ? `${selectedNames.join(', ')} ✎`
+                        : `${selectedNames.slice(0, 3).join(', ')} 외 ${selectedNames.length - 3}명 ✎`}
                   </Text>
                 </Button>
 

--- a/client/src/features/Event/components/EventCard/EventCard.tsx
+++ b/client/src/features/Event/components/EventCard/EventCard.tsx
@@ -109,9 +109,9 @@ export const EventCard = memo(function EventCard({
         <Flex alignItems="center" gap="4px" height="100%">
           <Icon name="user" size={16} color="gray500" />
           <Text type="Label" color={theme.colors.gray500}>
-            {organizerNicknames.length > 1
-              ? `${organizerNicknames[0]} 외 ${organizerNicknames.length - 1}명`
-              : organizerNicknames[0]}{' '}
+            {organizerNicknames.length <= 3
+              ? organizerNicknames.join(', ')
+              : `${organizerNicknames.slice(0, 3).join(', ')} 외 ${organizerNicknames.length - 3}명`}{' '}
             주최
           </Text>
         </Flex>


### PR DESCRIPTION
## 관련 이슈

close #872 

## ✨ 작업 내용

- 주최자가 2명 이상인 경우, 페이지마다 보여주는 방식이 상이해 일관성이 떨어지는 문제가 있었습니다.
- 공동 주최자 기능 개발 당시, 서버와 합의했던 형식인 '대표 1명 닉네임 + 외 N명'으로 통일했습니다.
## 🙏 기타 참고 사항

### AS IS (일관성 X)

|이벤트 생성 폼|전체 조회 페이지|상세 조회 페이지|관리 페이지|
|--|--|--|--|
|<img width="364" height="114" alt="image" src="https://github.com/user-attachments/assets/f32f3396-0955-47f5-bdde-02e32bc3bbc1" />|<img width="722" height="534" alt="image" src="https://github.com/user-attachments/assets/f916c0f1-2517-4f3c-ae10-1d8448cf1c53" />|<img width="312" height="166" alt="image" src="https://github.com/user-attachments/assets/32f8d0b7-e836-46c5-8b4a-5b79ae15eb5d" />|<img width="304" height="180" alt="image" src="https://github.com/user-attachments/assets/381a32b0-da93-416e-b2d3-3c3ef425f5e9" />|

### TO BE (통일)
|이벤트 생성 폼|전체 조회 페이지|상세 조회 페이지|관리 페이지|
|--|--|--|--|
|<img width="364" height="114" alt="image" src="https://github.com/user-attachments/assets/cca81972-69cf-427a-bd98-62faa87044f5" />|<img width="724" height="528" alt="image" src="https://github.com/user-attachments/assets/b0e54fb9-3fbf-463a-ad93-aecd29a5b437" />|<img width="361" height="172" alt="image" src="https://github.com/user-attachments/assets/3ec611cf-65bd-4fd9-9ef5-0c31caf48203" />|<img width="338" height="160" alt="image" src="https://github.com/user-attachments/assets/64fdbfe6-76f2-4ddb-9389-ac9a566129ae" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 여러 이벤트 주최자 표시 개선: 3명 이하일 땐 모든 이름을 쉼표로 표시, 4명 이상일 땐 앞 3명만 표시하고 "외 N명"으로 요약
  * 단일 주최자 표시는 기존 방식 유지
  * 신규 생성 화면에서 주최자 미선택 시 "미선택 ✎"을 명시적으로 표시
  * 이벤트 카드·상세·관리 화면에 일관되게 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->