### PR TITLE
[FE] 이벤트 상세 조회 페이지 스크롤 아래에서 시작하는 문제 해결

### DIFF
--- a/client/src/features/Event/Detail/pages/EventDetailPage.tsx
+++ b/client/src/features/Event/Detail/pages/EventDetailPage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { css } from '@emotion/react';
 import { useQuery, useSuspenseQueries } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
@@ -16,6 +18,10 @@ import { EventHeader } from '../components/info/EventHeader';
 import { EventDetailContainer } from '../containers/EventDetailContainer';
 
 export const EventDetailPage = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   const { eventId, organizationId } = useParams();
 
   const [{ data: event }] = useSuspenseQueries({


### PR DESCRIPTION
## 관련 이슈

close #884 

## ✨ 작업 내용

- 이벤트 상세 조회 페이지 스크롤이 아래에서 시작하는 문제를 해결했습니다.
- 정확하게는 어떨 땐 스크롤이 위에서 시작하고, 어떨 땐 아래에서 시작하는 현상이었는데, 이전 페이지(이벤트 전체 조회)의 스크롤 위치가 상세 조회 페이지의 스크롤 위치에도 영향을 주는 현상으로 확인하였습니다.
- `EventDetailPage`에 `window.scrollTo(0, 0)`을 추가하여 상세 조회 페이지에 접속할 때마다 초기 스크롤을 상단으로 고정했습니다.

## 🙏 기타 참고 사항

### AS IS (전체 조회 페이지의 스크롤 상태에 따라 상세 조회 페이지의 스크롤 상태가 달라짐)

https://github.com/user-attachments/assets/bb7a9452-5d4b-4a23-a19f-b1c2029bbf31

### TO BE

https://github.com/user-attachments/assets/28b2a142-cc88-4129-bc79-9483e7a9188c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이벤트 상세 페이지 접속 시 자동으로 페이지 상단으로 스크롤되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->