### PR TITLE
[FE] 로그인 한 사용자에 한해 스페이스 생성 버튼 노출

### DIFF
--- a/client/src/features/Event/Detail/components/LoginModal.tsx
+++ b/client/src/features/Event/Detail/components/LoginModal.tsx
@@ -33,7 +33,7 @@ export const LoginModal = ({ isOpen, onClose }: ModalProps) => {
             text-align: center;
           `}
         >
-          {`이벤트 신청은 로그인 후 이용할 수 있어요. \n먼저 로그인해 주세요.`}
+          {`로그인 후 이용할 수 있어요. \n먼저 로그인해 주세요.`}
         </Text>
         <Flex width="100%" gap="12px">
           <Button size="full" variant="outline" onClick={onClose}>

--- a/client/src/features/Organization/Overview/components/OrgSection.tsx
+++ b/client/src/features/Organization/Overview/components/OrgSection.tsx
@@ -2,7 +2,9 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
+import { isAuthenticated } from '@/api/auth';
 import { OrganizationAPIResponse } from '@/api/types/organizations';
+import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
 import { Text } from '@/shared/components/Text';
 import { theme } from '@/shared/styles/theme';
@@ -29,24 +31,40 @@ export const OrgSection = ({ organizations }: OrgSectionProps) => {
       <Flex
         dir="row"
         justifyContent="space-between"
-        alignItems="flex-end"
+        alignItems="flex-start"
         gap="8px"
         width="100%"
         css={css`
           @media (max-width: 768px) {
-            flex-direction: column;
             align-items: flex-start;
             gap: 10px;
           }
         `}
       >
-        <Text as="h1" type="Display" weight="bold">
-          스페이스 목록 ({organizations.length})
-        </Text>
-        <Text as="h3" type="Body" color={theme.colors.gray500}>
-          현재 가장 활발한 순서대로 스페이스를 노출해요.
-        </Text>
+        <Flex dir="column" gap="8px" alignItems="flex-start">
+          <Text as="h1" type="Display" weight="bold">
+            스페이스 목록 ({organizations.length})
+          </Text>
+
+          <Text as="h3" type="Body" color={theme.colors.gray500}>
+            현재 가장 활발한 순서대로 스페이스를 노출해요.
+          </Text>
+        </Flex>
+        {isAuthenticated() && (
+          <Flex dir="column" gap="8px" alignItems="flex-end">
+            <Button
+              size="md"
+              color="primary"
+              variant="solid"
+              iconName="plus"
+              onClick={() => navigate(`/organization/new`)}
+            >
+              스페이스 만들기
+            </Button>
+          </Flex>
+        )}
       </Flex>
+
       <OrgListContainer dir="column" width="100%" gap="8px">
         <DeskTopOrgList>
           {organizations.map((org) => (

--- a/client/src/router/ProtectRoute.tsx
+++ b/client/src/router/ProtectRoute.tsx
@@ -1,25 +1,31 @@
 import { useEffect } from 'react';
 
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
-import { getGoogleAuthUrl, isAuthenticated } from '@/api/auth';
+import { isAuthenticated } from '@/api/auth';
+import { LoginModal } from '@/features/Event/Detail/components/LoginModal';
 import { useToast } from '@/shared/components/Toast/ToastContext';
+import { useModal } from '@/shared/hooks/useModal';
 
 export const ProtectRoute = () => {
   const { error } = useToast();
   const location = useLocation();
+  const navigate = useNavigate();
+
+  const { isOpen, open, close } = useModal();
 
   useEffect(() => {
     if (!isAuthenticated()) {
+      open();
       sessionStorage.setItem('redirectAfterLogin', location.pathname);
       error('로그인이 필요한 서비스입니다. 먼저 로그인해 주세요.', { duration: 1500 });
-      const authUrl = getGoogleAuthUrl();
-      window.location.href = authUrl;
+    } else {
+      close();
     }
-  }, [error, location.pathname]);
+  }, [error, location.pathname, open, close]);
 
   if (!isAuthenticated()) {
-    return null;
+    return <LoginModal isOpen={isOpen} onClose={() => navigate('/')} />;
   }
 
   return <Outlet />;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #914

## ✨ 작업 내용

- 로그인을 한 사용자에게만 스페이스 생성을 노출 시켰습니다.

<table style="width:100%; border-collapse:collapse; text-align:left;">
  <thead>
    <tr>
      <th>AS-IS</th>
      <th>TO-BE</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="1244" height="856" alt="스크린샷 2025-10-21 오전 1 55 17" src="https://github.com/user-attachments/assets/4daaaa38-d2db-41b2-ab57-fcbb24b936f2" /></td>
      <td><img width="1255" height="858" alt="스크린샷 2025-10-21 오전 1 55 33" src="https://github.com/user-attachments/assets/dc15438f-32f9-4784-9dfe-ccd269a24566" /></td>
    </tr>
  </tbody>
</table>


- url를 통해 진입했을 경우, 다음과 같은 모달을 띄웠습니다. 요부분은 추후 수정되면 좋을 것 같아요! 더 친화적인 문구로 안내하는 게 좋을 것 같습니다! 우선 급하니, 따로 이슈만 파놓겠습니다! 

<img width="1330" height="896" alt="스크린샷 2025-10-21 오전 1 56 07" src="https://github.com/user-attachments/assets/6eecc532-cbc6-4bd3-ad0d-2399a099abed" />


<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - 로그인 모달을 통한 개선된 인증 방식 도입
  - 로그인 사용자 전용 스페이스 만들기 버튼 추가

* **Style**
  - 로그인 안내 메시지 텍스트 간결화
  - UI 레이아웃 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->