### PR TITLE
[BE] 조직 가입 시 닉네임 길이제한 해제

### DIFF
--- a/server/src/main/java/com/ahmadda/application/LoginService.java
+++ b/server/src/main/java/com/ahmadda/application/LoginService.java
@@ -102,7 +102,12 @@ public class LoginService {
 
     private void createOpenProfile(final Member member) {
         OrganizationGroup defaultGroup = getDefaultOrganizationGroup();
-        OpenProfile openProfile = OpenProfile.create(member, defaultGroup);
+
+        String memberName = member.getName();
+        String openProfileName =
+                memberName.substring(0, Math.min(memberName.length(), OpenProfile.MAX_NICKNAME_LENGTH));
+
+        OpenProfile openProfile = OpenProfile.create(member, openProfileName, defaultGroup);
 
         openProfileRepository.save(openProfile);
     }

--- a/server/src/main/java/com/ahmadda/domain/member/OpenProfile.java
+++ b/server/src/main/java/com/ahmadda/domain/member/OpenProfile.java
@@ -25,7 +25,7 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLRestriction("deleted_at IS NULL")
 public class OpenProfile extends BaseEntity {
 
-    private static final int MAX_NICKNAME_LENGTH = 10;
+    public static final int MAX_NICKNAME_LENGTH = 10;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,6 +48,8 @@ public class OpenProfile extends BaseEntity {
             final String nickname,
             final OrganizationGroup organizationGroup
     ) {
+        validateNickname(nickname);
+
         this.member = member;
         this.nickname = nickname;
         this.organizationGroup = organizationGroup;
@@ -55,21 +57,14 @@ public class OpenProfile extends BaseEntity {
 
     public static OpenProfile create(
             final Member member,
+            final String nickname,
             final OrganizationGroup organizationGroup
     ) {
-        if (isNicknameTooLong(member.getName())) {
-            String modifiedNickname = member.getName()
-                    .substring(0, MAX_NICKNAME_LENGTH);
-            return new OpenProfile(member, modifiedNickname, organizationGroup);
-        }
-
-        return new OpenProfile(member, member.getName(), organizationGroup);
+        return new OpenProfile(member, nickname, organizationGroup);
     }
 
     public void updateProfile(final String nickname, final OrganizationGroup organizationGroup) {
-        if (isNicknameTooLong(nickname)) {
-            throw new UnprocessableEntityException("최대 닉네임 길이는 " + MAX_NICKNAME_LENGTH + "자입니다.");
-        }
+        validateNickname(nickname);
 
         this.nickname = nickname;
         this.organizationGroup = organizationGroup;
@@ -83,7 +78,9 @@ public class OpenProfile extends BaseEntity {
         return member.getProfileImageUrl();
     }
 
-    private static boolean isNicknameTooLong(final String nickname) {
-        return nickname.length() > MAX_NICKNAME_LENGTH;
+    private void validateNickname(final String nickname) {
+        if (nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new UnprocessableEntityException("최대 닉네임 길이는 " + MAX_NICKNAME_LENGTH + "자 입니다.");
+        }
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
@@ -2,7 +2,6 @@ package com.ahmadda.domain.organization;
 
 
 import com.ahmadda.common.exception.ForbiddenException;
-import com.ahmadda.common.exception.UnprocessableEntityException;
 import com.ahmadda.domain.BaseEntity;
 import com.ahmadda.domain.event.Event;
 import com.ahmadda.domain.member.Member;
@@ -64,8 +63,6 @@ public class OrganizationMember extends BaseEntity {
             final OrganizationMemberRole role,
             final OrganizationGroup group
     ) {
-        validateNickname(nickname);
-
         this.nickname = nickname;
         this.member = member;
         this.organization = organization;
@@ -116,8 +113,6 @@ public class OrganizationMember extends BaseEntity {
     }
 
     public void rename(final String newNickname) {
-        validateNickname(newNickname);
-
         this.nickname = newNickname;
     }
 
@@ -128,11 +123,5 @@ public class OrganizationMember extends BaseEntity {
 
     public boolean isEqualNickname(final String nickname) {
         return this.nickname.equals(nickname);
-    }
-
-    private void validateNickname(final String nickname) {
-        if (nickname.length() > MAX_NICKNAME_LENGTH) {
-            throw new UnprocessableEntityException("최대 닉네임 길이는 10자입니다.");
-        }
     }
 }

--- a/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
+++ b/server/src/main/java/com/ahmadda/domain/organization/OrganizationMember.java
@@ -2,6 +2,7 @@ package com.ahmadda.domain.organization;
 
 
 import com.ahmadda.common.exception.ForbiddenException;
+import com.ahmadda.common.exception.UnprocessableEntityException;
 import com.ahmadda.domain.BaseEntity;
 import com.ahmadda.domain.event.Event;
 import com.ahmadda.domain.member.Member;
@@ -63,6 +64,8 @@ public class OrganizationMember extends BaseEntity {
             final OrganizationMemberRole role,
             final OrganizationGroup group
     ) {
+        validateNickname(nickname);
+
         this.nickname = nickname;
         this.member = member;
         this.organization = organization;
@@ -112,16 +115,20 @@ public class OrganizationMember extends BaseEntity {
         }
     }
 
-    public void rename(final String newNickname) {
-        this.nickname = newNickname;
-    }
-
     public void update(final String nickname, final OrganizationGroup group) {
+        validateNickname(nickname);
+
         this.nickname = nickname;
         this.group = group;
     }
 
     public boolean isEqualNickname(final String nickname) {
         return this.nickname.equals(nickname);
+    }
+
+    private void validateNickname(final String nickname) {
+        if (nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new UnprocessableEntityException("최대 닉네임 길이는 " + MAX_NICKNAME_LENGTH + "자 입니다.");
+        }
     }
 }

--- a/server/src/main/java/com/ahmadda/presentation/OpenProfileController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OpenProfileController.java
@@ -125,6 +125,18 @@ public class OpenProfileController {
                                                       "instance": "/api/open-profiles"
                                                     }
                                                     """
+                                    ),
+                                    @ExampleObject(
+                                            name = "변경 닉네임 10자 초과",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Unprocessable Entity",
+                                                      "status": 422,
+                                                      "detail": "최대 닉네임 길이는 10자입니다.",
+                                                      "instance": "/api/open-profiles"
+                                                    }
+                                                    """
                                     )
                             }
                     )

--- a/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
+++ b/server/src/main/java/com/ahmadda/presentation/OrganizationController.java
@@ -294,6 +294,18 @@ public class OrganizationController {
                                                       "instance": "/api/organizations/{organizationId}/participation"
                                                     }
                                                     """
+                                    ),
+                                    @ExampleObject(
+                                            name = "변경 닉네임 10자 초과",
+                                            value = """
+                                                    {
+                                                      "type": "about:blank",
+                                                      "title": "Unprocessable Entity",
+                                                      "status": 422,
+                                                      "detail": "최대 닉네임 길이는 10자 입니다.",
+                                                      "instance": "/api/organizations/{organizationId}/participation"
+                                                    }
+                                                    """
                                     )
                             }
                     )

--- a/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/LoginServiceTest.java
@@ -5,7 +5,6 @@ import com.ahmadda.common.exception.NotFoundException;
 import com.ahmadda.common.exception.UnauthorizedException;
 import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.member.MemberRepository;
-import com.ahmadda.domain.member.OpenProfileRepository;
 import com.ahmadda.infra.auth.HashEncoder;
 import com.ahmadda.infra.auth.RefreshTokenRepository;
 import com.ahmadda.infra.auth.jwt.config.JwtRefreshTokenProperties;
@@ -24,7 +23,6 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
 
 class LoginServiceTest extends IntegrationTest {
@@ -43,9 +41,6 @@ class LoginServiceTest extends IntegrationTest {
 
     @Autowired
     private HashEncoder hashEncoder;
-
-    @Autowired
-    private OpenProfileRepository openProfileRepository;
 
     @Test
     void 신규회원이면_저장한다() {
@@ -66,27 +61,6 @@ class LoginServiceTest extends IntegrationTest {
 
         // then
         assertThat(memberRepository.findByEmail(email)).isPresent();
-    }
-
-    @Test
-    void 회원가입_시_이름이_길어도_예외가_발생하지_않는다() {
-        // given
-        var code = "code";
-        var name = "이_닉네임은_엄청나게_긴_닉네임_입니다.";
-        var email = "test@example.com";
-        var userAgent = createUserAgent();
-
-        var redirectUri = "redirectUri";
-        var testPicture = "testPicture";
-
-        given(googleOAuthProvider.getUserInfo(code, redirectUri))
-                .willReturn(new OAuthUserInfoResponse(email, name, testPicture));
-
-        // when
-        sut.login(code, redirectUri, userAgent);
-
-        // then
-        assertDoesNotThrow(() -> sut.login(code, redirectUri, userAgent));
     }
 
     @Test

--- a/server/src/test/java/com/ahmadda/application/OpenProfileServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OpenProfileServiceTest.java
@@ -3,6 +3,7 @@ package com.ahmadda.application;
 import com.ahmadda.application.dto.LoginMember;
 import com.ahmadda.application.dto.OpenProfileUpdateRequest;
 import com.ahmadda.common.exception.NotFoundException;
+import com.ahmadda.common.exception.UnprocessableEntityException;
 import com.ahmadda.domain.member.Member;
 import com.ahmadda.domain.member.MemberRepository;
 import com.ahmadda.domain.member.OpenProfile;
@@ -112,6 +113,26 @@ class OpenProfileServiceTest extends IntegrationTest {
             assertThat(updated.getNickname())
                     .isEqualTo("새닉네임");
         });
+    }
+
+    @Test
+    void 변경하려는_닉네임이_닉네임_제한을_넘어서면_예외가_발생한다() {
+        // given
+        var oldGroup = createGroup("프론트엔드");
+        var newGroup = createGroup("백엔드");
+
+        var member = createMember("홍길동", "hong@email.com");
+        var openProfile = createOpenProfile(member, oldGroup);
+        var loginMember = new LoginMember(member.getId());
+
+        var request = new OpenProfileUpdateRequest("새닉네임은_10글자가_넘습니다", newGroup.getId());
+
+        // when
+        assertThatThrownBy(() -> sut.updateProfile(
+                loginMember,
+                request
+        )).isInstanceOf(UnprocessableEntityException.class)
+                .hasMessage("최대 닉네임 길이는 10자입니다.");
     }
 
     @Test

--- a/server/src/test/java/com/ahmadda/application/OpenProfileServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OpenProfileServiceTest.java
@@ -132,7 +132,7 @@ class OpenProfileServiceTest extends IntegrationTest {
                 loginMember,
                 request
         )).isInstanceOf(UnprocessableEntityException.class)
-                .hasMessage("최대 닉네임 길이는 10자입니다.");
+                .hasMessage("최대 닉네임 길이는 10자 입니다.");
     }
 
     @Test
@@ -204,7 +204,7 @@ class OpenProfileServiceTest extends IntegrationTest {
     }
 
     private OpenProfile createOpenProfile(Member member, OrganizationGroup group) {
-        return openProfileRepository.save(OpenProfile.create(member, group));
+        return openProfileRepository.save(OpenProfile.create(member, member.getName(), group));
     }
 
     private Organization createOrganization(String name) {

--- a/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
+++ b/server/src/test/java/com/ahmadda/application/OrganizationServiceTest.java
@@ -471,7 +471,7 @@ class OrganizationServiceTest extends IntegrationTest {
         }
 
         var cannotParticipateUser =
-                memberRepository.save(Member.create("cannotparticipate", "cannotparticiapteuser@test.com", "pic"));
+                memberRepository.save(Member.create("memberName", "cannotparticiapteuser@test.com", "pic"));
         var openProfile = createOpenProfile(cannotParticipateUser, group);
         var loginMember = new LoginMember(cannotParticipateUser.getId());
 
@@ -574,7 +574,7 @@ class OrganizationServiceTest extends IntegrationTest {
     }
 
     private OpenProfile createOpenProfile(Member member, OrganizationGroup group) {
-        return openProfileRepository.save(OpenProfile.create(member, group));
+        return openProfileRepository.save(OpenProfile.create(member, member.getName(), group));
     }
 
     private Event createEvent(

--- a/server/src/test/java/com/ahmadda/domain/organization/OrganizationTest.java
+++ b/server/src/test/java/com/ahmadda/domain/organization/OrganizationTest.java
@@ -86,6 +86,24 @@ class OrganizationTest {
     }
 
     @Test
+    void 닉네임이_제한을_넘어가면_예외가_발생한다() {
+        //given
+        var member = Member.create("주최자 회원", "organizer@example.com", "testPicture");
+        var inviteCode = InviteCode.create("code", sut, organizer, LocalDateTime.now());
+
+        //when
+        assertThatThrownBy(() ->
+                sut.participate(
+                        member,
+                        "매우_긴_닉네임_입니다",
+                        inviteCode,
+                        OrganizationGroup.create("백엔드"),
+                        LocalDateTime.now()
+                )).isInstanceOf(UnprocessableEntityException.class)
+                .hasMessage("최대 닉네임 길이는 10자 입니다.");
+    }
+
+    @Test
     void 이벤트_스페이스의_초대코드가_아닌_초대코드로_이벤트_스페이스에_참여한다면_예외가_발생한다() {
         //given
         var organization = Organization.create("테스트 이벤트 스페이스2", "이벤트 스페이스 설명", "image.png");

--- a/server/src/test/java/com/ahmadda/domain/organization/OrganizationTest.java
+++ b/server/src/test/java/com/ahmadda/domain/organization/OrganizationTest.java
@@ -86,7 +86,7 @@ class OrganizationTest {
     }
 
     @Test
-    void 닉네임이_제한을_넘어가면_예외가_발생한다() {
+    void 이벤트_스페이스_참여시_닉네임이_제한을_넘어가면_예외가_발생한다() {
         //given
         var member = Member.create("주최자 회원", "organizer@example.com", "testPicture");
         var inviteCode = InviteCode.create("code", sut, organizer, LocalDateTime.now());


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #974 

## ✨ 작업 내용
조직원을 만들 때 닉네임 길이제한이 걸려있었습니다. 이 때문에 닉네임이 긴 경우 조직 가입이 불가능한 문제가 발생했습니다.

그래서 조직원 생성 시 닉네임 길이 제한을 풀었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 닉네임 길이 제한이 제거되어 사용자가 더 긴 닉네임을 설정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->