### PR TITLE
[FE] 임시 저장 토스트로 인해 이벤트 기간 인풋이 초기화되는 문제 해결

### DIFF
--- a/client/src/features/Event/New/components/EventCreateForm.tsx
+++ b/client/src/features/Event/New/components/EventCreateForm.tsx
@@ -230,7 +230,16 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
     latestGetterRef.current = () => ({ basicEventForm, questions });
   }, [basicEventForm, questions]);
 
+  const isModalOpen =
+    isOpen('eventDateRange') ||
+    isOpen('registrationEnd') ||
+    isCapacityModalOpen ||
+    isCohostModalOpen ||
+    isTemplateModalOpen;
+
   useEffect(() => {
+    if (isModalOpen) return;
+
     const id = setInterval(() => {
       const current = latestGetterRef.current();
       const snapshot = JSON.stringify(current);
@@ -244,7 +253,7 @@ export const EventCreateForm = ({ isEdit, eventId }: EventCreateFormProps) => {
     }, 5000);
 
     return () => clearInterval(id);
-  }, [save]);
+  }, [isModalOpen, save]);
 
   const submitCreate = async (payload: ReturnType<typeof buildPayload>) => {
     const { eventId } = await addEvent(payload);


### PR DESCRIPTION
## 관련 이슈

close #948 

## ✨ 작업 내용

- 임시 저장 토스트로 인해 이벤트 기간 인풋이 초기화되는 문제가 있어 해결했습니다.
- 모달에서 선택을 끝내고 확인 버튼을 누르기도 전에 임시 저장을 하는 로직 자체가 어색하다는 생각이 들었고, 실제로 너무 자주 토스트가 뜨면서 산만한 느낌이 드는 문제도 있었습니다. 따라서 어떠한 모달이라도 열려있으면 자동 임시 저장을 하지 않고, 닫힌 뒤에만 동작하도록 로직을 변경하였습니다.

## 🙏 기타 참고 사항

AS IS

https://github.com/user-attachments/assets/ec4ea8e3-26ff-4ca7-b693-34c1bc02ba9b


TO BE

https://github.com/user-attachments/assets/16a4dc44-06f0-4ece-83ab-0ace202764a2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이벤트 관련 모달 창이 열려있는 동안 자동 저장이 일시 중단되도록 개선했습니다. 모달 상호작용 중 발생하던 예상치 못한 저장 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->