### PR TITLE
[FE] 스페이스 조회 버튼 깨지는 문제 수정(padding값 조절)

### DIFF
--- a/client/src/features/Organization/Overview/components/OrgCard.tsx
+++ b/client/src/features/Organization/Overview/components/OrgCard.tsx
@@ -77,7 +77,6 @@ const StyledCardContainer = styled(Flex)`
 
 const StyledImageWrapper = styled(Flex)`
   border-radius: 12px;
-
   flex-shrink: 0;
   overflow: hidden;
 `;
@@ -93,7 +92,7 @@ const StyledOverlay = styled(Flex)`
 `;
 
 const StyledImg = styled.img`
-  padding: 10px;
+  padding: 8px;
   width: 100%;
   height: 100%;
   object-fit: scale-down;

--- a/client/src/features/Organization/Overview/components/OrgSection.tsx
+++ b/client/src/features/Organization/Overview/components/OrgSection.tsx
@@ -6,6 +6,7 @@ import { isAuthenticated } from '@/api/auth';
 import { OrganizationAPIResponse } from '@/api/types/organizations';
 import { Button } from '@/shared/components/Button';
 import { Flex } from '@/shared/components/Flex';
+import { Spacing } from '@/shared/components/Spacing';
 import { Text } from '@/shared/components/Text';
 import { theme } from '@/shared/styles/theme';
 
@@ -20,22 +21,23 @@ export const OrgSection = ({ organizations }: OrgSectionProps) => {
   const handleJoin = (orgId: number) => navigate(`/${orgId}/event`);
 
   return (
-    <Flex dir="column" gap="24px" margin="60px 0 0 0" padding="40px 20px 0 20px">
+    <Flex dir="column" margin="60px 0 0 0" padding="40px 20px 0 20px">
       <Flex
         dir="row"
         justifyContent="space-between"
-        alignItems="flex-start"
-        gap="8px"
+        alignItems="flex-end"
         width="100%"
-        margin="0 0 30px 0"
+        margin="0 0 20px 0"
         css={css`
           @media (max-width: 768px) {
-            align-items: flex-start;
+            flex-direction: column;
+            align-items: flex-end;
+
             gap: 10px;
           }
         `}
       >
-        <Flex dir="column" gap="8px" alignItems="flex-start">
+        <Flex dir="column" gap="8px" alignItems="flex-start" width="100%">
           <Text as="h1" type="Display" weight="bold">
             스페이스 목록 ({organizations.length})
           </Text>
@@ -45,7 +47,7 @@ export const OrgSection = ({ organizations }: OrgSectionProps) => {
           </Text>
         </Flex>
         {isAuthenticated() && (
-          <Flex dir="column" gap="8px" alignItems="flex-end">
+          <Flex dir="column" gap="8px" alignItems="flex-end" width="100%">
             <Button
               size="md"
               color="primary"

--- a/client/src/features/Organization/Overview/pages/OrganizationOverviewPage.tsx
+++ b/client/src/features/Organization/Overview/pages/OrganizationOverviewPage.tsx
@@ -14,7 +14,7 @@ export const OrganizationOverviewPage = () => {
 
   return (
     <PageLayout>
-      <Flex dir="column" width="100%" margin="0 auto" padding="28px 20px" gap="24px">
+      <Flex dir="column" gap="24px" padding="20px 0 0 0">
         <OrgSection organizations={organizations} />
       </Flex>
     </PageLayout>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #945

## ✨ 작업 내용

- padding 값 조절해서 수정 진행했습니다! 


<table>
  <thead>
    <tr>
      <th>AS IS</th>
      <th>TO BE</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td style="border:1px solid #ddd; padding:8px; vertical-align:top;">
<img width="436" height="859" alt="IMG_4897" src="https://github.com/user-attachments/assets/d45c4d55-f009-4a17-a2b3-923e50546c6d" />
      </td>
<td style="border:1px solid #ddd; padding:8px; vertical-align:top;">
<img width="436" height="859" alt="image" src="https://github.com/user-attachments/assets/73db7b33-7af1-47b9-b0c7-a57729d6cea8" />
      </td>
    </tr>
  </tbody>
</table>


<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 조직 카드의 이미지 패딩을 조정했습니다.
  * 조직 섹션의 레이아웃 정렬과 간격을 개선했습니다.
  * 모바일 환경의 반응형 동작을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->