### PR TITLE
[FE] 모바일에서 Input 요소 확대되는 문제 해결

### DIFF
--- a/client/src/shared/components/Input/Input.styled.ts
+++ b/client/src/shared/components/Input/Input.styled.ts
@@ -58,6 +58,10 @@ export const StyledInput = styled.input<{
     opacity: 0;
     pointer-events: none;
   }
+
+  @supports (-webkit-touch-callout: none) {
+    font-size: 16px;
+  }
 `;
 
 export const StyledHelperText = styled.p<{ isError: boolean }>`

--- a/client/src/shared/components/Textarea/Textarea.styled.ts
+++ b/client/src/shared/components/Textarea/Textarea.styled.ts
@@ -32,6 +32,10 @@ export const StyledTextarea = styled.textarea<{ isError: boolean }>`
       outline-color: ${theme.colors.red500};
       box-shadow: 0 0 0 4px ${theme.colors.red100};
     `}
+
+  @supports (-webkit-touch-callout: none) {
+    font-size: 16px;
+  }
 `;
 
 export const StyledHelperText = styled.p<{ isError: boolean }>`


### PR DESCRIPTION
## 관련 이슈

close #883 

## ✨ 작업 내용

- 모바일에서 Input 요소가 확대되는 문제를 해결했습니다.
- iOS Safari에서 폰트가 16px 미만이면 focus 시 자동 확대시키는 현상이었어서, Input 컴포넌트와 Textarea 컴포넌트에서 폰트 크기를 최소 16px로 보장하는 로직을 추가하였습니다.

## 🙏 기타 참고 사항

AS IS

https://github.com/user-attachments/assets/6751b965-8051-4ed2-bbab-0f2d51f76395


TO BE

https://github.com/user-attachments/assets/fe03b31e-379c-42f8-a875-fe476dd523cb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 특정 환경에서 입력 필드와 텍스트 영역의 글꼴 크기 표시가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->