### PR TITLE
[BE] EmailOutbox 중복 생성으로 인한 NonUniqueResultException 해결 

### DIFF
--- a/server/src/main/java/com/ahmadda/infra/notification/mail/outbox/EmailOutboxRepository.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/outbox/EmailOutboxRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface EmailOutboxRepository extends JpaRepository<EmailOutbox, Long> {
 
-    Optional<EmailOutbox> findBySubjectAndBody(final String subject, final String body);
+    Optional<EmailOutbox> findTopBySubjectAndBodyOrderByCreatedAtDesc(final String subject, final String body);
 
     /**
      * 지정된 시각(threshold) 이전에 locked_at이 만료된 Outbox 레코드를 조회하고 잠근다.

--- a/server/src/main/java/com/ahmadda/infra/notification/mail/outbox/EmailOutboxSuccessHandler.java
+++ b/server/src/main/java/com/ahmadda/infra/notification/mail/outbox/EmailOutboxSuccessHandler.java
@@ -16,7 +16,7 @@ public class EmailOutboxSuccessHandler {
     @Transactional
     public void handleSuccess(final String recipientEmail, final String subject, final String body) {
         EmailOutbox outbox = emailOutboxRepository
-                .findBySubjectAndBody(subject, body)
+                .findTopBySubjectAndBodyOrderByCreatedAtDesc(subject, body)
                 .orElseThrow(() -> new EmailOutboxException("존재하지 않는 아웃박스입니다."));
 
         int deletedCount = emailOutboxRecipientRepository


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #976

## ✨ 작업 내용

- EmailOutboxSuccessHandler의 조회 방식 변경
  - 기존: findBySubjectAndBody() → 단일 결과 가정
  - 변경: findTopBySubjectAndBodyOrderByCreatedAtDesc()로 가장 최근 1건만 조회

## 🙏 기타 참고 사항
버그 해결은 언제나 심장을 뛰게 하네요 ㅋㅋㅋ 

- UNIQUE 제약 추가를 통한 해결은 LONGTEXT 인덱스 제약으로 인해 도입 난이도가 높고,
  현재 구조에서 Chunking/Retry 상황을 고려하면 완전한 유일성을 보장하기 어려움
  (추후 idempotency 도입 과정에서 재검토 예정)

- 이번 수정은 장애 전파를 막는 가장 빠르고 안정적인 Hotfix이며,
  근본적인 Outbox 데이터 정합성 개선은 후속 리팩토링 이슈로 진행 예정

- 현재까지 확인된 케이스는 드물지만, 정상적인 처리 흐름을 벗어난 정합성 문제이므로
  중복 발생 여부를 추적하고 근본 원인을 파악하기 위한 모니터링 강화가 필요함



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 이메일 아웃박스 조회 시 가장 최근에 생성된 항목을 우선적으로 처리하도록 변경되었습니다. 이를 통해 중복된 항목이 있을 경우 최신 데이터를 기반으로 작업이 진행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->