### PR TITLE
[BE] codedeploy 배포시 JVM timezone Asia/Seoul로 실행되도록 변경

### DIFF
--- a/server/codedeploy/scripts/start.sh
+++ b/server/codedeploy/scripts/start.sh
@@ -14,7 +14,7 @@ if [ -n "$PIDS" ]; then
   sleep 2
 fi
 
-nohup java -jar $APP_DIR/$JAR_NAME \
+nohup java -Duser.timezone=Asia/Seoul -jar $APP_DIR/$JAR_NAME \
   --server.port=$APP_PORT \
   --spring.profiles.active=prod \
   > $LOG_FILE 2>&1 < /dev/null &


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BE] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #980 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
현재 prod배포를 jar로 변경하면서 timezone이 EC2 서버 환경에 의존되던 현상이 발생해 UTC시간으로 설정되어 다음과 같이 마감 임박 이벤트 이메일이 마감 시간 기준 9시간 늦게 도착한걸 확인했습니다.
그레서 prod 환경에서 JVM timezone을 Asia/Seoul로 실행되도록 변경했습니다.
- 모집 마감이 29일 10:30분이지만 29일 19시 38분에 메일이 도착
<img width="951" height="844" alt="스크린샷 2025-10-30 오후 6 47 40" src="https://github.com/user-attachments/assets/ecb0b729-f683-4cff-9cd6-76dafb75fb8a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **운영**
  * 애플리케이션의 시스템 시간대를 Asia/Seoul(서울)로 설정했습니다. 이제 모든 시간 관련 처리가 서울 시간대를 기준으로 작동합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->