### PR TITLE
[FE] 이벤트 상세 조회 페이지 제목 레이아웃 변경

### DIFF
--- a/client/src/features/Event/Detail/components/info/EventHeader.tsx
+++ b/client/src/features/Event/Detail/components/info/EventHeader.tsx
@@ -57,7 +57,20 @@ export const EventHeader = ({
             min-width: 0;
           `}
         >
-          <Badge variant={status.color}>{status.text}</Badge>
+          <Flex dir="row" justifyContent="space-between" alignItems="flex-end">
+            <Badge variant={status.color}>{status.text}</Badge>
+            {isAuthenticated() && isMember && (
+              <Flex alignItems="center" gap="8px">
+                <Text type="Body">알림 받기</Text>
+                <Switch
+                  aria-label="이벤트 알림 수신 설정"
+                  checked={checked}
+                  onCheckedChange={handleSwitch}
+                  disabled={isLoading}
+                />
+              </Flex>
+            )}
+          </Flex>
           <Text as="h1" type="Display" weight="bold">
             {title}
           </Text>
@@ -80,17 +93,6 @@ export const EventHeader = ({
             </Text>
           </Flex>
         </Flex>
-        {isAuthenticated() && isMember && (
-          <Flex alignItems="center" gap="8px">
-            <Text type="Body">알림 받기</Text>
-            <Switch
-              aria-label="이벤트 알림 수신 설정"
-              checked={checked}
-              onCheckedChange={handleSwitch}
-              disabled={isLoading}
-            />
-          </Flex>
-        )}
       </Flex>
     </>
   );


### PR DESCRIPTION
## 관련 이슈

close #959 

## ✨ 작업 내용

- 이벤트 상세 조회 페이지 제목 레이아웃 변경
- 모집중 배지랑 알림 스위치를 같은 행에 두도록 레이아웃 변경했습니다.

## 🙏 기타 참고 사항

AS IS
<img width="382" height="258" alt="image" src="https://github.com/user-attachments/assets/d04dd61a-85f7-405c-9847-59a244aa7c57" />
<img width="382" height="250" alt="image" src="https://github.com/user-attachments/assets/1497a535-2330-48bd-bd5d-d90aa4fcd830" />

TO BE
<img width="383" height="243" alt="image" src="https://github.com/user-attachments/assets/4b10d031-d1e3-4ea2-86c0-9758b2fd24aa" />
<img width="383" height="223" alt="image" src="https://github.com/user-attachments/assets/199fb6e0-cb2d-4ee3-ac83-51740ea1f571" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 이벤트 상세 페이지에서 알림 토글 UI의 레이아웃을 개선했습니다. 알림 받기 스위치가 상태 배지와 함께 한 줄로 표시되어 더욱 간결한 인터페이스를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->